### PR TITLE
feat: add Dracula theme

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,6 +55,7 @@ user can compare themes visually:
 | `nord` | frost cyan · green · purple, arctic tones |
 | `gruvbox-dark` | retro blue · aqua · orange, warm cream text |
 | `tokyo-night` | neon blue · green · purple on deep navy |
+| `dracula` | cyan · pink · purple on Dracula charcoal |
 | `mono` | grayscale, minimalist |
 
 Use ASCII previews shaped like the real bar, for example:

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Prefer Powerlevel10k's *lean* look — no backgrounds, just colored text? Set
 | **`claude-coral`** — steel blue · mauve · Claude coral (default)<br>![claude-coral theme preview](./assets/theme-claude-coral.png) | **`catppuccin-mocha`** — soft pastels on dark<br>![catppuccin-mocha theme preview](./assets/theme-catppuccin-mocha.png) |
 | **`nord`** — arctic frost<br>![nord theme preview](./assets/theme-nord.png) | **`gruvbox-dark`** — warm retro<br>![gruvbox-dark theme preview](./assets/theme-gruvbox-dark.png) |
 | **`tokyo-night`** — neon on deep navy<br>![tokyo-night theme preview](./assets/theme-tokyo-night.png) | **`mono`** — grayscale minimalism<br>![mono theme preview](./assets/theme-mono.png) |
+| **`dracula`** — cyan · pink · purple on charcoal<br>![dracula theme preview](./assets/theme-dracula.png) | |
 
 A theme is just a `.conf` file assigning `VL_BG_*` / `VL_FG_*` — copy one, change the colors,
 and source yours from `coralline.conf` instead. PRs with new themes are welcome.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -144,6 +144,7 @@ narrow window:  ~/dev/app  ⎇ main  ◆ Fable 5
 | **`claude-coral`** — 鋼藍 · 木槿紫 · Claude 珊瑚紅（預設）<br>![claude-coral 主題預覽](./assets/theme-claude-coral.png) | **`catppuccin-mocha`** — 深底粉彩<br>![catppuccin-mocha 主題預覽](./assets/theme-catppuccin-mocha.png) |
 | **`nord`** — 北極冷霜<br>![nord 主題預覽](./assets/theme-nord.png) | **`gruvbox-dark`** — 溫暖復古<br>![gruvbox-dark 主題預覽](./assets/theme-gruvbox-dark.png) |
 | **`tokyo-night`** — 深藍霓虹<br>![tokyo-night 主題預覽](./assets/theme-tokyo-night.png) | **`mono`** — 灰階極簡<br>![mono 主題預覽](./assets/theme-mono.png) |
+| **`dracula`** — 青 · 粉 · 紫，Dracula 暗炭底<br>![dracula 主題預覽](./assets/theme-dracula.png) | |
 
 主題就只是一個指定 `VL_BG_*` / `VL_FG_*` 的 `.conf` 檔——複製一份、改顏色、
 在 `coralline.conf` 裡改 source 你的版本即可。歡迎發 PR 貢獻新主題。

--- a/statusline.sh
+++ b/statusline.sh
@@ -42,6 +42,7 @@ VL_SEP=$(printf '\xee\x82\xb0')     # U+E0B0 segment separator
 
 # Default theme: claude-coral (steel blue · mauve · Claude coral)
 VL_BG_DIR="81,166,199"
+VL_BG_PROJECT=""               # optional; falls back to VL_BG_DIR when empty
 VL_BG_GIT_OK=65
 VL_BG_GIT_DIRTY=130
 VL_BG_MODEL=173
@@ -261,7 +262,7 @@ trunc() {  # echo $1 clipped to $2 visible chars, middle-truncated with … ; $2
 
 seg_project() {  # stable repo-root name (same in every worktree); hidden outside a repo
   [ -n "$GIT_ROOT" ] || return 0
-  push "$VL_BG_DIR" "${BOLD}$(fg $VL_FG_TEXT) ⬢ $(trunc "$GIT_ROOT" "$VL_NAME_MAX") ${NORM}"
+  push "${VL_BG_PROJECT:-$VL_BG_DIR}" "${BOLD}$(fg $VL_FG_TEXT) ⬢ $(trunc "$GIT_ROOT" "$VL_NAME_MAX") ${NORM}"
 }
 
 seg_dir() {

--- a/themes/dracula.conf
+++ b/themes/dracula.conf
@@ -1,0 +1,22 @@
+# coralline theme: dracula
+# Official Dracula palette — https://draculatheme.com
+# Neon pills with dark text; dark gauge segments
+VL_BG_DIR="139,233,253"        # cyan
+VL_BG_PROJECT="255,121,198"    # pink
+VL_BG_GIT_OK="80,250,123"      # green
+VL_BG_GIT_DIRTY="255,184,108"  # orange
+VL_BG_MODEL="189,147,249"      # purple
+VL_BG_CTX="68,71,90"           # current line
+VL_BG_5H="54,56,72"            # between current line and bg
+VL_BG_7D="40,42,54"            # background
+VL_BG_COST="255,85,85"         # red
+VL_BG_CLOCK="255,121,198"      # pink
+VL_BG_LINES="68,71,90"         # current line
+VL_BG_STYLE="255,121,198"      # pink
+VL_BG_DURATION="139,233,253"   # cyan
+
+VL_FG_TEXT="40,42,54"          # background (dark text on neon pills)
+VL_FG_DIM="98,114,164"         # comment
+VL_FG_OK="80,250,123"          # green
+VL_FG_WARN="241,250,140"       # yellow
+VL_FG_HOT="255,85,85"          # red

--- a/tools/render-screenshots.py
+++ b/tools/render-screenshots.py
@@ -31,7 +31,7 @@ FAKE_HOME = Path(tempfile.gettempdir()) / "vl-home"
 DEMO = FAKE_HOME / "dev" / "coralline"
 
 THEMES = ["claude-coral", "catppuccin-mocha", "nord",
-          "gruvbox-dark", "tokyo-night", "mono"]
+          "gruvbox-dark", "tokyo-night", "mono", "dracula"]
 
 # ── Geometry (S = supersampling factor, downscaled at save time) ─────────────
 S = 2


### PR DESCRIPTION
Closes #5

Adds `themes/dracula.conf` using the official [Dracula](https://draculatheme.com) palette: cyan `dir`, green/orange `git`, purple `model`, pink `project`, with `#44475a` / `#282a36` gauge backgrounds.

Introduces an optional `VL_BG_PROJECT` so the `project` segment can carry its own background color; it falls back to `VL_BG_DIR` when unset, so **every existing theme is byte-for-byte unchanged**.

Registers the theme in `INSTALL.md`, both README galleries, and the screenshot tool's `THEMES` list.

> **Note:** `assets/theme-dracula.png` isn't included
