### PR TITLE
Fix auto-layout over-wrapping: measure display columns, not bytes

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -258,17 +258,63 @@ case " $VL_SEGMENTS $VL_SEGMENTS2 $VL_SEGMENTS3 " in *" git "*|*" stash "*|*" pr
 # ── Segments ─────────────────────────────────────────────────────────────────
 # Each seg_* appends (background, text, visible width) to the segment arrays.
 ESC=$'\033'
-seg_len() {  # visible char count of $1 with ANSI sequences stripped → SEG_LEN_R
-  local s="$1" plain=""
-  while [ "${s#*$ESC}" != "$s" ]; do
+# Visible DISPLAY WIDTH (terminal columns) of $1, ANSI stripped → SEG_LEN_R.
+# Decodes UTF-8 straight from the bytes (LC_ALL=C forced locally) so the count is
+# correct no matter what $LANG is. This matters: Git Bash usually leaves LANG empty,
+# where ${#s} counts *bytes* — a 5-glyph "▰▰▰▱▱" bar then reads as 15 and a CJK path
+# char as 3, inflating every segment so the auto-layout wrap fires far too early.
+# Wide CJK / kana / Hangul / fullwidth / emoji code points count as 2 columns,
+# combining and zero-width marks as 0, everything else as 1. Pure bash, no subprocess.
+seg_len() {
+  local s="$1" plain="" LC_ALL=C n i b cp c2 c3 c4 w=0
+  while [ "${s#*$ESC}" != "$s" ]; do          # strip CSI "...m" color escapes
     plain+="${s%%$ESC*}"
     s="${s#*$ESC}" ; s="${s#*m}"
   done
   plain+="$s"
-  SEG_LEN_R=${#plain}
+  n=${#plain} ; i=0
+  while [ "$i" -lt "$n" ]; do
+    printf -v b '%d' "'${plain:i:1}" ; [ "$b" -lt 0 ] && b=$((b + 256))
+    if   [ "$b" -lt 192 ]; then cp=$b ; i=$((i + 1))                  # ASCII / stray byte
+    elif [ "$b" -lt 224 ]; then                                      # 2-byte sequence
+      printf -v c2 '%d' "'${plain:i+1:1}" ; [ "$c2" -lt 0 ] && c2=$((c2 + 256))
+      cp=$(( (b - 192) * 64 + (c2 - 128) )) ; i=$((i + 2))
+    elif [ "$b" -lt 240 ]; then                                      # 3-byte sequence
+      printf -v c2 '%d' "'${plain:i+1:1}" ; [ "$c2" -lt 0 ] && c2=$((c2 + 256))
+      printf -v c3 '%d' "'${plain:i+2:1}" ; [ "$c3" -lt 0 ] && c3=$((c3 + 256))
+      cp=$(( (b - 224) * 4096 + (c2 - 128) * 64 + (c3 - 128) )) ; i=$((i + 3))
+    else                                                             # 4-byte sequence
+      printf -v c2 '%d' "'${plain:i+1:1}" ; [ "$c2" -lt 0 ] && c2=$((c2 + 256))
+      printf -v c3 '%d' "'${plain:i+2:1}" ; [ "$c3" -lt 0 ] && c3=$((c3 + 256))
+      printf -v c4 '%d' "'${plain:i+3:1}" ; [ "$c4" -lt 0 ] && c4=$((c4 + 256))
+      cp=$(( (b - 240) * 262144 + (c2 - 128) * 4096 + (c3 - 128) * 64 + (c4 - 128) )) ; i=$((i + 4))
+    fi
+    if [ "$cp" -lt 768 ]; then w=$((w + 1)) ; continue ; fi          # ASCII + Latin fast path
+    if   { [ "$cp" -ge 768 ]   && [ "$cp" -le 879 ]; }   \
+      || { [ "$cp" -ge 8203 ]  && [ "$cp" -le 8207 ]; }  \
+      || { [ "$cp" -ge 65024 ] && [ "$cp" -le 65039 ]; }; then
+      :                                                              # combining / ZWSP / variation selector → 0 cols
+    elif { [ "$cp" -ge 4352 ]   && [ "$cp" -le 4447 ]; }   \
+      || { [ "$cp" -ge 11904 ]  && [ "$cp" -le 42191 ]; }  \
+      || { [ "$cp" -ge 44032 ]  && [ "$cp" -le 55203 ]; }  \
+      || { [ "$cp" -ge 63744 ]  && [ "$cp" -le 64255 ]; }  \
+      || { [ "$cp" -ge 65040 ]  && [ "$cp" -le 65049 ]; }  \
+      || { [ "$cp" -ge 65072 ]  && [ "$cp" -le 65103 ]; }  \
+      || { [ "$cp" -ge 65280 ]  && [ "$cp" -le 65376 ]; }  \
+      || { [ "$cp" -ge 65504 ]  && [ "$cp" -le 65510 ]; }  \
+      || { [ "$cp" -ge 127744 ] && [ "$cp" -le 129791 ]; } \
+      || { [ "$cp" -ge 131072 ] && [ "$cp" -le 262143 ]; }; then
+      w=$((w + 2))                                                   # East-Asian wide / fullwidth / emoji → 2 cols
+    else
+      w=$((w + 1))
+    fi
+  done
+  SEG_LEN_R=$w
 }
 push() {
-  seg_len "$2"
+  # SEG_LEN[] is read only by the auto-layout wrap; fixed-layout print_range never
+  # touches it, so skip the per-char width scan entirely outside auto layout.
+  if [ "$VL_LAYOUT" = "auto" ]; then seg_len "$2" ; else SEG_LEN_R=0 ; fi
   SEG_BGS[${#SEG_BGS[@]}]="$1"
   SEG_TXT[${#SEG_TXT[@]}]="$2"
   SEG_LEN[${#SEG_LEN[@]}]="$SEG_LEN_R"

--- a/test/test-width.sh
+++ b/test/test-width.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Unit test for seg_len() — the display-width measurement that drives auto-layout
+# wrapping. Extracts the live function from statusline.sh so this test can never
+# drift from the implementation it checks.
+#
+#   bash test/test-width.sh
+#
+# Exits non-zero if any case fails. Needs only bash (no jq, no git).
+set -u
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+SCRIPT="$HERE/../statusline.sh"
+ESC=$'\033'
+
+# Pull just the seg_len function body out of the real script and define it here.
+eval "$(sed -n '/^seg_len() {/,/^}/p' "$SCRIPT")"
+
+fail=0
+check() {  # $1=expected width  $2=label  $3=text
+  seg_len "$3"
+  if [ "$SEG_LEN_R" = "$1" ]; then
+    printf 'ok    %-22s width=%s\n' "$2" "$SEG_LEN_R"
+  else
+    printf 'FAIL  %-22s want=%s got=%s\n' "$2" "$1" "$SEG_LEN_R"; fail=1
+  fi
+}
+
+check 3  ascii            "abc"
+check 0  empty            ""
+check 11 ascii-spaces     " hello dir "
+check 5  powerline-bar    "▰▰▰▱▱"             # each block glyph = 1 column
+check 8  cjk-han          "期末專案"          # 4 wide CJK = 8 columns
+check 6  mixed-cjk-ascii  "ab中文"            # 1+1+2+2
+check 2  emoji            "🚀"                # 4-byte wide = 2 columns
+check 7  icon-bar-pct     "⬡ ▰▱ 9%"           # hexagon + bars treated as narrow
+check 5  ansi-stripped    "${ESC}[1m${ESC}[38;5;231mhello${ESC}[0m"
+
+if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "SOME FAILED"; exit 1; fi


### PR DESCRIPTION
## 問題

`seg_len()` 用 `${#plain}` 量每個 segment 的寬度。當 `$LANG` 是空的(**Windows Git Bash 的常態**),bash 會把它算成**位元組數**而不是字元數:

- `▰▰▰▱▱` 這條 gauge(5 個字元、每個 3 bytes)被算成 **15**
- 每個 Nerd Font 圖示(`⬡ ⎇ ◆ ⊙`)被算成 **3**
- 每個 CJK(中文)路徑/分支字元被算成 **3**

於是 `VL_LAYOUT="auto"` 以為每個 segment 都比實際寬約 3 倍,**太早換行**。而且即使在 UTF-8 的 `$LANG` 下,**一個 CJK 字是 1 個 code point 卻佔 2 個顯示欄**,所以中文路徑在所有平台都會換錯行。這剛好打到預設推薦的 `auto` 版面。

### 修正前 / 後

`claude-coral` 主題、含中文工作目錄(`…/水文分析`)、bar 密集的 segments,實際輸出:

```
COLUMNS=100   修正前(byte)   → 3 行   (過度換行)
              修正後(column) → 2 行   (dir + model + ctx 正確擠進第 1 行)
```

## 修正

把 `seg_len()` 改成回傳真正的終端欄寬(display columns):

- `local LC_ALL=C` 強制 byte-level 切片,**在任何 `$LANG` 下都正確**(實測:即使外層是 UTF-8 locale 也會強制成 byte mode,函式返回後自動復原)
- 直接從原始 bytes 解碼 UTF-8 —— 不依賴 locale,所以在 macOS 內建 bash 3.2、Linux、Git Bash 上行為一致
- 依每個 code point 累加寬度:寬 CJK / 假名 / 諺文 / 全形 / emoji 算 **2**,組合字與零寬字元算 **0**,其餘算 **1**

維持純 bash、**不新增任何 subprocess**(只用 `printf -v` + 整數運算,符合腳本的設計目標)。Powerline 圓角/分隔符(PUA)、`▰`/`▱` bar、Nerd Font 圖示一律正確算 1 欄,所以既有單行版面的輸出完全不變。

附帶一個小優化:`push()` 現在只在 `auto` 版面才跑逐字元掃描,因為 fixed 版面的 `print_range()` 根本不讀 `SEG_LEN[]` —— 預設的 fixed 路徑省一點開銷。

## 測試

新增 `test/test-width.sh` —— 它從 `statusline.sh` 抽出**正在使用的** `seg_len()`(所以測試不會跟實作脫鉤),對 ASCII、powerline bar、中文、emoji、中英混合、含 ANSI 的字串斷言寬度:

```
bash test/test-width.sh   # 9 個 case,不需要 jq/git
```

另外也驗證:畸形/截斷的 UTF-8 → 不會卡住、不噴 stderr、能優雅處理;純 ASCII 的寬度與舊版 `${#plain}` 完全一致;`bash -n` 通過;`fixed` / `lean` / `VL_ASCII=1` 版面都不受影響。

## 範圍說明

- `trunc()`(在 `VL_NAME_MAX>0` 時啟用)同樣是 byte 切片,中文名稱可能被切錯 —— 這個 PR 先聚焦在換行路徑,沒有一起改;很樂意另開一個 follow-up PR。
- 寬字元範圍表鎖定實際會出現的範圍(CJK、假名、諺文、全形、常見 emoji `0x1F300–0x1FAFF`)。寬度曖昧(ambiguous)的字元(例如 `⬡` 六角形)當作窄字元處理,符合 coralline 目標終端機的實際渲染方式。

---

**EN summary:** `seg_len()` counted bytes (`${#plain}`) when `$LANG` is empty — the common Git Bash case — so bars/icons/CJK measured ~3× too wide and `auto` layout over-wrapped; CJK paths also mis-wrapped on every platform (1 code point = 2 columns). Rewrote it to count true display columns: force `LC_ALL=C`, decode UTF-8 from raw bytes (locale-independent, bash 3.2-safe), sum per-code-point width (wide CJK/emoji = 2, combining = 0, else 1). Pure bash, no new subprocess; **fixed-layout output is byte-identical**. Added `test/test-width.sh` (9 cases).
