### PR TITLE
feat: fall back to dir when project segment has no git repo

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -259,8 +259,11 @@ trunc() {  # echo $1 clipped to $2 visible chars, middle-truncated with … ; $2
   printf '%s…%s' "${s:0:head}" "${s:start}"
 }
 
-seg_project() {  # stable repo-root name (same in every worktree); hidden outside a repo
-  [ -n "$GIT_ROOT" ] || return 0
+seg_project() {  # repo-root name in a repo; falls back to dir outside one (unless dir is already shown)
+  if [ -z "$GIT_ROOT" ]; then
+    case " $VL_SEGMENTS $VL_SEGMENTS2 $VL_SEGMENTS3 " in *" dir "*) return 0 ;; esac
+    seg_dir; return
+  fi
   push "$VL_BG_DIR" "${BOLD}$(fg $VL_FG_TEXT) ⬢ $(trunc "$GIT_ROOT" "$VL_NAME_MAX") ${NORM}"
 }
 


### PR DESCRIPTION
Closes #4

The `project` segment renders the repo-root name and is hidden outside a git repo. When it's used in place of `dir` (e.g. `VL_SEGMENTS="project ..."`), that left **no path indicator at all** in non-repo directories.

This delegates to `seg_dir` when `GIT_ROOT` is empty — but only when `dir` isn't already in the active layout, so `dir`+`project` configs don't show the path twice.

### Behavior
| context | `dir` in layout? | result |
|---|---|---|
| in a repo | — | `⬢ <repo>` (unchanged) |
| outside a repo | no | current path (fallback) |
| outside a repo | yes | `project` stays quiet (no duplicate) |

Only touches `seg_project` (+5/−2); independent of the Dracula PR.
