### PR TITLE
feat: 新增視覺化設定與一鍵安裝流程

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -89,18 +89,44 @@ curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.s
 
 When installing for a user:
 
-1. Run the fast-path installer first with `--install-only`.
-2. If it fails because `jq` is missing, explain the package-manager command and rerun after
+1. Ask the user to choose setup mode before installing. Use the runtime's native choice UI
+   when available; otherwise show the text menu below and wait for a reply.
+2. Run the fast-path installer with `--install-only`.
+3. If it fails because `jq` is missing, explain the package-manager command and rerun after
    the user installs it.
-3. Interview the user with the questions below.
-4. Write `~/.claude/coralline.conf`.
-5. Verify with the bundled sample input.
-6. After success, tell the user to restart Claude Code or open a new session if the statusline
+4. Follow the selected setup mode.
+5. Write `~/.claude/coralline.conf` unless the user chose the visual wizard.
+6. Verify with the bundled sample input.
+7. After success, tell the user to restart Claude Code or open a new session if the statusline
    does not appear immediately, and mention they can rerun
    `bash ~/.claude/coralline/configure.sh` to customize it later.
 
 Do not manually rewrite `~/.claude/settings.json` unless the installer cannot run. The
 installer already performs a merge and creates a backup when a settings file exists.
+
+## Setup Mode
+
+Ask this first:
+
+```text
+How do you want to configure coralline?
+1. Let Claude configure it for me
+2. Import my local ~/.p10k.zsh
+3. Use the coralline default
+4. Open the visual wizard so I can customize manually
+```
+
+Mode behavior:
+
+| Mode | What Claude should do |
+|---|---|
+| Let Claude configure it | Bootstrap with `--install-only`, run the AI interview, write config, verify |
+| Import `~/.p10k.zsh` | Ask for confirmation if the file exists, bootstrap with `--install-only`, translate p10k, write config, verify |
+| Use default | Bootstrap with `--install-only`, write the default config, verify |
+| Visual wizard | Run `curl -fsSL .../install.sh | bash` without `--install-only` and let the user operate the TUI |
+
+If the user says "you decide", choose **Let Claude configure it** and keep the interview short.
+Never import `~/.p10k.zsh` unless the user explicitly chooses or confirms that mode.
 
 ## AI Interview
 
@@ -116,8 +142,9 @@ Ask concise questions. If the user says "you decide", choose the defaults.
 5. **Details**: clock `12h` default, `24h`, or `off`; Nerd Font yes/no; if they use git
    worktrees, suggest enabling `project`.
 
-If `~/.p10k.zsh` exists, offer to import its style, clock, and main colors before asking the
-full questions. Read the file and map these values when present:
+If `~/.p10k.zsh` exists, ask whether the user wants to import its style, clock, and main
+colors. Do not import it by default. If the user agrees, read the file and map these values
+when present:
 
 | p10k setting | coralline config |
 |---|---|

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -132,8 +132,9 @@ Never import `~/.p10k.zsh` unless the user explicitly chooses or confirms that m
 
 Ask concise questions. If the user says "you decide", choose the defaults.
 
-1. **Theme**: `claude-coral` default, `catppuccin-mocha`, `nord`, `gruvbox-dark`,
-   `tokyo-night`, `dracula`, or `mono`.
+1. **Theme**: inspect `~/.claude/coralline/themes/**/*.conf` and offer the installed theme
+   labels. Default to `claude-coral` when unsure. Nested themes use labels like
+   `best-themes/github-dark`.
 2. **Style**: `pill` default, or `lean`.
 3. **Segments**: default is `dir git model ctx limit5h limit7d cost clock`.
    Optional: `project`, `lines`, `style`, `duration`, `effort`, `stash`.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,9 @@ and registering the script in `settings.json`:
 | Artifact | Destination | Purpose |
 |---|---|---|
 | `statusline.sh` | `~/.claude/coralline/statusline.sh` | The statusline renderer |
+| `configure.sh` | `~/.claude/coralline/configure.sh` | Visual setup wizard and reconfiguration entrypoint |
 | `themes/<chosen>.conf` | `~/.claude/coralline/themes/<chosen>.conf` | Color palette |
+| `sample-input.json` | `~/.claude/coralline/sample-input.json` | Local preview + verification sample |
 | generated config | `~/.claude/coralline.conf` | User's layout + theme choices |
 | `statusLine` entry | `~/.claude/settings.json` | Registers the script |
 
@@ -24,6 +26,26 @@ flowchart LR
     D --> E[Update settings.json]
     E --> F[Verify with sample input]
 ```
+
+## Fast path
+
+If you are working from a local clone, prefer the built-in wizard:
+
+```bash
+bash configure.sh --install
+```
+
+If the repository has not been cloned yet:
+
+```bash
+git clone https://github.com/Nanako0129/coralline ~/.claude/coralline-src
+bash ~/.claude/coralline-src/configure.sh --install
+```
+
+The wizard copies the renderer and bundled themes, updates `settings.json`, offers the
+default config, local `~/.p10k.zsh` import when present, or a visual wizard, then verifies the
+final render with sample input. Use the manual steps below only when the wizard cannot run in
+the current environment.
 
 ## Step 1 — Check prerequisites
 
@@ -157,8 +179,10 @@ otherwise. Show the user the generated palette before writing it.
 mkdir -p ~/.claude/coralline/themes
 BASE="https://raw.githubusercontent.com/Nanako0129/coralline/main"
 curl -fsSL "$BASE/statusline.sh"            -o ~/.claude/coralline/statusline.sh
+curl -fsSL "$BASE/configure.sh"             -o ~/.claude/coralline/configure.sh
 curl -fsSL "$BASE/themes/<CHOSEN>.conf"     -o ~/.claude/coralline/themes/<CHOSEN>.conf
-chmod +x ~/.claude/coralline/statusline.sh
+curl -fsSL "$BASE/test/sample-input.json"   -o ~/.claude/coralline/sample-input.json
+chmod +x ~/.claude/coralline/statusline.sh ~/.claude/coralline/configure.sh
 ```
 
 > **Note:** if the repo is already cloned locally, copy from the clone instead of downloading.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,9 +1,10 @@
 # coralline — AI Installation Playbook
 
 > **You are an AI coding assistant** and a user asked you to install coralline.
-> Humans and AI use the same entrypoint: the one-line installer. Run it for the
-> user, handle missing prerequisites, choose a setup path, and remind them they can
-> rerun the visual wizard later if they want to rice the statusline themselves.
+> Humans and AI use the same installer entrypoint, but not the same setup UX.
+> For AI installs, bootstrap the runtime with `install.sh --install-only`, interview
+> the user, write `~/.claude/coralline.conf`, and verify. Do not operate the human TUI
+> unless the user explicitly asks to customize visually.
 
 ## Overview
 
@@ -22,10 +23,17 @@ the `statusLine` command into `~/.claude/settings.json`.
 
 ## Fast Path
 
-Run:
+Bootstrap the runtime and Claude settings:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash -s -- --install-only
+```
+
+If the user is testing a fork, keep the downloaded installer and runtime files on the same
+repo:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/miyago9267/coralline/main/install.sh | bash -s -- --repo miyago9267/coralline --install-only
 ```
 
 If you are already inside a local clone, run:
@@ -34,16 +42,13 @@ If you are already inside a local clone, run:
 bash install.sh
 ```
 
-The installer delegates to `configure.sh --install`, so it automatically enters the setup
-flow after downloading or locating the runtime files. It will:
+The installer delegates to `configure.sh --install-only` for AI installs. It will:
 
 1. copy the renderer, wizard, sample input, and bundled themes;
 2. merge the Claude Code `statusLine` setting with `jq`;
-3. offer setup choices for either the user or the AI assistant:
-   - **Default**: install the recommended look immediately;
-   - **Import `.p10k.zsh`**: carry over matching Powerlevel10k style and colors when available;
-   - **Visual wizard**: choose theme, segments, layout, glyph mode, and clock format with previews;
-4. render a sample statusline to verify the final config.
+3. exit without opening the human setup menu or writing theme config.
+
+After bootstrap, do the AI interview below and write `~/.claude/coralline.conf`.
 
 ## Prerequisites
 
@@ -77,25 +82,80 @@ bash ~/.claude/coralline/configure.sh
 To reinstall files and re-merge Claude settings:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash -s -- --install-only
 ```
 
 ## AI Guidance
 
 When installing for a user:
 
-1. Run the fast-path installer first.
+1. Run the fast-path installer first with `--install-only`.
 2. If it fails because `jq` is missing, explain the package-manager command and rerun after
    the user installs it.
-3. If `~/.p10k.zsh` exists, prefer the import path unless the user asks for a fresh design.
-4. If the user wants detailed visual control, choose the visual wizard path and let them pick.
-5. If the user wants you to handle it, choose the default path or the p10k import path yourself.
+3. Interview the user with the questions below.
+4. Write `~/.claude/coralline.conf`.
+5. Verify with the bundled sample input.
 6. After success, tell the user to restart Claude Code or open a new session if the statusline
    does not appear immediately, and mention they can rerun
    `bash ~/.claude/coralline/configure.sh` to customize it later.
 
-Do not manually rewrite `~/.claude/settings.json` unless the installer cannot run. The wizard
-already performs a merge and creates a backup when a settings file exists.
+Do not manually rewrite `~/.claude/settings.json` unless the installer cannot run. The
+installer already performs a merge and creates a backup when a settings file exists.
+
+## AI Interview
+
+Ask concise questions. If the user says "you decide", choose the defaults.
+
+1. **Theme**: `claude-coral` default, `catppuccin-mocha`, `nord`, `gruvbox-dark`,
+   `tokyo-night`, `dracula`, or `mono`.
+2. **Style**: `pill` default, or `lean`.
+3. **Segments**: default is `dir git model ctx limit5h limit7d cost clock`.
+   Optional: `project`, `lines`, `style`, `duration`, `effort`, `stash`.
+4. **Layout**: responsive default (`VL_LAYOUT="auto"`, `VL_MAX_LINES=3`), single line,
+   fixed two lines, or fixed three lines.
+5. **Details**: clock `12h` default, `24h`, or `off`; Nerd Font yes/no; if they use git
+   worktrees, suggest enabling `project`.
+
+If `~/.p10k.zsh` exists, offer to import its style, clock, and main colors before asking the
+full questions. Read the file and map these values when present:
+
+| p10k setting | coralline config |
+|---|---|
+| Wizard options include `lean` | `VL_STYLE="lean"` |
+| Wizard options include `classic`, `rainbow`, or `powerline` | `VL_STYLE="pill"` |
+| Wizard options or time format indicate 24h | `VL_CLOCK="24h"` |
+| `POWERLEVEL9K_DIR_BACKGROUND` or `_FOREGROUND` | `VL_BG_DIR` |
+| `POWERLEVEL9K_VCS_CLEAN_*` | `VL_BG_GIT_OK` |
+| `POWERLEVEL9K_VCS_MODIFIED_*` / `_UNTRACKED_*` | `VL_BG_GIT_DIRTY` |
+| `POWERLEVEL9K_TIME_*` | `VL_BG_CLOCK` |
+
+## Write Config
+
+Create `~/.claude/coralline.conf`:
+
+```bash
+# coralline config
+. "$HOME/.claude/coralline/themes/claude-coral.conf"
+
+VL_STYLE="pill"
+VL_LAYOUT="auto"
+VL_MAX_LINES=3
+VL_WRAP_MARGIN=4
+VL_SEGMENTS="dir git model ctx limit5h limit7d cost clock"
+VL_SEGMENTS2=""
+VL_SEGMENTS3=""
+VL_CLOCK="12h"
+VL_CLOCK_SECONDS=1
+VL_BAR_WIDTH=5
+VL_COST_DECIMALS=2
+VL_PATH_DEPTH=4
+VL_NAME_MAX=0
+VL_ASCII=0
+VL_LEAN_SEP=""
+```
+
+Adjust the values based on the interview. If the config already exists, preserve the user's
+manual edits when possible, or show the change before overwriting.
 
 ## Manual Fallback
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,250 +1,129 @@
 # coralline — AI Installation Playbook
 
-> **You are an AI coding assistant** (Claude Code or similar) and a user asked you to install
-> coralline. Follow this playbook top to bottom. Do not skip the interview step — letting the
-> user pick their own colors and layout is the whole point of this installer.
+> **You are an AI coding assistant** and a user asked you to install coralline.
+> Humans and AI use the same entrypoint: the one-line installer. Run it for the
+> user, handle missing prerequisites, choose a setup path, and remind them they can
+> rerun the visual wizard later if they want to rice the statusline themselves.
 
 ## Overview
 
-coralline is a powerline-style statusline for Claude Code. Installation means placing two files
-and registering the script in `settings.json`:
+coralline is a powerline-style statusline for Claude Code. Installation places the
+renderer under `~/.claude/coralline`, writes `~/.claude/coralline.conf`, and merges
+the `statusLine` command into `~/.claude/settings.json`.
 
 | Artifact | Destination | Purpose |
 |---|---|---|
-| `statusline.sh` | `~/.claude/coralline/statusline.sh` | The statusline renderer |
-| `configure.sh` | `~/.claude/coralline/configure.sh` | Visual setup wizard and reconfiguration entrypoint |
-| `themes/<chosen>.conf` | `~/.claude/coralline/themes/<chosen>.conf` | Color palette |
-| `sample-input.json` | `~/.claude/coralline/sample-input.json` | Local preview + verification sample |
-| generated config | `~/.claude/coralline.conf` | User's layout + theme choices |
-| `statusLine` entry | `~/.claude/settings.json` | Registers the script |
+| `statusline.sh` | `~/.claude/coralline/statusline.sh` | Statusline renderer |
+| `configure.sh` | `~/.claude/coralline/configure.sh` | Setup wizard and reconfiguration entrypoint |
+| `themes/*.conf` | `~/.claude/coralline/themes/` | Bundled palettes |
+| `sample-input.json` | `~/.claude/coralline/sample-input.json` | Local preview and verification sample |
+| generated config | `~/.claude/coralline.conf` | User layout, segments, and theme choices |
+| `statusLine` entry | `~/.claude/settings.json` | Registers coralline in Claude Code |
 
-```mermaid
-flowchart LR
-    A[Check prerequisites] --> B[Interview the user]
-    B --> C[Download files]
-    C --> D[Generate coralline.conf]
-    D --> E[Update settings.json]
-    E --> F[Verify with sample input]
-```
+## Fast Path
 
-## Fast path
-
-If you are working from a local clone, prefer the built-in wizard:
+Run:
 
 ```bash
-bash configure.sh --install
+curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
 ```
 
-If the repository has not been cloned yet:
+If you are already inside a local clone, run:
 
 ```bash
-git clone https://github.com/Nanako0129/coralline ~/.claude/coralline-src
-bash ~/.claude/coralline-src/configure.sh --install
+bash install.sh
 ```
 
-The wizard copies the renderer and bundled themes, updates `settings.json`, offers the
-default config, local `~/.p10k.zsh` import when present, or a visual wizard, then verifies the
-final render with sample input. Use the manual steps below only when the wizard cannot run in
-the current environment.
+The installer delegates to `configure.sh --install`, so it automatically enters the setup
+flow after downloading or locating the runtime files. It will:
 
-## Step 1 — Check prerequisites
+1. copy the renderer, wizard, sample input, and bundled themes;
+2. merge the Claude Code `statusLine` setting with `jq`;
+3. offer setup choices for either the user or the AI assistant:
+   - **Default**: install the recommended look immediately;
+   - **Import `.p10k.zsh`**: carry over matching Powerlevel10k style and colors when available;
+   - **Visual wizard**: choose theme, segments, layout, glyph mode, and clock format with previews;
+4. render a sample statusline to verify the final config.
+
+## Prerequisites
+
+Check:
 
 ```bash
 command -v jq || echo "MISSING: jq"
-command -v git && bash --version | head -1
+command -v curl || echo "MISSING: curl"
 ```
 
-> **Note:** `jq` is required. If missing, offer to install it (`brew install jq` on macOS,
-> `apt/dnf install jq` on Linux) before continuing. `git` is optional — the git segment
-> silently disappears without it.
+`jq` is required because coralline uses it at runtime and the installer uses it to merge
+`settings.json`. If it is missing, help the user install it first:
 
-> **Windows:** coralline is a bash script. Claude Code runs it through **Git Bash** when
-> installed, or PowerShell otherwise. If the user is on Windows, confirm Git Bash is present
-> (`git --version` from a Claude Code shell, or check for `C:/Program Files/Git`). If Git Bash
-> is absent, tell the user coralline needs [Git for Windows](https://git-scm.com/download/win)
-> plus `jq`; there is no native PowerShell version yet. Use forward slashes in the
-> `settings.json` command path on Windows.
-
-## Step 2 — Interview the user
-
-Use your interactive question tool (e.g. `AskUserQuestion`). If you have no such tool, ask in
-plain text and wait for answers. Ask these five questions — include the preview blocks so the
-user can compare themes visually:
-
-> **Note:** before asking, check whether `~/.p10k.zsh` exists. If it does, offer the
-> Powerlevel10k import (Step 2.5) as the first option — p10k users usually want their
-> existing look carried over, which answers most of these questions automatically.
-
-### Question 1 · Theme
-
-| Option | Palette |
-|---|---|
-| `claude-coral` | steel blue · mauve · coral (default) |
-| `catppuccin-mocha` | pastel blue · green · mauve on dark |
-| `nord` | frost cyan · green · purple, arctic tones |
-| `gruvbox-dark` | retro blue · aqua · orange, warm cream text |
-| `tokyo-night` | neon blue · green · purple on deep navy |
-| `dracula` | cyan · pink · purple on Dracula charcoal |
-| `mono` | grayscale, minimalist |
-
-Use ASCII previews shaped like the real bar, for example:
-
-```text
-claude-coral:     ~/proj  ⎇ main  ◆ Fable 5  ⬡ ▰▰▰▱▱ 62%  ⊙ 2:45 pm
-tokyo-night:      ~/proj  ⎇ main  ◆ Fable 5  ⬡ ▰▰▰▱▱ 62%  ⊙ 2:45 pm
+```bash
+brew install jq
 ```
 
-### Question 2 · Style
+Use the platform package manager on Linux (`apt`, `dnf`, `pacman`, etc.). `curl` is only
+needed for the remote one-line installer; local clone installs can run without it.
 
-| Option | Config to write | Looks like |
-|---|---|---|
-| Pill (default) | `VL_STYLE="pill"` | powerline pills with colored backgrounds |
-| Lean | `VL_STYLE="lean"` | flat colored text, like Powerlevel10k's lean preset |
+`git` is optional. Git segments disappear automatically when unavailable.
 
-```text
-pill:   ~/proj  ⎇ main  ◆ Fable 5  ⊙ 14:45     (colored capsule backgrounds)
-lean:   ~/proj  ⎇ main  ◆ Fable 5  ⊙ 14:45     (no backgrounds, colored text)
+## Reconfigure
+
+Rice-focused users can rerun the visual wizard at any time:
+
+```bash
+bash ~/.claude/coralline/configure.sh
 ```
 
-### Question 3 · Segments (multi-select)
+To reinstall files and re-merge Claude settings:
 
-| Segment | Shows | Default |
-|---|---|---|
-| `dir` | current directory (shortened) | on |
-| `git` | branch, dirty marks `+!?`, ahead/behind `⇡⇣` | on |
-| `model` | active Claude model | on |
-| `ctx` | context-window gauge + token counts | on |
-| `limit5h` / `limit7d` | rate-limit gauges with reset countdown | on |
-| `cost` | session cost in USD | on |
-| `clock` | current time | on |
-| `lines` | lines added/removed this session | off |
-| `style` | active output style | off |
-| `duration` | session wall-clock duration | off |
-| `effort` | reasoning effort level (`ψ`) | off |
-| `stash` | git stash count | off |
-| `project` | stable repo name (`⬢`), same across all git worktrees | off |
+```bash
+curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
+```
 
-### Question 4 · Layout
+## AI Guidance
 
-| Option | Config to write |
-|---|---|
-| Responsive (recommended) | `VL_LAYOUT="auto"` — one line when wide, wraps into `VL_MAX_LINES` rows when the window narrows; ask 2 or 3 as the cap |
-| Always single line | `VL_LAYOUT="auto"` + `VL_MAX_LINES=1` |
-| Fixed two lines | `VL_LAYOUT="fixed"` — path/git/model in `VL_SEGMENTS`, gauges in `VL_SEGMENTS2` |
-| Fixed three lines | `VL_LAYOUT="fixed"` + `VL_SEGMENTS3` |
+When installing for a user:
 
-### Question 5 · Details
+1. Run the fast-path installer first.
+2. If it fails because `jq` is missing, explain the package-manager command and rerun after
+   the user installs it.
+3. If `~/.p10k.zsh` exists, prefer the import path unless the user asks for a fresh design.
+4. If the user wants detailed visual control, choose the visual wizard path and let them pick.
+5. If the user wants you to handle it, choose the default path or the p10k import path yourself.
+6. After success, tell the user to restart Claude Code or open a new session if the statusline
+   does not appear immediately, and mention they can rerun
+   `bash ~/.claude/coralline/configure.sh` to customize it later.
 
-Ask about: clock format (`12h` / `24h` / `off`), and whether their terminal uses a
-**Nerd Font** (if not, set `VL_ASCII=1` so no broken glyphs appear).
+Do not manually rewrite `~/.claude/settings.json` unless the installer cannot run. The wizard
+already performs a merge and creates a backup when a settings file exists.
 
-Also ask whether they work in **git worktrees**. If yes, suggest adding the `project`
-segment (a stable repo name that stays the same across worktrees) and setting `VL_NAME_MAX`
-(e.g. `14`) to truncate long branch names. If they don't use worktrees, skip both — `dir`
-already shows what they need.
+## Manual Fallback
 
-## Step 2.5 — Powerlevel10k import (optional)
+Use this only if the one-line installer cannot run in the current environment.
 
-If the user opts in, read `~/.p10k.zsh` and translate their existing p10k look into the
-coralline config. You are the parser — read the file and map fuzzily, don't script it.
+```bash
+git clone https://github.com/Nanako0129/coralline ~/.claude/coralline-src
+cd ~/.claude/coralline-src
+bash configure.sh --install
+```
 
-| What to look for in `~/.p10k.zsh` | Write into coralline config |
-|---|---|
-| `# Wizard options:` comment contains `lean` | `VL_STYLE="lean"` |
-| `# Wizard options:` contains `classic`, `rainbow`, or `powerline` | `VL_STYLE="pill"` |
-| `# Wizard options:` contains `24h time` | `VL_CLOCK="24h"` |
-| `POWERLEVEL9K_TIME_FORMAT` with `%H` / `%S` | `VL_CLOCK="24h"` / `VL_CLOCK_SECONDS=1` |
-| `POWERLEVEL9K_DIR_BACKGROUND` (pill) or `_FOREGROUND` (lean) | `VL_BG_DIR` |
-| `POWERLEVEL9K_VCS_CLEAN_*` | `VL_BG_GIT_OK` |
-| `POWERLEVEL9K_VCS_MODIFIED_*` / `_UNTRACKED_*` | `VL_BG_GIT_DIRTY` |
-| `POWERLEVEL9K_TIME_*` | `VL_BG_CLOCK` |
-| `POWERLEVEL9K_STATUS_OK_*` greens | `VL_FG_OK` |
-| `POWERLEVEL9K_STATUS_ERROR_*` reds | `VL_FG_HOT` |
-
-Conversion rules:
-
-| p10k value | coralline value |
-|---|---|
-| Plain number (e.g. `4`, `76`) | Same number — both use xterm-256 indexes |
-| `#RRGGBB` | Convert to `"R,G,B"` decimal triplet |
-| In **lean** style, p10k sets `*_FOREGROUND` only | Use those as `VL_BG_*` — lean mode treats them as text accents |
-
-Segments coralline has no counterpart for (os_icon, virtualenv, kubecontext, …) are simply
-skipped; segments coralline adds (ctx, limits, cost) keep theme defaults unless the user says
-otherwise. Show the user the generated palette before writing it.
-
-## Step 3 — Download the files
+If the repository is already available locally, copy from that clone instead of downloading:
 
 ```bash
 mkdir -p ~/.claude/coralline/themes
-BASE="https://raw.githubusercontent.com/Nanako0129/coralline/main"
-curl -fsSL "$BASE/statusline.sh"            -o ~/.claude/coralline/statusline.sh
-curl -fsSL "$BASE/configure.sh"             -o ~/.claude/coralline/configure.sh
-curl -fsSL "$BASE/themes/<CHOSEN>.conf"     -o ~/.claude/coralline/themes/<CHOSEN>.conf
-curl -fsSL "$BASE/test/sample-input.json"   -o ~/.claude/coralline/sample-input.json
+cp statusline.sh configure.sh install.sh ~/.claude/coralline/
+cp test/sample-input.json ~/.claude/coralline/sample-input.json
+cp themes/*.conf ~/.claude/coralline/themes/
 chmod +x ~/.claude/coralline/statusline.sh ~/.claude/coralline/configure.sh
+bash ~/.claude/coralline/configure.sh --install
 ```
 
-> **Note:** if the repo is already cloned locally, copy from the clone instead of downloading.
+## Verification
 
-## Step 4 — Generate `~/.claude/coralline.conf`
-
-Write the user's answers into the config. Template:
+The installer verifies rendering automatically. For a manual check, run:
 
 ```bash
-# coralline config — generated by AI installer on <DATE>
-. ~/.claude/coralline/themes/<CHOSEN>.conf
-
-VL_STYLE="pill"          # pill: powerline pills · lean: flat p10k-lean text
-VL_LAYOUT="auto"         # auto: responsive · fixed: pinned rows
-VL_MAX_LINES=3           # auto only — wrap cap (1 = never wrap)
-VL_WRAP_MARGIN=4         # auto only — columns kept free on the right edge
-VL_SEGMENTS="dir git model ctx limit5h limit7d cost clock"
-VL_SEGMENTS2=""          # fixed only — second line, e.g. "lines style duration"
-VL_SEGMENTS3=""          # fixed only — third line
-VL_CLOCK="12h"           # 12h | 24h | off
-VL_CLOCK_SECONDS=1
-VL_BAR_WIDTH=5
-VL_COST_DECIMALS=2
-VL_PATH_DEPTH=4
-VL_NAME_MAX=0            # 0 = off; >0 truncates project/git names (middle-truncation)
-VL_ASCII=0               # 1 = no Nerd Font glyphs
+bash ~/.claude/coralline/statusline.sh < ~/.claude/coralline/sample-input.json
 ```
 
-> ⚠️ **Warning:** if `~/.claude/coralline.conf` already exists, show the user a diff and ask
-> before overwriting — it may contain their manual tweaks.
-
-## Step 5 — Update `settings.json`
-
-Merge — never overwrite the whole file. Back up first:
-
-```bash
-cp ~/.claude/settings.json ~/.claude/settings.json.bak 2>/dev/null
-jq '.statusLine = {
-  "type": "command",
-  "command": "bash ~/.claude/coralline/statusline.sh",
-  "refreshInterval": 1
-}' ~/.claude/settings.json > /tmp/settings.json && mv /tmp/settings.json ~/.claude/settings.json
-```
-
-If `settings.json` does not exist, create it containing only the `statusLine` key.
-
-## Step 6 — Verify
-
-Run the script against the bundled sample input and confirm it renders without errors:
-
-```bash
-curl -fsSL "$BASE/test/sample-input.json" | bash ~/.claude/coralline/statusline.sh
-```
-
-Success criteria:
-
-| Check | Expected |
-|---|---|
-| Exit code | `0` |
-| Output | One (or two) colored pill rows, no error text |
-| stderr | Empty |
-
-Finally, tell the user the statusline appears after their next Claude Code restart (or
-immediately in new sessions), and that they can re-run this installer anytime to restyle, or
-hand-edit `~/.claude/coralline.conf`.
+Success means exit code `0`, a rendered statusline on stdout, and no error text on stderr.

--- a/README.md
+++ b/README.md
@@ -187,9 +187,9 @@ Prefer Powerlevel10k's *lean* look — no backgrounds, just colored text? Set
 | `VL_LEAN_SEP` | _(empty)_ | extra text between segments, e.g. `·` |
 | `VL_LEAN_FG` | _(empty)_ | force a text color; empty = inherit each segment's accent |
 
-> **Tip:** already a p10k user? Tell the AI installer to import your `~/.p10k.zsh` — it will
-> carry over your style, colors, and time format. See the
-> [Powerlevel10k import step in INSTALL.md](./INSTALL.md#step-25--powerlevel10k-import-optional).
+> **Tip:** already a p10k user? Tell the AI installer or the visual wizard to import your
+> `~/.p10k.zsh` — it will carry over your style, colors, and time format after you opt in.
+> See the [AI interview notes in INSTALL.md](./INSTALL.md#ai-interview).
 
 ## Themes
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ Prefer Powerlevel10k's *lean* look — no backgrounds, just colored text? Set
 
 A theme is just a `.conf` file assigning `VL_BG_*` / `VL_FG_*` — copy one, change the colors,
 and source yours from `coralline.conf` instead. PRs with new themes are welcome.
+The wizard discovers themes automatically from `themes/*.conf` and nested collections such as
+`themes/best-themes/*.conf`, so adding a theme file does not require editing `configure.sh`.
 
 > **Tip:** the preview images are generated from the real script by
 > [`tools/render-screenshots.py`](./tools/render-screenshots.py) — after adding a theme, add it

--- a/README.md
+++ b/README.md
@@ -22,6 +22,28 @@ Claude will ask you to pick a theme (with previews), choose which segments you w
 between a one-line or two-line layout, then wire everything up and verify it. No manual
 config editing required.
 
+## Install (direct)
+
+```bash
+git clone https://github.com/Nanako0129/coralline ~/.claude/coralline-src
+bash ~/.claude/coralline-src/configure.sh --install
+```
+
+The wizard installs the renderer, copies all bundled themes, updates `~/.claude/settings.json`,
+then lets you choose one of three setup paths:
+
+| Mode | Use when |
+|---|---|
+| Default | You want the coralline default immediately |
+| Powerlevel10k import | You already have `~/.p10k.zsh` and want to carry over its style, time format, and main colors |
+| Visual wizard | You want to preview themes, style, segments, wrapping, clock, and font compatibility before writing config |
+
+Re-run this anytime to restyle:
+
+```bash
+bash ~/.claude/coralline/configure.sh
+```
+
 ## What you get
 
 ```text
@@ -62,6 +84,7 @@ spam. Works on stock macOS bash 3.2 and any Linux bash.
 git clone https://github.com/Nanako0129/coralline ~/.claude/coralline-src
 mkdir -p ~/.claude/coralline/themes
 cp ~/.claude/coralline-src/statusline.sh ~/.claude/coralline/
+cp ~/.claude/coralline-src/configure.sh ~/.claude/coralline/
 cp ~/.claude/coralline-src/themes/claude-coral.conf ~/.claude/coralline/themes/
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ Paste this into Claude Code:
 
 ```text
 Please install coralline for me:
-curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
+fetch https://raw.githubusercontent.com/Nanako0129/coralline/main/INSTALL.md
+and follow the playbook in it.
 ```
 
-Claude will run the same installer humans use, help with any missing prerequisites, choose a
-setup path for you, and remind you that you can rerun the visual wizard if the first result
-doesn't match your taste.
+Claude will read the playbook, use the same installer to bootstrap the runtime, interview you
+about the look, write the config, verify it, and remind you that you can rerun the visual
+wizard if the first result doesn't match your taste.
 
 ## Install Yourself
 
@@ -31,9 +32,8 @@ curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.s
 
 ## Setup Choices
 
-Both paths run the same installer. It copies the renderer and bundled themes, updates
-`~/.claude/settings.json`, then automatically opens the setup flow and asks you or Claude to
-choose:
+Both paths use the same installer. Humans run it with no mode and get the visual setup. Claude
+uses it with `--install-only`, then follows `INSTALL.md` to interview you and write config.
 
 | Mode | Use when |
 |---|---|
@@ -41,10 +41,19 @@ choose:
 | Powerlevel10k import | You already have `~/.p10k.zsh` and want to carry over its style, time format, and main colors |
 | Visual wizard | You want to preview themes, style, segments, wrapping, clock, and font compatibility before writing config |
 
+Running the installer yourself with no mode opens the interactive setup. Claude should not
+operate that TUI unless you explicitly ask for visual customization.
+
 Re-run the wizard anytime to restyle:
 
 ```bash
 bash ~/.claude/coralline/configure.sh
+```
+
+Testing a fork? Point the installer at the same fork:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/miyago9267/coralline/main/install.sh | bash -s -- --repo miyago9267/coralline
 ```
 
 ## What you get

--- a/README.md
+++ b/README.md
@@ -1,36 +1,39 @@
 # coralline
 
 > A [Powerlevel10k](https://github.com/romkatv/powerlevel10k)-inspired statusline for Claude
-> Code that **installs itself through your AI** — paste one prompt, answer a few questions
-> about colors and layout, done.
+> Code with one installer entrypoint for humans and AI: run it directly, or ask Claude to run
+> it and handle the setup for you.
 
 [繁體中文說明](./README.zh-TW.md)
 
 ![All six coralline themes rendered side by side](./assets/hero.png)
 
-## Install (the fun way)
+## Ask Claude to Install
 
 Paste this into Claude Code:
 
 ```text
 Please install coralline for me:
-fetch https://raw.githubusercontent.com/Nanako0129/coralline/main/INSTALL.md
-and follow the playbook in it.
+curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
 ```
 
-Claude will ask you to pick a theme (with previews), choose which segments you want, decide
-between a one-line or two-line layout, then wire everything up and verify it. No manual
-config editing required.
+Claude will run the same installer humans use, help with any missing prerequisites, choose a
+setup path for you, and remind you that you can rerun the visual wizard if the first result
+doesn't match your taste.
 
-## Install (direct)
+## Install Yourself
+
+Run the installer in your terminal:
 
 ```bash
-git clone https://github.com/Nanako0129/coralline ~/.claude/coralline-src
-bash ~/.claude/coralline-src/configure.sh --install
+curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
 ```
 
-The wizard installs the renderer, copies all bundled themes, updates `~/.claude/settings.json`,
-then lets you choose one of three setup paths:
+## Setup Choices
+
+Both paths run the same installer. It copies the renderer and bundled themes, updates
+`~/.claude/settings.json`, then automatically opens the setup flow and asks you or Claude to
+choose:
 
 | Mode | Use when |
 |---|---|
@@ -38,7 +41,7 @@ then lets you choose one of three setup paths:
 | Powerlevel10k import | You already have `~/.p10k.zsh` and want to carry over its style, time format, and main colors |
 | Visual wizard | You want to preview themes, style, segments, wrapping, clock, and font compatibility before writing config |
 
-Re-run this anytime to restyle:
+Re-run the wizard anytime to restyle:
 
 ```bash
 bash ~/.claude/coralline/configure.sh
@@ -85,6 +88,7 @@ git clone https://github.com/Nanako0129/coralline ~/.claude/coralline-src
 mkdir -p ~/.claude/coralline/themes
 cp ~/.claude/coralline-src/statusline.sh ~/.claude/coralline/
 cp ~/.claude/coralline-src/configure.sh ~/.claude/coralline/
+cp ~/.claude/coralline-src/install.sh ~/.claude/coralline/
 cp ~/.claude/coralline-src/themes/claude-coral.conf ~/.claude/coralline/themes/
 ```
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -14,11 +14,12 @@
 
 ```text
 Please install coralline for me:
-curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
+fetch https://raw.githubusercontent.com/Nanako0129/coralline/main/INSTALL.md
+and follow the playbook in it.
 ```
 
-Claude 會執行同一支 installer、協助處理缺少的依賴、幫你選完設定流程，最後提醒你
-如果不滿意可以自己重新開啟視覺化 wizard。
+Claude 會先讀 playbook，再用同一支 installer bootstrap runtime、訪談你的外觀偏好、
+寫入設定並驗證，最後提醒你如果不滿意可以自己重新開啟視覺化 wizard。
 
 ## 自己安裝
 
@@ -30,8 +31,8 @@ curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.s
 
 ## 設定選項
 
-兩種方式都會執行同一支 installer。它會安裝 renderer、複製內建主題、
-更新 `~/.claude/settings.json`，接著自動開啟設定流程，讓你或 Claude 選：
+兩種方式都使用同一支 installer。人類不帶模式參數執行時會進入視覺化設定；
+Claude 則使用 `--install-only` bootstrap，接著依照 `INSTALL.md` 訪談並寫入設定。
 
 | 模式 | 適合情境 |
 |---|---|
@@ -39,10 +40,19 @@ curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.s
 | Powerlevel10k import | 已經有 `~/.p10k.zsh`，想帶入 style、時間格式與主要色彩 |
 | 視覺化 wizard | 想先預覽 theme、style、segments、折行、時鐘與字型相容性 |
 
+自己直接執行 installer、不帶模式參數時，會開啟互動式設定。除非你明確要求視覺化自訂，
+Claude 不需要操作這個人類 TUI。
+
 之後要重新調整外觀可以跑：
 
 ```bash
 bash ~/.claude/coralline/configure.sh
+```
+
+測試 fork 時，可以讓 installer 指向同一個 fork：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/miyago9267/coralline/main/install.sh | bash -s -- --repo miyago9267/coralline
 ```
 
 ## 效果

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -184,9 +184,9 @@ narrow window:  ~/dev/app  ⎇ main  ◆ Fable 5
 | `VL_LEAN_SEP` | （空） | 區段之間的額外分隔字串，例如 `·` |
 | `VL_LEAN_FG` | （空） | 強制指定文字色；留空 = 繼承各區段的強調色 |
 
-> **提示：** 本來就是 p10k 使用者？跟 AI 安裝員說一聲，它會讀你的 `~/.p10k.zsh`，
-> 把風格、配色、時間格式都搬過來。詳見
-> [INSTALL.md 的 Powerlevel10k 匯入步驟](./INSTALL.md#step-25--powerlevel10k-import-optional)。
+> **提示：** 本來就是 p10k 使用者？跟 AI 安裝員或視覺化 wizard 說要匯入
+> `~/.p10k.zsh`，它會在你同意後帶入風格、配色與時間格式。詳見
+> [INSTALL.md 的 AI interview](./INSTALL.md#ai-interview)。
 
 ## 主題
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -20,6 +20,27 @@ and follow the playbook in it.
 Claude 會讓你挑主題（附預覽圖）、選擇要顯示哪些區段、決定單行或雙行版面，
 然後自動完成設定並驗證。完全不需要手動編輯設定檔。
 
+## 直接安裝
+
+```bash
+git clone https://github.com/Nanako0129/coralline ~/.claude/coralline-src
+bash ~/.claude/coralline-src/configure.sh --install
+```
+
+wizard 會安裝 renderer、複製內建主題、更新 `~/.claude/settings.json`，接著讓你選：
+
+| 模式 | 適合情境 |
+|---|---|
+| 預設 | 想直接使用 coralline 預設外觀 |
+| Powerlevel10k import | 已經有 `~/.p10k.zsh`，想帶入 style、時間格式與主要色彩 |
+| 視覺化 wizard | 想先預覽 theme、style、segments、折行、時鐘與字型相容性 |
+
+之後要重新設定可以跑：
+
+```bash
+bash ~/.claude/coralline/configure.sh
+```
+
 ## 效果
 
 ```text
@@ -60,6 +81,7 @@ macOS 內建的 bash 3.2 和任何 Linux bash 都能跑。
 git clone https://github.com/Nanako0129/coralline ~/.claude/coralline-src
 mkdir -p ~/.claude/coralline/themes
 cp ~/.claude/coralline-src/statusline.sh ~/.claude/coralline/
+cp ~/.claude/coralline-src/configure.sh ~/.claude/coralline/
 cp ~/.claude/coralline-src/themes/claude-coral.conf ~/.claude/coralline/themes/
 ```
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -199,6 +199,8 @@ narrow window:  ~/dev/app  ⎇ main  ◆ Fable 5
 
 主題就只是一個指定 `VL_BG_*` / `VL_FG_*` 的 `.conf` 檔——複製一份、改顏色、
 在 `coralline.conf` 裡改 source 你的版本即可。歡迎發 PR 貢獻新主題。
+wizard 會自動掃描 `themes/*.conf` 與 `themes/best-themes/*.conf` 這類巢狀集合，
+新增主題檔時不需要修改 `configure.sh`。
 
 > **提示：** 預覽圖是由 [`tools/render-screenshots.py`](./tools/render-screenshots.py)
 > 直接執行真實腳本產生的——新增主題後把名稱加進該檔的 `THEMES` 清單再跑一次，

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,33 +1,37 @@
 # coralline
 
 > 給 Claude Code 用、向 [Powerlevel10k](https://github.com/romkatv/powerlevel10k) 致敬的
-> statusline，特色是**由 AI 幫你安裝**——貼一句提示詞，回答幾個配色與版面的問題，就裝好了。
+> statusline，特色是人類與 AI 共用同一個 installer 入口：你可以直接跑，也可以交給
+> Claude 幫你跑完設定。
 
 [English README](./README.md)
 
 ![六種 coralline 主題總覽](./assets/hero.png)
 
-## 安裝（有趣的方式）
+## 請 Claude 安裝
 
 把這段貼進 Claude Code：
 
 ```text
 Please install coralline for me:
-fetch https://raw.githubusercontent.com/Nanako0129/coralline/main/INSTALL.md
-and follow the playbook in it.
+curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
 ```
 
-Claude 會讓你挑主題（附預覽圖）、選擇要顯示哪些區段、決定單行或雙行版面，
-然後自動完成設定並驗證。完全不需要手動編輯設定檔。
+Claude 會執行同一支 installer、協助處理缺少的依賴、幫你選完設定流程，最後提醒你
+如果不滿意可以自己重新開啟視覺化 wizard。
 
-## 直接安裝
+## 自己安裝
+
+在終端機執行：
 
 ```bash
-git clone https://github.com/Nanako0129/coralline ~/.claude/coralline-src
-bash ~/.claude/coralline-src/configure.sh --install
+curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
 ```
 
-wizard 會安裝 renderer、複製內建主題、更新 `~/.claude/settings.json`，接著讓你選：
+## 設定選項
+
+兩種方式都會執行同一支 installer。它會安裝 renderer、複製內建主題、
+更新 `~/.claude/settings.json`，接著自動開啟設定流程，讓你或 Claude 選：
 
 | 模式 | 適合情境 |
 |---|---|
@@ -35,7 +39,7 @@ wizard 會安裝 renderer、複製內建主題、更新 `~/.claude/settings.json
 | Powerlevel10k import | 已經有 `~/.p10k.zsh`，想帶入 style、時間格式與主要色彩 |
 | 視覺化 wizard | 想先預覽 theme、style、segments、折行、時鐘與字型相容性 |
 
-之後要重新設定可以跑：
+之後要重新調整外觀可以跑：
 
 ```bash
 bash ~/.claude/coralline/configure.sh
@@ -82,6 +86,7 @@ git clone https://github.com/Nanako0129/coralline ~/.claude/coralline-src
 mkdir -p ~/.claude/coralline/themes
 cp ~/.claude/coralline-src/statusline.sh ~/.claude/coralline/
 cp ~/.claude/coralline-src/configure.sh ~/.claude/coralline/
+cp ~/.claude/coralline-src/install.sh ~/.claude/coralline/
 cp ~/.claude/coralline-src/themes/claude-coral.conf ~/.claude/coralline/themes/
 ```
 

--- a/configure.sh
+++ b/configure.sh
@@ -17,6 +17,8 @@ P10K_FILE="${P10K_CONFIG:-$HOME/.p10k.zsh}"
 # The live list is derived from statusline.sh's seg_* functions by load_segment_choices.
 SEGMENT_CHOICES="dir project git model ctx limit5h limit7d cost clock lines style duration effort stash"
 DEFAULT_SEGMENTS="dir git model ctx limit5h limit7d cost clock"
+THEME_CHOICES=""
+theme_choices_loaded=0
 
 theme="claude-coral"
 style="pill"
@@ -36,6 +38,8 @@ install_only=0
 setup_mode=""
 screen_active=0
 old_stty=""
+preview_input_file=""
+preview_cache_dir=""
 
 T_RESET=$(printf '\033[0m')
 T_BOLD=$(printf '\033[1m')
@@ -96,9 +100,24 @@ runtime_theme_dir() {
 
 theme_list() {
   local dir
+  if [ "$theme_choices_loaded" = "1" ]; then
+    printf '%s' "$THEME_CHOICES"
+    return 0
+  fi
   dir=$(runtime_theme_dir)
   [ -d "$dir" ] || return 0
   (cd "$dir" && find . -type f -name '*.conf' | sed 's#^\./##; s#\.conf$##' | sort)
+}
+
+load_theme_choices() {
+  local dir
+  dir=$(runtime_theme_dir)
+  [ -d "$dir" ] || return 0
+  THEME_CHOICES=$(cd "$dir" && find . -type f -name '*.conf' | sed 's#^\./##; s#\.conf$##' | sort; printf x)
+  THEME_CHOICES=${THEME_CHOICES%x}
+  [ -n "$THEME_CHOICES" ] && THEME_CHOICES="${THEME_CHOICES}
+"
+  theme_choices_loaded=1
 }
 
 theme_count() {
@@ -134,6 +153,34 @@ runtime_sample() {
   else
     printf '%s\n' ""
   fi
+}
+
+prepare_preview_input() {
+  local sample input
+  if [ -n "$preview_input_file" ] && [ -f "$preview_input_file" ]; then
+    printf '%s\n' "$preview_input_file"
+    return 0
+  fi
+  sample=$(runtime_sample)
+  [ -n "$sample" ] && need_file "$sample"
+  input=$(mktemp "${TMPDIR:-/tmp}/coralline-input.XXXXXX") || exit 1
+  if [ -n "$sample" ]; then
+    jq --arg cwd "$SCRIPT_DIR" '.cwd = $cwd | .workspace.current_dir = $cwd' "$sample" > "$input" 2>/dev/null || cp "$sample" "$input"
+  else
+    jq -n --arg cwd "$SCRIPT_DIR" '{cwd: $cwd, workspace: {current_dir: $cwd}}' > "$input"
+  fi
+  preview_input_file="$input"
+  printf '%s\n' "$preview_input_file"
+}
+
+preview_cache_path() {
+  local config="$1" cols="$2" key crc bytes
+  [ -n "$preview_cache_dir" ] || preview_cache_dir=$(mktemp -d "${TMPDIR:-/tmp}/coralline-preview.XXXXXX") || exit 1
+  key=$( (printf '%s\n' "$cols"; cat "$config") | cksum )
+  set -- $key
+  crc="$1"
+  bytes="$2"
+  printf '%s/%s-%s.out\n' "$preview_cache_dir" "$crc" "$bytes"
 }
 
 ask() {
@@ -211,6 +258,12 @@ leave_screen() {
   tput cnorm 2>/dev/null || true
   tput rmcup 2>/dev/null || true
   screen_active=0
+}
+
+cleanup() {
+  leave_screen
+  [ -n "$preview_input_file" ] && rm -f "$preview_input_file"
+  [ -n "$preview_cache_dir" ] && rm -rf "$preview_cache_dir"
 }
 
 clear_screen() {
@@ -368,22 +421,22 @@ EOF
 }
 
 render_preview() {
-  local tmp input statusline sample cols="${1:-120}"
+  local tmp input statusline cache cols="${1:-120}"
   statusline=$(runtime_statusline)
-  sample=$(runtime_sample)
   need_file "$statusline"
-  [ -n "$sample" ] && need_file "$sample"
   tmp=$(mktemp "${TMPDIR:-/tmp}/coralline-config.XXXXXX") || exit 1
-  input=$(mktemp "${TMPDIR:-/tmp}/coralline-input.XXXXXX") || exit 1
+  input=$(prepare_preview_input)
   write_candidate_config "$tmp"
-  if [ -n "$sample" ]; then
-    jq --arg cwd "$SCRIPT_DIR" '.cwd = $cwd | .workspace.current_dir = $cwd' "$sample" > "$input" 2>/dev/null || cp "$sample" "$input"
-  else
-    jq -n --arg cwd "$SCRIPT_DIR" '{cwd: $cwd, workspace: {current_dir: $cwd}}' > "$input"
-  fi
+  cache=$(preview_cache_path "$tmp" "$cols")
   printf '\nPreview (%s cols):\n' "$cols"
-  CORALLINE_CONFIG="$tmp" COLUMNS="$cols" bash "$statusline" < "$input"
-  rm -f "$tmp" "$input"
+  if [ ! -f "$cache" ]; then
+    if ! CORALLINE_CONFIG="$tmp" COLUMNS="$cols" bash "$statusline" < "$input" > "$cache"; then
+      rm -f "$cache" "$tmp"
+      return 1
+    fi
+  fi
+  cat "$cache"
+  rm -f "$tmp"
 }
 
 preview_current() {
@@ -1095,12 +1148,13 @@ for arg in "$@"; do
   esac
 done
 
-trap 'leave_screen' EXIT
-trap 'leave_screen; exit 130' INT TERM
+trap 'cleanup' EXIT
+trap 'cleanup; exit 130' INT TERM
 
 [ "$install_only" = "1" ] && exit 0
 
 load_segment_choices
+load_theme_choices
 main_menu
 write_final_config || exit 0
 verify_render

--- a/configure.sh
+++ b/configure.sh
@@ -42,6 +42,7 @@ T_BOLD=$(printf '\033[1m')
 T_DIM=$(printf '\033[2m')
 T_BLUE=$(printf '\033[38;5;81m')
 T_GREEN=$(printf '\033[38;5;114m')
+T_RED=$(printf '\033[38;5;167m')
 T_MAUVE=$(printf '\033[38;5;183m')
 T_CORAL=$(printf '\033[38;5;173m')
 T_WARN=$(printf '\033[38;5;179m')
@@ -165,13 +166,34 @@ ask_choice() {
 yes_no() {
   local prompt="$1" default="$2" answer
   while :; do
-    answer=$(ask "$prompt" "$default")
+    case "$default" in
+      y|Y) printf '%s [Y/n]: ' "$prompt" >&2 ;;
+      *) printf '%s [y/N]: ' "$prompt" >&2 ;;
+    esac
+    IFS= read -r answer
+    [ -n "$answer" ] || answer="$default"
     case "$answer" in
       y|Y|yes|YES) return 0 ;;
       n|N|no|NO) return 1 ;;
       *) printf 'Answer y or n.\n' >&2 ;;
     esac
   done
+}
+
+show_diff() {
+  if [ -t 1 ]; then
+    diff -u "$1" "$2" | while IFS= read -r line; do
+      case "$line" in
+        ---*|+++*) printf '%s%s%s\n' "$T_DIM" "$line" "$T_RESET" ;;
+        @@*) printf '%s%s%s\n' "$T_MAUVE" "$line" "$T_RESET" ;;
+        +*) printf '%s%s%s\n' "$T_GREEN" "$line" "$T_RESET" ;;
+        -*) printf '%s%s%s\n' "$T_RED" "$line" "$T_RESET" ;;
+        *) printf '%s\n' "$line" ;;
+      esac
+    done
+  else
+    diff -u "$1" "$2"
+  fi
 }
 
 enter_screen() {
@@ -875,17 +897,17 @@ write_final_config() {
   tmp=$(mktemp "${TMPDIR:-/tmp}/coralline-config.XXXXXX") || exit 1
   write_candidate_config "$tmp"
   if [ -f "$CONFIG_FILE" ]; then
-    printf '\nExisting config diff:\n'
-    diff -u "$CONFIG_FILE" "$tmp" || true
+    printf '\n%sExisting config diff:%s\n' "$T_BOLD" "$T_RESET"
+    show_diff "$CONFIG_FILE" "$tmp" || true
     if ! yes_no "Overwrite $CONFIG_FILE" n; then
       rm -f "$tmp"
-      printf 'Config unchanged.\n'
+      printf '%sConfig unchanged.%s\n' "$T_WARN" "$T_RESET"
       return 1
     fi
   fi
   mkdir -p "$(dirname "$CONFIG_FILE")"
   mv "$tmp" "$CONFIG_FILE"
-  printf 'Wrote %s\n' "$CONFIG_FILE"
+  printf '%sWrote%s %s\n' "$T_GREEN" "$T_RESET" "$CONFIG_FILE"
 }
 
 install_files() {
@@ -1082,5 +1104,5 @@ load_segment_choices
 main_menu
 write_final_config || exit 0
 verify_render
-printf '\nDone. Restart Claude Code or open a new session to see coralline.\n'
-printf 'Reconfigure anytime with:\n  bash %s/configure.sh\n' "$TARGET_DIR"
+printf '\n%sDone.%s Restart Claude Code or open a new session to see coralline.\n' "$T_GREEN" "$T_RESET"
+printf '%sReconfigure anytime with:%s\n  %sbash %s/configure.sh%s\n' "$T_DIM" "$T_RESET" "$T_CORAL" "$TARGET_DIR" "$T_RESET"

--- a/configure.sh
+++ b/configure.sh
@@ -31,6 +31,8 @@ name_max=0
 lean_sep=""
 extra_config=""
 installed=0
+install_only=0
+setup_mode=""
 screen_active=0
 old_stty=""
 
@@ -41,6 +43,13 @@ coralline configure
 Options:
   --install    Copy coralline into ~/.claude/coralline, update Claude settings,
                then run the visual wizard.
+  --install-only
+               Copy coralline into ~/.claude/coralline and update Claude settings,
+               then exit without writing theme config.
+  --default    Use the coralline default config without opening the setup menu.
+  --import-p10k
+               Import ~/.p10k.zsh without opening the setup menu.
+  --wizard     Open the visual wizard directly.
   --help       Show this help.
 EOF
 }
@@ -898,6 +907,22 @@ draw_main_menu() {
 
 main_menu() {
   local answer max default_choice
+  case "$setup_mode" in
+    default)
+      preview_current 120
+      return 0
+      ;;
+    import-p10k)
+      [ -f "$P10K_FILE" ] || die "cannot import $P10K_FILE: file not found"
+      import_p10k
+      preview_current 120
+      return 0
+      ;;
+    wizard)
+      visual_wizard
+      return 0
+      ;;
+  esac
   if [ -t 0 ] && [ -t 1 ]; then
     enter_screen
     main_menu_screen
@@ -934,6 +959,10 @@ main_menu() {
 for arg in "$@"; do
   case "$arg" in
     --install) install_files; update_settings ;;
+    --install-only) install_files; update_settings; install_only=1 ;;
+    --default) setup_mode="default" ;;
+    --import-p10k) setup_mode="import-p10k" ;;
+    --wizard) setup_mode="wizard" ;;
     --help|-h) usage; exit 0 ;;
     *) usage; exit 1 ;;
   esac
@@ -941,6 +970,8 @@ done
 
 trap 'leave_screen' EXIT
 trap 'leave_screen; exit 130' INT TERM
+
+[ "$install_only" = "1" ] && exit 0
 
 main_menu
 write_final_config || exit 0

--- a/configure.sh
+++ b/configure.sh
@@ -932,10 +932,11 @@ main_menu() {
   printf '\nChoose how to create your theme config:\n'
   printf '  1) Use the coralline default\n'
   if [ -f "$P10K_FILE" ]; then
+    printf '     Found %s. Choose import only if you want to use it.\n' "$P10K_FILE"
     printf '  2) Import local .p10k.zsh colors\n'
     printf '  3) Visual wizard\n'
     max=3
-    default_choice=2
+    default_choice=1
   else
     printf '  2) Visual wizard\n'
     max=2

--- a/configure.sh
+++ b/configure.sh
@@ -1,0 +1,948 @@
+#!/usr/bin/env bash
+# coralline visual configuration wizard.
+#
+# Usage:
+#   bash configure.sh
+#   bash configure.sh --install
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+TARGET_DIR="${CORALLINE_HOME:-$HOME/.claude/coralline}"
+CONFIG_FILE="${CORALLINE_CONFIG:-$HOME/.claude/coralline.conf}"
+SETTINGS_FILE="${CLAUDE_SETTINGS:-$HOME/.claude/settings.json}"
+P10K_FILE="${P10K_CONFIG:-$HOME/.p10k.zsh}"
+
+THEMES="claude-coral catppuccin-mocha nord gruvbox-dark tokyo-night dracula mono"
+SEGMENT_CHOICES="dir project git model ctx limit5h limit7d cost clock lines style duration effort stash"
+DEFAULT_SEGMENTS="dir git model ctx limit5h limit7d cost clock"
+
+theme="claude-coral"
+style="pill"
+layout="auto"
+max_lines=3
+segments="$DEFAULT_SEGMENTS"
+segments2=""
+segments3=""
+clock_mode="12h"
+clock_seconds=1
+ascii_mode=0
+name_max=0
+lean_sep=""
+extra_config=""
+installed=0
+screen_active=0
+old_stty=""
+
+usage() {
+  cat <<'EOF'
+coralline configure
+
+Options:
+  --install    Copy coralline into ~/.claude/coralline, update Claude settings,
+               then run the visual wizard.
+  --help       Show this help.
+EOF
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_file() {
+  [ -f "$1" ] || die "missing required file: $1"
+}
+
+runtime_statusline() {
+  if [ "$installed" = "1" ] && [ -f "$TARGET_DIR/statusline.sh" ]; then
+    printf '%s\n' "$TARGET_DIR/statusline.sh"
+  elif [ -f "$SCRIPT_DIR/statusline.sh" ]; then
+    printf '%s\n' "$SCRIPT_DIR/statusline.sh"
+  else
+    printf '%s\n' "$TARGET_DIR/statusline.sh"
+  fi
+}
+
+runtime_theme_dir() {
+  if [ "$installed" = "1" ] && [ -d "$TARGET_DIR/themes" ]; then
+    printf '%s\n' "$TARGET_DIR/themes"
+  elif [ -d "$SCRIPT_DIR/themes" ]; then
+    printf '%s\n' "$SCRIPT_DIR/themes"
+  else
+    printf '%s\n' "$TARGET_DIR/themes"
+  fi
+}
+
+runtime_sample() {
+  if [ "$installed" = "1" ] && [ -f "$TARGET_DIR/sample-input.json" ]; then
+    printf '%s\n' "$TARGET_DIR/sample-input.json"
+  elif [ -f "$SCRIPT_DIR/test/sample-input.json" ]; then
+    printf '%s\n' "$SCRIPT_DIR/test/sample-input.json"
+  elif [ -f "$TARGET_DIR/sample-input.json" ]; then
+    printf '%s\n' "$TARGET_DIR/sample-input.json"
+  else
+    printf '%s\n' ""
+  fi
+}
+
+ask() {
+  local prompt="$1" default="${2:-}" answer
+  if [ -n "$default" ]; then
+    printf '%s [%s]: ' "$prompt" "$default" >&2
+  else
+    printf '%s: ' "$prompt" >&2
+  fi
+  IFS= read -r answer
+  [ -n "$answer" ] || answer="$default"
+  printf '%s\n' "$answer"
+}
+
+ask_choice() {
+  local prompt="$1" max="$2" default="$3" answer
+  while :; do
+    answer=$(ask "$prompt" "$default")
+    case "$answer" in
+      ''|*[!0-9]*) printf 'Choose a number from 1 to %s.\n' "$max" >&2 ;;
+      *) if [ "$answer" -ge 1 ] && [ "$answer" -le "$max" ]; then
+           printf '%s\n' "$answer"
+           return 0
+         fi
+         printf 'Choose a number from 1 to %s.\n' "$max" >&2 ;;
+    esac
+  done
+}
+
+yes_no() {
+  local prompt="$1" default="$2" answer
+  while :; do
+    answer=$(ask "$prompt" "$default")
+    case "$answer" in
+      y|Y|yes|YES) return 0 ;;
+      n|N|no|NO) return 1 ;;
+      *) printf 'Answer y or n.\n' >&2 ;;
+    esac
+  done
+}
+
+enter_screen() {
+  [ -t 0 ] && [ -t 1 ] || return 1
+  old_stty=$(stty -g 2>/dev/null || true)
+  tput smcup 2>/dev/null || true
+  tput civis 2>/dev/null || true
+  stty -echo 2>/dev/null || true
+  screen_active=1
+}
+
+leave_screen() {
+  [ "$screen_active" = "1" ] || return 0
+  [ -n "$old_stty" ] && stty "$old_stty" 2>/dev/null || stty echo 2>/dev/null || true
+  tput cnorm 2>/dev/null || true
+  tput rmcup 2>/dev/null || true
+  screen_active=0
+}
+
+clear_screen() {
+  printf '\033[H\033[J'
+}
+
+clear_tail() {
+  printf '\033[J'
+}
+
+redraw_menu_area() {
+  printf '\033[u'
+}
+
+read_key() {
+  local k k2 k3
+  IFS= read -rsn1 k || return 1
+  if [ "$k" = $'\033' ]; then
+    IFS= read -rsn1 -t 1 k2 2>/dev/null || k2=""
+    IFS= read -rsn1 -t 1 k3 2>/dev/null || k3=""
+    k="$k$k2$k3"
+  fi
+  case "$k" in
+    $'\033[A') printf 'up\n' ;;
+    $'\033[B') printf 'down\n' ;;
+    $'\033[C') printf 'right\n' ;;
+    $'\033[D') printf 'left\n' ;;
+    '') printf 'enter\n' ;;
+    ' ') printf 'space\n' ;;
+    q|Q) printf 'quit\n' ;;
+    k|K) printf 'up\n' ;;
+    j|J) printf 'down\n' ;;
+    *) printf '%s\n' "$k" ;;
+  esac
+}
+
+menu_move() {
+  local selected="$1" key="$2" count="$3"
+  case "$key" in
+    up) selected=$((selected - 1)); [ "$selected" -lt 0 ] && selected=$((count - 1)) ;;
+    down) selected=$((selected + 1)); [ "$selected" -ge "$count" ] && selected=0 ;;
+  esac
+  printf '%s\n' "$selected"
+}
+
+add_extra() {
+  extra_config="${extra_config}$1=\"$2\"
+"
+}
+
+hex_to_rgb() {
+  local h="$1" r g b
+  h="${h#\#}"
+  [ "${#h}" = "6" ] || return 1
+  r=$((16#${h:0:2}))
+  g=$((16#${h:2:2}))
+  b=$((16#${h:4:2}))
+  printf '%s,%s,%s\n' "$r" "$g" "$b"
+}
+
+normalize_color() {
+  local v="$1"
+  v="${v%% #*}"
+  v="${v#\"}" ; v="${v%\"}"
+  v="${v#\'}" ; v="${v%\'}"
+  case "$v" in
+    \#??????) hex_to_rgb "$v" ;;
+    ''|*[!0-9]*) return 1 ;;
+    *) printf '%s\n' "$v" ;;
+  esac
+}
+
+p10k_value() {
+  local name="$1" line
+  line=$(grep -E "^[[:space:]]*(typeset -g )?${name}=" "$P10K_FILE" 2>/dev/null | tail -1) || return 1
+  line="${line#*${name}=}"
+  line="${line%%[[:space:]]#*}"
+  line="${line#\"}" ; line="${line%\"}"
+  line="${line#\'}" ; line="${line%\'}"
+  printf '%s\n' "$line"
+}
+
+map_p10k_color() {
+  local p10k_name="$1" coralline_name="$2" value color
+  value=$(p10k_value "$p10k_name") || return 0
+  color=$(normalize_color "$value") || return 0
+  add_extra "$coralline_name" "$color"
+}
+
+import_p10k() {
+  local wizard_options time_fmt
+  [ -f "$P10K_FILE" ] || die "cannot import; $P10K_FILE does not exist"
+
+  wizard_options=$(grep -E '^# Wizard options:' "$P10K_FILE" 2>/dev/null | tail -1)
+  case "$wizard_options" in
+    *lean*) style="lean" ;;
+    *classic*|*rainbow*|*powerline*) style="pill" ;;
+  esac
+  case "$wizard_options" in
+    *24h\ time*) clock_mode="24h" ;;
+  esac
+
+  time_fmt=$(p10k_value POWERLEVEL9K_TIME_FORMAT || true)
+  case "$time_fmt" in
+    *%H*) clock_mode="24h" ;;
+  esac
+  case "$time_fmt" in
+    *%S*) clock_seconds=1 ;;
+  esac
+
+  if [ "$style" = "lean" ]; then
+    map_p10k_color POWERLEVEL9K_DIR_FOREGROUND VL_BG_DIR
+    map_p10k_color POWERLEVEL9K_VCS_CLEAN_FOREGROUND VL_BG_GIT_OK
+    map_p10k_color POWERLEVEL9K_VCS_MODIFIED_FOREGROUND VL_BG_GIT_DIRTY
+    map_p10k_color POWERLEVEL9K_VCS_UNTRACKED_FOREGROUND VL_BG_GIT_DIRTY
+    map_p10k_color POWERLEVEL9K_TIME_FOREGROUND VL_BG_CLOCK
+  else
+    map_p10k_color POWERLEVEL9K_DIR_BACKGROUND VL_BG_DIR
+    map_p10k_color POWERLEVEL9K_VCS_CLEAN_BACKGROUND VL_BG_GIT_OK
+    map_p10k_color POWERLEVEL9K_VCS_MODIFIED_BACKGROUND VL_BG_GIT_DIRTY
+    map_p10k_color POWERLEVEL9K_VCS_UNTRACKED_BACKGROUND VL_BG_GIT_DIRTY
+    map_p10k_color POWERLEVEL9K_TIME_BACKGROUND VL_BG_CLOCK
+  fi
+  map_p10k_color POWERLEVEL9K_STATUS_OK_FOREGROUND VL_FG_OK
+  map_p10k_color POWERLEVEL9K_STATUS_ERROR_FOREGROUND VL_FG_HOT
+}
+
+write_candidate_config() {
+  local out="$1" theme_dir
+  theme_dir=$(runtime_theme_dir)
+  cat > "$out" <<EOF
+# coralline config
+. "$theme_dir/$theme.conf"
+
+VL_STYLE="$style"
+VL_LAYOUT="$layout"
+VL_MAX_LINES=$max_lines
+VL_WRAP_MARGIN=4
+VL_SEGMENTS="$segments"
+VL_SEGMENTS2="$segments2"
+VL_SEGMENTS3="$segments3"
+VL_CLOCK="$clock_mode"
+VL_CLOCK_SECONDS=$clock_seconds
+VL_BAR_WIDTH=5
+VL_COST_DECIMALS=2
+VL_PATH_DEPTH=4
+VL_NAME_MAX=$name_max
+VL_ASCII=$ascii_mode
+VL_LEAN_SEP="$lean_sep"
+EOF
+  if [ -n "$extra_config" ]; then
+    printf '\n# Imported p10k color hints.\n' >> "$out"
+    printf '%s' "$extra_config" >> "$out"
+  fi
+}
+
+render_preview() {
+  local tmp input statusline sample cols="${1:-120}"
+  statusline=$(runtime_statusline)
+  sample=$(runtime_sample)
+  need_file "$statusline"
+  [ -n "$sample" ] && need_file "$sample"
+  tmp=$(mktemp "${TMPDIR:-/tmp}/coralline-config.XXXXXX") || exit 1
+  input=$(mktemp "${TMPDIR:-/tmp}/coralline-input.XXXXXX") || exit 1
+  write_candidate_config "$tmp"
+  jq --arg cwd "$SCRIPT_DIR" '.cwd = $cwd | .workspace.current_dir = $cwd' "$sample" > "$input" 2>/dev/null || cp "$sample" "$input"
+  printf '\nPreview (%s cols):\n' "$cols"
+  CORALLINE_CONFIG="$tmp" COLUMNS="$cols" bash "$statusline" < "$input"
+  rm -f "$tmp" "$input"
+}
+
+preview_current() {
+  render_preview "${1:-120}"
+}
+
+check_mark() {
+  if [ "$1" = "$2" ]; then printf '✓'; else printf ' '; fi
+}
+
+flag_mark() {
+  if [ "$1" = "1" ]; then printf '✓'; else printf ' '; fi
+}
+
+current_theme_index() {
+  local i=1 t
+  for t in $THEMES; do
+    if [ "$t" = "$theme" ]; then printf '%s\n' "$i"; return 0; fi
+    i=$((i + 1))
+  done
+  printf '1\n'
+}
+
+step_header() {
+  printf '\n────────────────────────────────────────\n'
+  printf '%s\n' "$1"
+  printf '────────────────────────────────────────\n'
+}
+
+show_current_state() {
+  printf 'Theme: %s · Style: %s · Layout: %s' "$theme" "$style" "$layout"
+  if [ "$layout" = "auto" ]; then printf ':%s' "$max_lines"; fi
+  printf ' · Clock: %s' "$clock_mode"
+  if [ "$clock_mode" != "off" ]; then
+    [ "$clock_seconds" = "1" ] && printf '+seconds' || printf '-seconds'
+  fi
+  [ "$ascii_mode" = "1" ] && printf ' · ASCII' || printf ' · Nerd Font'
+  printf '\n'
+}
+
+show_step() {
+  step_header "$1"
+  show_current_state
+  preview_current "${2:-120}"
+}
+
+draw_screen_header() {
+  local preview
+  preview=$(render_preview "${2:-120}")
+  clear_screen
+  printf 'coralline configure  ·  %s\n' "$1"
+  printf '↑/↓ move · Space toggle · Enter accept · q quit\n\n'
+  show_current_state
+  printf '%s\n\n' "$preview"
+  printf '\033[s'
+}
+
+theme_by_index() {
+  local want="$1" i=0 t
+  for t in $THEMES; do
+    [ "$i" = "$want" ] && { printf '%s\n' "$t"; return 0; }
+    i=$((i + 1))
+  done
+  printf '%s\n' "$theme"
+}
+
+choose_theme_screen() {
+  local selected key i t mark pointer
+  selected=$(( $(current_theme_index) - 1 ))
+  while :; do
+    theme=$(theme_by_index "$selected")
+    draw_screen_header "Theme" 120
+    i=0
+    for t in $THEMES; do
+      [ "$i" = "$selected" ] && pointer="❯" || pointer=" "
+      [ "$i" = "$selected" ] && mark="✓" || mark=" "
+      printf ' %s [%s] %s\n' "$pointer" "$mark" "$t"
+      i=$((i + 1))
+    done
+    clear_tail
+    key=$(read_key) || return 1
+    case "$key" in
+      up|down) selected=$(menu_move "$selected" "$key" 7) ;;
+      enter) theme=$(theme_by_index "$selected"); return 0 ;;
+      quit) leave_screen; exit 69 ;;
+    esac
+  done
+}
+
+choose_style_screen() {
+  local selected key pointer mark
+  [ "$style" = "lean" ] && selected=1 || selected=0
+  while :; do
+    [ "$selected" = "1" ] && style="lean" || style="pill"
+    draw_screen_header "Style" 120
+    [ "$selected" = "0" ] && pointer="❯" || pointer=" "
+    [ "$selected" = "0" ] && mark="✓" || mark=" "
+    printf ' %s [%s] pill\n' "$pointer" "$mark"
+    [ "$selected" = "1" ] && pointer="❯" || pointer=" "
+    [ "$selected" = "1" ] && mark="✓" || mark=" "
+    printf ' %s [%s] lean\n' "$pointer" "$mark"
+    clear_tail
+    key=$(read_key) || return 1
+    case "$key" in
+      up|down) selected=$(menu_move "$selected" "$key" 2) ;;
+      enter)
+        [ "$selected" = "1" ] && style="lean" || style="pill"
+        if [ "$style" = "lean" ]; then
+          leave_screen
+          lean_sep=$(ask "Lean separator, empty is okay" "$lean_sep")
+          enter_screen
+        else
+          lean_sep=""
+        fi
+        return 0 ;;
+      quit) leave_screen; exit 69 ;;
+    esac
+  done
+}
+
+choose_segments_screen() {
+  local selected=0 key count=15 dirty=1 reorder_index=14
+  while :; do
+    if [ "$dirty" = "1" ]; then
+      draw_screen_header "Segments" 120
+      dirty=0
+    fi
+    draw_segments_menu "$selected"
+    key=$(read_key) || return 1
+    case "$key" in
+      up|down) selected=$(menu_move "$selected" "$key" "$count") ;;
+      enter) return 0 ;;
+      space)
+        if [ "$selected" -lt 14 ]; then
+          local i=0 s
+          i=0
+          for s in $SEGMENT_CHOICES; do
+            if [ "$i" = "$selected" ]; then toggle_segment "$s"; break; fi
+            i=$((i + 1))
+          done
+          dirty=1
+        elif [ "$selected" = "$reorder_index" ]; then
+          leave_screen
+          local answer
+          answer=$(ask "Segments in order" "$segments")
+          [ -n "$answer" ] && segments="$answer"
+          enter_screen
+          dirty=1
+        fi ;;
+      quit) leave_screen; exit 69 ;;
+    esac
+  done
+}
+
+draw_segments_menu() {
+  local selected="$1" i=0 s enabled pointer reorder_index
+  redraw_menu_area
+  printf 'Segments: %s\n\n' "$segments"
+  for s in $SEGMENT_CHOICES; do
+    has_segment "$s" && enabled=1 || enabled=0
+    [ "$i" = "$selected" ] && pointer="❯" || pointer=" "
+    printf ' %s [%s] %s\n' "$pointer" "$(flag_mark "$enabled")" "$s"
+    i=$((i + 1))
+  done
+  reorder_index=$i
+  [ "$selected" = "$reorder_index" ] && pointer="❯" || pointer=" "
+  printf ' %s [ ] reorder\n' "$pointer"
+  printf '\nEnter done · Space toggle\n'
+  clear_tail
+}
+
+layout_selected_index() {
+  if [ "$layout" = "auto" ] && [ "$max_lines" -gt 1 ]; then printf '0\n'; return; fi
+  if [ "$layout" = "auto" ] && [ "$max_lines" -eq 1 ]; then printf '1\n'; return; fi
+  if [ "$layout" = "fixed" ] && [ -n "$segments2" ] && [ -z "$segments3" ]; then printf '2\n'; return; fi
+  printf '3\n'
+}
+
+apply_layout_index() {
+  case "$1" in
+    0) layout="auto"; max_lines=3; segments2=""; segments3="" ;;
+    1) layout="auto"; max_lines=1; segments2=""; segments3="" ;;
+    2) layout="fixed"; max_lines=3; segments="dir git model"; segments2="ctx limit5h limit7d cost clock"; segments3="" ;;
+    3) layout="fixed"; max_lines=3; segments="dir git model"; segments2="ctx limit5h limit7d"; segments3="cost clock" ;;
+  esac
+}
+
+choose_layout_screen() {
+  local selected key pointer mark
+  selected=$(layout_selected_index)
+  while :; do
+    apply_layout_index "$selected"
+    draw_screen_header "Layout" 80
+    printf '80-column preview\n\n'
+    [ "$selected" = "0" ] && pointer="❯" || pointer=" "; [ "$selected" = "0" ] && mark="✓" || mark=" "
+    printf ' %s [%s] responsive wrap\n' "$pointer" "$mark"
+    [ "$selected" = "1" ] && pointer="❯" || pointer=" "; [ "$selected" = "1" ] && mark="✓" || mark=" "
+    printf ' %s [%s] always single line\n' "$pointer" "$mark"
+    [ "$selected" = "2" ] && pointer="❯" || pointer=" "; [ "$selected" = "2" ] && mark="✓" || mark=" "
+    printf ' %s [%s] fixed two lines\n' "$pointer" "$mark"
+    [ "$selected" = "3" ] && pointer="❯" || pointer=" "; [ "$selected" = "3" ] && mark="✓" || mark=" "
+    printf ' %s [%s] fixed three lines\n' "$pointer" "$mark"
+    clear_tail
+    key=$(read_key) || return 1
+    case "$key" in
+      up|down) selected=$(menu_move "$selected" "$key" 4) ;;
+      enter) apply_layout_index "$selected"; return 0 ;;
+      quit) leave_screen; exit 69 ;;
+    esac
+  done
+}
+
+choose_details_screen() {
+  local selected=0 key count=6 dirty=1
+  while :; do
+    if [ "$dirty" = "1" ]; then
+      draw_screen_header "Details" 120
+      dirty=0
+    fi
+    draw_details_menu "$selected"
+    key=$(read_key) || return 1
+    case "$key" in
+      up|down) selected=$(menu_move "$selected" "$key" "$count") ;;
+      enter) return 0 ;;
+      space)
+        case "$selected" in
+          0) clock_mode="12h"; dirty=1 ;;
+          1) clock_mode="24h"; dirty=1 ;;
+          2) clock_mode="off"; dirty=1 ;;
+          3) [ "$clock_seconds" = "1" ] && clock_seconds=0 || clock_seconds=1; dirty=1 ;;
+          4) [ "$ascii_mode" = "1" ] && ascii_mode=0 || ascii_mode=1; dirty=1 ;;
+          5)
+            leave_screen
+            name_max=$(ask "Max chars for project/git names, 0 disables truncation" "$name_max")
+            case "$name_max" in ''|*[!0-9]*) name_max=0 ;; esac
+            enter_screen
+            dirty=1 ;;
+        esac ;;
+      quit) leave_screen; exit 69 ;;
+    esac
+  done
+}
+
+draw_details_menu() {
+  local selected="$1" pointer mark
+  redraw_menu_area
+  printf 'Details\n\n'
+  [ "$selected" = "0" ] && pointer="❯" || pointer=" "; [ "$clock_mode" = "12h" ] && mark="✓" || mark=" "
+  printf ' %s [%s] clock: 12h\n' "$pointer" "$mark"
+  [ "$selected" = "1" ] && pointer="❯" || pointer=" "; [ "$clock_mode" = "24h" ] && mark="✓" || mark=" "
+  printf ' %s [%s] clock: 24h\n' "$pointer" "$mark"
+  [ "$selected" = "2" ] && pointer="❯" || pointer=" "; [ "$clock_mode" = "off" ] && mark="✓" || mark=" "
+  printf ' %s [%s] clock: off\n' "$pointer" "$mark"
+  [ "$selected" = "3" ] && pointer="❯" || pointer=" "
+  printf ' %s [%s] seconds\n' "$pointer" "$(flag_mark "$clock_seconds")"
+  [ "$selected" = "4" ] && pointer="❯" || pointer=" "
+  [ "$ascii_mode" = "0" ] && mark="✓" || mark=" "
+  printf ' %s [%s] Nerd Font\n' "$pointer" "$mark"
+  [ "$selected" = "5" ] && pointer="❯" || pointer=" "
+  printf ' %s [ ] name max: %s\n' "$pointer" "$name_max"
+  printf '\nEnter done · Space toggle\n'
+  clear_tail
+}
+
+choose_theme() {
+  local i t answer
+  if [ -t 0 ] && [ -t 1 ]; then
+    choose_theme_screen
+    return 0
+  fi
+  while :; do
+    show_step "Theme" 120
+    printf '\nTheme\n'
+    i=1
+    for t in $THEMES; do
+      printf '  %s) [%s] %s\n' "$i" "$(check_mark "$theme" "$t")" "$t"
+      i=$((i + 1))
+    done
+    answer=$(ask "Theme number, Enter to keep" "$(current_theme_index)")
+    case "$answer" in
+      ''|*[!0-9]*) printf 'Choose a number from 1 to 7.\n' >&2 ;;
+      *) if [ "$answer" -ge 1 ] && [ "$answer" -le 7 ]; then
+           i=1
+           for t in $THEMES; do
+             if [ "$i" = "$answer" ]; then theme="$t"; break; fi
+             i=$((i + 1))
+           done
+           show_step "Theme selected" 120
+           return 0
+         fi
+         printf 'Choose a number from 1 to 7.\n' >&2 ;;
+    esac
+  done
+}
+
+choose_style() {
+  local answer
+  if [ -t 0 ] && [ -t 1 ]; then
+    choose_style_screen
+    return 0
+  fi
+  while :; do
+    show_step "Style" 120
+    printf '\nPick a style.\n'
+    printf '  1) [%s] pill\n' "$(check_mark "$style" "pill")"
+    printf '  2) [%s] lean\n' "$(check_mark "$style" "lean")"
+    answer=$(ask "Style number, Enter to keep" "$([ "$style" = "lean" ] && printf 2 || printf 1)")
+    case "$answer" in
+      1) style="pill"; lean_sep=""; show_step "Style selected" 120; return 0 ;;
+      2) style="lean"; lean_sep=$(ask "Lean separator, empty is okay" "$lean_sep"); show_step "Style selected" 120; return 0 ;;
+      *) printf 'Choose 1 or 2.\n' >&2 ;;
+    esac
+  done
+}
+
+has_segment() {
+  case " $segments " in *" $1 "*) return 0 ;; *) return 1 ;; esac
+}
+
+toggle_segment() {
+  local target="$1" s next=""
+  if has_segment "$target"; then
+    for s in $segments; do
+      [ "$s" = "$target" ] && continue
+      next="${next}${next:+ }$s"
+    done
+    segments="$next"
+  else
+    segments="${segments}${segments:+ }$target"
+  fi
+}
+
+choose_segments() {
+  local answer i s enabled
+  if [ -t 0 ] && [ -t 1 ]; then
+    choose_segments_screen
+    return 0
+  fi
+  while :; do
+    show_step "Segments" 120
+    printf '\nSegments: %s\n' "$segments"
+    i=1
+    for s in $SEGMENT_CHOICES; do
+      has_segment "$s" && enabled=1 || enabled=0
+      printf '  %2s) [%s] %s\n' "$i" "$(flag_mark "$enabled")" "$s"
+      i=$((i + 1))
+    done
+    printf '   r) reorder\n'
+    printf '   d) done\n'
+    answer=$(ask "Toggle number, r, or d" "d")
+    case "$answer" in
+      d|D|'') return 0 ;;
+      r|R)
+        answer=$(ask "Segments in order" "$segments")
+        [ -n "$answer" ] && segments="$answer" ;;
+      ''|*[!0-9]*) printf 'Choose a segment number, r, or d.\n' >&2 ;;
+      *)
+        i=1
+        for s in $SEGMENT_CHOICES; do
+          if [ "$i" = "$answer" ]; then toggle_segment "$s"; break; fi
+          i=$((i + 1))
+        done
+        if [ "$i" -gt 14 ]; then printf 'Choose a segment number from 1 to 14.\n' >&2; fi ;;
+    esac
+  done
+}
+
+choose_layout() {
+  local answer rows
+  if [ -t 0 ] && [ -t 1 ]; then
+    choose_layout_screen
+    return 0
+  fi
+  while :; do
+    show_step "Layout" 80
+    printf '\nLayout\n'
+    printf '  1) [%s] responsive wrap\n' "$([ "$layout" = "auto" ] && [ "$max_lines" -gt 1 ] && printf '✓' || printf ' ')"
+    printf '  2) [%s] always single line\n' "$([ "$layout" = "auto" ] && [ "$max_lines" -eq 1 ] && printf '✓' || printf ' ')"
+    printf '  3) [%s] fixed two lines\n' "$([ "$layout" = "fixed" ] && [ -n "$segments2" ] && [ -z "$segments3" ] && printf '✓' || printf ' ')"
+    printf '  4) [%s] fixed three lines\n' "$([ "$layout" = "fixed" ] && [ -n "$segments3" ] && printf '✓' || printf ' ')"
+    answer=$(ask "Layout number, Enter to keep" "1")
+    case "$answer" in
+      1)
+        layout="auto"
+        rows=$(ask_choice "Maximum rows" 3 3)
+        max_lines="$rows"
+        segments2=""
+        segments3=""
+        show_step "Layout selected" 80
+        return 0 ;;
+      2)
+        layout="auto"
+        max_lines=1
+        segments2=""
+        segments3=""
+        show_step "Layout selected" 80
+        return 0 ;;
+      3)
+        layout="fixed"
+        max_lines=3
+        segments=$(ask "Line 1 segments" "dir git model")
+        segments2=$(ask "Line 2 segments" "ctx limit5h limit7d cost clock")
+        segments3=""
+        show_step "Layout selected" 80
+        return 0 ;;
+      4)
+        layout="fixed"
+        max_lines=3
+        segments=$(ask "Line 1 segments" "dir git model")
+        segments2=$(ask "Line 2 segments" "ctx limit5h limit7d")
+        segments3=$(ask "Line 3 segments" "cost clock")
+        show_step "Layout selected" 80
+        return 0 ;;
+      *) printf 'Choose a layout number from 1 to 4.\n' >&2 ;;
+    esac
+  done
+}
+
+choose_details() {
+  local answer
+  if [ -t 0 ] && [ -t 1 ]; then
+    choose_details_screen
+    return 0
+  fi
+  while :; do
+    show_step "Details" 120
+    printf '\nToggle details.\n'
+    printf '  1) [%s] clock: 12h\n' "$(check_mark "$clock_mode" "12h")"
+    printf '  2) [%s] clock: 24h\n' "$(check_mark "$clock_mode" "24h")"
+    printf '  3) [%s] clock: off\n' "$(check_mark "$clock_mode" "off")"
+    printf '  4) [%s] show seconds\n' "$(flag_mark "$clock_seconds")"
+    printf '  5) [%s] Nerd Font\n' "$([ "$ascii_mode" = "0" ] && printf '✓' || printf ' ')"
+    printf '  6) name truncation: %s\n' "$name_max"
+    printf '  d) done\n'
+    answer=$(ask "Detail number or d" "d")
+    case "$answer" in
+      d|D|'') return 0 ;;
+      1) clock_mode="12h" ;;
+      2) clock_mode="24h" ;;
+      3) clock_mode="off" ;;
+      4) [ "$clock_seconds" = "1" ] && clock_seconds=0 || clock_seconds=1 ;;
+      5) [ "$ascii_mode" = "1" ] && ascii_mode=0 || ascii_mode=1 ;;
+      6)
+        name_max=$(ask "Max chars for project/git names, 0 disables truncation" "$name_max")
+        case "$name_max" in ''|*[!0-9]*) name_max=0 ;; esac ;;
+      *) printf 'Choose 1-6 or d.\n' >&2 ;;
+    esac
+  done
+}
+
+visual_wizard() {
+  if [ -t 0 ] && [ -t 1 ]; then
+    enter_screen
+  fi
+  choose_theme
+  choose_style
+  choose_segments
+  choose_layout
+  choose_details
+  leave_screen
+}
+
+write_final_config() {
+  local tmp
+  tmp=$(mktemp "${TMPDIR:-/tmp}/coralline-config.XXXXXX") || exit 1
+  write_candidate_config "$tmp"
+  if [ -f "$CONFIG_FILE" ]; then
+    printf '\nExisting config diff:\n'
+    diff -u "$CONFIG_FILE" "$tmp" || true
+    if ! yes_no "Overwrite $CONFIG_FILE" n; then
+      rm -f "$tmp"
+      printf 'Config unchanged.\n'
+      return 1
+    fi
+  fi
+  mkdir -p "$(dirname "$CONFIG_FILE")"
+  mv "$tmp" "$CONFIG_FILE"
+  printf 'Wrote %s\n' "$CONFIG_FILE"
+}
+
+install_files() {
+  local theme_dir
+  command -v jq >/dev/null 2>&1 || die "jq is required by coralline and by the installer"
+  need_file "$SCRIPT_DIR/statusline.sh"
+  need_file "$SCRIPT_DIR/test/sample-input.json"
+  [ -d "$SCRIPT_DIR/themes" ] || die "missing themes directory"
+
+  mkdir -p "$TARGET_DIR/themes"
+  cp "$SCRIPT_DIR/statusline.sh" "$TARGET_DIR/statusline.sh"
+  cp "$SCRIPT_DIR/configure.sh" "$TARGET_DIR/configure.sh"
+  cp "$SCRIPT_DIR/test/sample-input.json" "$TARGET_DIR/sample-input.json"
+  theme_dir="$SCRIPT_DIR/themes"
+  cp "$theme_dir"/*.conf "$TARGET_DIR/themes/"
+  chmod +x "$TARGET_DIR/statusline.sh" "$TARGET_DIR/configure.sh"
+  installed=1
+}
+
+update_settings() {
+  local tmp backup
+  command -v jq >/dev/null 2>&1 || die "jq is required to merge Claude settings"
+  mkdir -p "$(dirname "$SETTINGS_FILE")"
+  tmp=$(mktemp "${TMPDIR:-/tmp}/coralline-settings.XXXXXX") || exit 1
+  if [ -f "$SETTINGS_FILE" ]; then
+    backup="$SETTINGS_FILE.bak.$(date +%Y%m%d%H%M%S)"
+    cp "$SETTINGS_FILE" "$backup"
+    jq --arg command "bash $TARGET_DIR/statusline.sh" '.statusLine = {
+      "type": "command",
+      "command": $command,
+      "refreshInterval": 1
+    }' "$SETTINGS_FILE" > "$tmp"
+  else
+    cat > "$tmp" <<EOF
+{
+  "statusLine": {
+    "type": "command",
+    "command": "bash $TARGET_DIR/statusline.sh",
+    "refreshInterval": 1
+  }
+}
+EOF
+  fi
+  mv "$tmp" "$SETTINGS_FILE"
+  printf 'Updated %s\n' "$SETTINGS_FILE"
+}
+
+verify_render() {
+  local statusline sample
+  statusline=$(runtime_statusline)
+  sample=$(runtime_sample)
+  printf '\nVerification render:\n'
+  CORALLINE_CONFIG="$CONFIG_FILE" COLUMNS=120 bash "$statusline" < "$sample"
+}
+
+main_menu_screen() {
+  local selected=0 key count drawn=0
+  [ -f "$P10K_FILE" ] && count=3 || count=2
+  while :; do
+    if [ "$drawn" = "0" ]; then
+      draw_screen_header "Setup mode" 120
+      drawn=1
+    fi
+    draw_main_menu "$selected"
+    key=$(read_key) || return 1
+    case "$key" in
+      up|down) selected=$(menu_move "$selected" "$key" "$count") ;;
+      enter)
+        leave_screen
+        if [ -f "$P10K_FILE" ]; then
+          case "$selected" in
+            0) preview_current 120 ;;
+            1) import_p10k; preview_current 120 ;;
+            2) visual_wizard ;;
+          esac
+        else
+          case "$selected" in
+            0) preview_current 120 ;;
+            1) visual_wizard ;;
+          esac
+        fi
+        return 0 ;;
+      quit) leave_screen; exit 69 ;;
+    esac
+  done
+}
+
+draw_main_menu() {
+  local selected="$1" pointer mark
+  redraw_menu_area
+  printf 'Setup\n\n'
+  [ "$selected" = "0" ] && pointer="❯" || pointer=" "
+  [ "$selected" = "0" ] && mark="✓" || mark=" "
+  printf ' %s [%s] Default\n' "$pointer" "$mark"
+  if [ -f "$P10K_FILE" ]; then
+    [ "$selected" = "1" ] && pointer="❯" || pointer=" "
+    [ "$selected" = "1" ] && mark="✓" || mark=" "
+    printf ' %s [%s] Import p10k\n' "$pointer" "$mark"
+    [ "$selected" = "2" ] && pointer="❯" || pointer=" "
+    [ "$selected" = "2" ] && mark="✓" || mark=" "
+    printf ' %s [%s] Wizard\n' "$pointer" "$mark"
+  else
+    [ "$selected" = "1" ] && pointer="❯" || pointer=" "
+    [ "$selected" = "1" ] && mark="✓" || mark=" "
+    printf ' %s [%s] Wizard\n' "$pointer" "$mark"
+  fi
+  clear_tail
+}
+
+main_menu() {
+  local answer max default_choice
+  if [ -t 0 ] && [ -t 1 ]; then
+    enter_screen
+    main_menu_screen
+    return 0
+  fi
+  printf 'coralline visual setup\n'
+  printf '\nChoose how to create your theme config:\n'
+  printf '  1) Use the coralline default\n'
+  if [ -f "$P10K_FILE" ]; then
+    printf '  2) Import local .p10k.zsh colors\n'
+    printf '  3) Visual wizard\n'
+    max=3
+    default_choice=2
+  else
+    printf '  2) Visual wizard\n'
+    max=2
+    default_choice=2
+  fi
+  answer=$(ask_choice "Mode" "$max" "$default_choice")
+  if [ -f "$P10K_FILE" ]; then
+    case "$answer" in
+      1) preview_current 120 ;;
+      2) import_p10k; preview_current 120 ;;
+      3) visual_wizard ;;
+    esac
+  else
+    case "$answer" in
+      1) preview_current 120 ;;
+      2) visual_wizard ;;
+    esac
+  fi
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --install) install_files; update_settings ;;
+    --help|-h) usage; exit 0 ;;
+    *) usage; exit 1 ;;
+  esac
+done
+
+trap 'leave_screen' EXIT
+trap 'leave_screen; exit 130' INT TERM
+
+main_menu
+write_final_config || exit 0
+verify_render
+printf '\nDone. Restart Claude Code or open a new session to see coralline.\n'

--- a/configure.sh
+++ b/configure.sh
@@ -13,7 +13,6 @@ CONFIG_FILE="${CORALLINE_CONFIG:-$HOME/.claude/coralline.conf}"
 SETTINGS_FILE="${CLAUDE_SETTINGS:-$HOME/.claude/settings.json}"
 P10K_FILE="${P10K_CONFIG:-$HOME/.p10k.zsh}"
 
-THEMES="claude-coral catppuccin-mocha nord gruvbox-dark tokyo-night dracula mono"
 SEGMENT_CHOICES="dir project git model ctx limit5h limit7d cost clock lines style duration effort stash"
 DEFAULT_SEGMENTS="dir git model ctx limit5h limit7d cost clock"
 
@@ -81,6 +80,17 @@ runtime_theme_dir() {
   else
     printf '%s\n' "$TARGET_DIR/themes"
   fi
+}
+
+theme_list() {
+  local dir
+  dir=$(runtime_theme_dir)
+  [ -d "$dir" ] || return 0
+  (cd "$dir" && find . -type f -name '*.conf' | sed 's#^\./##; s#\.conf$##' | sort)
+}
+
+theme_count() {
+  theme_list | wc -l | tr -d ' '
 }
 
 runtime_sample() {
@@ -334,10 +344,13 @@ flag_mark() {
 
 current_theme_index() {
   local i=1 t
-  for t in $THEMES; do
+  while IFS= read -r t; do
+    [ -n "$t" ] || continue
     if [ "$t" = "$theme" ]; then printf '%s\n' "$i"; return 0; fi
     i=$((i + 1))
-  done
+  done <<THEMES
+$(theme_list)
+THEMES
   printf '1\n'
 }
 
@@ -377,21 +390,36 @@ draw_screen_header() {
 
 theme_by_index() {
   local want="$1" i=0 t
-  for t in $THEMES; do
+  while IFS= read -r t; do
+    [ -n "$t" ] || continue
     [ "$i" = "$want" ] && { printf '%s\n' "$t"; return 0; }
     i=$((i + 1))
-  done
+  done <<THEMES
+$(theme_list)
+THEMES
   printf '%s\n' "$theme"
 }
 
 choose_theme_screen() {
-  local selected key i t mark pointer
+  local selected key i t mark pointer count win=14 start end
+  count=$(theme_count)
+  [ "$count" -gt 0 ] 2>/dev/null || die "no themes found in $(runtime_theme_dir)"
   selected=$(( $(current_theme_index) - 1 ))
   while :; do
     theme=$(theme_by_index "$selected")
     draw_screen_header "Theme" 120
-    i=0
-    for t in $THEMES; do
+    printf 'Theme %s/%s\n\n' "$((selected + 1))" "$count"
+    start=$((selected - win / 2))
+    [ "$start" -lt 0 ] && start=0
+    end=$((start + win))
+    if [ "$end" -gt "$count" ]; then
+      end="$count"
+      start=$((end - win))
+      [ "$start" -lt 0 ] && start=0
+    fi
+    i="$start"
+    while [ "$i" -lt "$end" ]; do
+      t=$(theme_by_index "$i")
       [ "$i" = "$selected" ] && pointer="❯" || pointer=" "
       [ "$i" = "$selected" ] && mark="✓" || mark=" "
       printf ' %s [%s] %s\n' "$pointer" "$mark" "$t"
@@ -400,7 +428,7 @@ choose_theme_screen() {
     clear_tail
     key=$(read_key) || return 1
     case "$key" in
-      up|down) selected=$(menu_move "$selected" "$key" 7) ;;
+      up|down) selected=$(menu_move "$selected" "$key" "$count") ;;
       enter) theme=$(theme_by_index "$selected"); return 0 ;;
       quit) leave_screen; exit 69 ;;
     esac
@@ -583,7 +611,9 @@ draw_details_menu() {
 }
 
 choose_theme() {
-  local i t answer
+  local i t answer count
+  count=$(theme_count)
+  [ "$count" -gt 0 ] 2>/dev/null || die "no themes found in $(runtime_theme_dir)"
   if [ -t 0 ] && [ -t 1 ]; then
     choose_theme_screen
     return 0
@@ -592,23 +622,29 @@ choose_theme() {
     show_step "Theme" 120
     printf '\nTheme\n'
     i=1
-    for t in $THEMES; do
+    while IFS= read -r t; do
+      [ -n "$t" ] || continue
       printf '  %s) [%s] %s\n' "$i" "$(check_mark "$theme" "$t")" "$t"
       i=$((i + 1))
-    done
+    done <<THEMES
+$(theme_list)
+THEMES
     answer=$(ask "Theme number, Enter to keep" "$(current_theme_index)")
     case "$answer" in
-      ''|*[!0-9]*) printf 'Choose a number from 1 to 7.\n' >&2 ;;
-      *) if [ "$answer" -ge 1 ] && [ "$answer" -le 7 ]; then
+      ''|*[!0-9]*) printf 'Choose a number from 1 to %s.\n' "$count" >&2 ;;
+      *) if [ "$answer" -ge 1 ] && [ "$answer" -le "$count" ]; then
            i=1
-           for t in $THEMES; do
+           while IFS= read -r t; do
+             [ -n "$t" ] || continue
              if [ "$i" = "$answer" ]; then theme="$t"; break; fi
              i=$((i + 1))
-           done
+           done <<THEMES
+$(theme_list)
+THEMES
            show_step "Theme selected" 120
            return 0
          fi
-         printf 'Choose a number from 1 to 7.\n' >&2 ;;
+         printf 'Choose a number from 1 to %s.\n' "$count" >&2 ;;
     esac
   done
 }
@@ -799,7 +835,7 @@ write_final_config() {
 }
 
 install_files() {
-  local theme_dir
+  local theme_dir rel
   command -v jq >/dev/null 2>&1 || die "jq is required by coralline and by the installer"
   need_file "$SCRIPT_DIR/statusline.sh"
   need_file "$SCRIPT_DIR/test/sample-input.json"
@@ -810,7 +846,13 @@ install_files() {
   cp "$SCRIPT_DIR/configure.sh" "$TARGET_DIR/configure.sh"
   cp "$SCRIPT_DIR/test/sample-input.json" "$TARGET_DIR/sample-input.json"
   theme_dir="$SCRIPT_DIR/themes"
-  cp "$theme_dir"/*.conf "$TARGET_DIR/themes/"
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    mkdir -p "$TARGET_DIR/themes/$(dirname "$rel")"
+    cp "$theme_dir/$rel" "$TARGET_DIR/themes/$rel"
+  done <<THEMES
+$(cd "$theme_dir" && find . -type f -name '*.conf' | sed 's#^\./##')
+THEMES
   chmod +x "$TARGET_DIR/statusline.sh" "$TARGET_DIR/configure.sh"
   installed=1
 }

--- a/configure.sh
+++ b/configure.sh
@@ -15,7 +15,7 @@ P10K_FILE="${P10K_CONFIG:-$HOME/.p10k.zsh}"
 
 # Fallback list, used only when the runtime statusline cannot be scanned.
 # The live list is derived from statusline.sh's seg_* functions by load_segment_choices.
-SEGMENT_CHOICES="dir project git model ctx limit5h limit7d cost clock lines style duration effort stash"
+SEGMENT_CHOICES="dir project git model effort ctx limit5h limit7d lines cost style duration stash clock"
 DEFAULT_SEGMENTS="dir git model ctx limit5h limit7d cost clock"
 THEME_CHOICES=""
 theme_choices_loaded=0
@@ -38,6 +38,9 @@ install_only=0
 setup_mode=""
 screen_active=0
 old_stty=""
+resized=0          # set by the SIGWINCH trap; consumed by read_key
+KEY=""             # read_key writes the decoded key here (avoids a $() subshell)
+last_size=""       # last seen "rows cols" — polled so resize is caught reliably
 preview_input_file=""
 preview_cache_dir=""
 
@@ -115,8 +118,6 @@ load_theme_choices() {
   [ -d "$dir" ] || return 0
   THEME_CHOICES=$(cd "$dir" && find . -type f -name '*.conf' | sed 's#^\./##; s#\.conf$##' | sort; printf x)
   THEME_CHOICES=${THEME_CHOICES%x}
-  [ -n "$THEME_CHOICES" ] && THEME_CHOICES="${THEME_CHOICES}
-"
   theme_choices_loaded=1
 }
 
@@ -127,15 +128,20 @@ theme_count() {
 # Derive the segment menu from the runtime's seg_* functions so a new segment in
 # statusline.sh shows up here automatically — mirrors the theme auto-scan above.
 load_segment_choices() {
-  local statusline names
+  local statusline discovered s ordered=""
   statusline=$(runtime_statusline)
   [ -f "$statusline" ] || return 0
-  names=$(grep -oE '^seg_[A-Za-z0-9_]+' "$statusline" \
-    | sed 's/^seg_//' \
-    | grep -Ev '^(len|limit)$' \
-    | tr '\n' ' ')
-  names="${names% }"
-  [ -n "$names" ] && SEGMENT_CHOICES="$names"
+  discovered=" $(grep -oE '^seg_[A-Za-z0-9_]+' "$statusline" \
+    | sed 's/^seg_//' | grep -Ev '^(len|limit)$' | tr '\n' ' ') "
+  [ "$discovered" = "  " ] && return 0
+  # Show segments in the canonical SEGMENT_CHOICES order (keeping only the ones
+  # that still exist), then append any newly added segments not listed there, so
+  # a new seg_* in statusline.sh still shows up automatically.
+  for s in $SEGMENT_CHOICES; do
+    case "$discovered" in *" $s "*) ordered="${ordered}${ordered:+ }$s"; discovered="${discovered/ $s / }" ;; esac
+  done
+  for s in $discovered; do ordered="${ordered}${ordered:+ }$s"; done
+  SEGMENT_CHOICES="$ordered"
 }
 
 segment_total() {
@@ -278,25 +284,38 @@ redraw_menu_area() {
   printf '\033[u'
 }
 
-read_key() {
-  local k k2 k3
-  IFS= read -rsn1 k || return 1
+read_key() {  # sets global KEY; returns 1 on EOF. Polls with a 1s timeout so a
+              # window resize is always caught — even when SIGWINCH does not
+              # interrupt the blocking read — by comparing the terminal size.
+  local k k2 k3 now rc
+  while :; do
+    IFS= read -rsn1 -t 1 k; rc=$?
+    [ "$rc" = 0 ] && break        # got a key
+    [ "$rc" = 1 ] && return 1      # EOF
+    # timeout or signal: detect resize via the trap flag or a size change
+    if [ "$resized" = "1" ]; then resized=0; KEY="resize"; return 0; fi
+    now=$(stty size 2>/dev/null || true)
+    if [ -n "$now" ] && [ -n "$last_size" ] && [ "$now" != "$last_size" ]; then
+      last_size="$now"; KEY="resize"; return 0
+    fi
+    [ -n "$now" ] && last_size="$now"
+  done
   if [ "$k" = $'\033' ]; then
     IFS= read -rsn1 -t 1 k2 2>/dev/null || k2=""
     IFS= read -rsn1 -t 1 k3 2>/dev/null || k3=""
     k="$k$k2$k3"
   fi
   case "$k" in
-    $'\033[A') printf 'up\n' ;;
-    $'\033[B') printf 'down\n' ;;
-    $'\033[C') printf 'right\n' ;;
-    $'\033[D') printf 'left\n' ;;
-    '') printf 'enter\n' ;;
-    ' ') printf 'space\n' ;;
-    q|Q) printf 'quit\n' ;;
-    k|K) printf 'up\n' ;;
-    j|J) printf 'down\n' ;;
-    *) printf '%s\n' "$k" ;;
+    $'\033[A') KEY=up ;;
+    $'\033[B') KEY=down ;;
+    $'\033[C') KEY=right ;;
+    $'\033[D') KEY=left ;;
+    '') KEY=enter ;;
+    ' ') KEY=space ;;
+    q|Q) KEY=quit ;;
+    k|K) KEY=up ;;
+    j|J) KEY=down ;;
+    *) KEY="$k" ;;
   esac
 }
 
@@ -441,7 +460,10 @@ write_candidate_config() {
 }
 
 render_preview() {
-  local tmp input statusline cache cols="${1:-120}"
+  local tmp input statusline cache cols="${1:-120}" sz
+  # Cap the preview to the real terminal width so it never wraps on a narrow window.
+  sz=$(stty size 2>/dev/null || true)
+  if [ -n "$sz" ]; then set -- $sz; [ -n "${2:-}" ] && [ "$2" -gt 0 ] 2>/dev/null && [ "$cols" -gt "$2" ] && cols="$2"; fi
   statusline=$(runtime_statusline)
   need_file "$statusline"
   tmp=$(mktemp "${TMPDIR:-/tmp}/coralline-config.XXXXXX") || exit 1
@@ -497,7 +519,7 @@ show_current_state() {
   if [ "$layout" = "auto" ]; then printf ':%s' "$max_lines"; fi
   printf ' · %sClock%s: %s' "$T_DIM" "$T_RESET" "$clock_mode"
   if [ "$clock_mode" != "off" ]; then
-    [ "$clock_seconds" = "1" ] && printf '+seconds' || printf '-seconds'
+    [ "$clock_seconds" = "1" ] && printf '%s' '+seconds' || printf '%s' '-seconds'
   fi
   [ "$ascii_mode" = "1" ] && printf ' · %sASCII%s' "$T_WARN" "$T_RESET" || printf ' · %sNerd Font%s' "$T_GREEN" "$T_RESET"
   printf '\n'
@@ -547,7 +569,7 @@ theme_by_index() {
   done <<THEMES
 $(theme_list)
 THEMES
-  printf '%s\n' "$theme"
+  return 1
 }
 
 choose_theme_screen() {
@@ -576,7 +598,7 @@ choose_theme_screen() {
     done
     draw_screen_footer
     clear_tail
-    key=$(read_key) || return 1
+    read_key || return 1; key="$KEY"
     case "$key" in
       up|down) selected=$(menu_move "$selected" "$key" "$count") ;;
       enter) theme=$(theme_by_index "$selected"); return 0 ;;
@@ -597,7 +619,7 @@ choose_style_screen() {
     [ "$selected" = "1" ] && draw_option 1 "$mark" "lean" || draw_option 0 "$mark" "lean"
     draw_screen_footer
     clear_tail
-    key=$(read_key) || return 1
+    read_key || return 1; key="$KEY"
     case "$key" in
       up|down) selected=$(menu_move "$selected" "$key" 2) ;;
       enter)
@@ -626,9 +648,10 @@ choose_segments_screen() {
       dirty=0
     fi
     draw_segments_menu "$selected"
-    key=$(read_key) || return 1
+    read_key || return 1; key="$KEY"
     case "$key" in
       up|down) selected=$(menu_move "$selected" "$key" "$count") ;;
+      resize) dirty=1 ;;
       enter) return 0 ;;
       space)
         if [ "$selected" -lt "$seg_n" ]; then
@@ -674,12 +697,32 @@ layout_selected_index() {
   printf '3\n'
 }
 
+split_segments() {  # $1=lines (2 or 3), $2=full list — distributes evenly into segments/segments2/segments3
+  local n="$1" all="$2" total per i=0 line=1 s
+  set -- $all; total=$#
+  segments=""; segments2=""; segments3=""
+  per=$(( (total + n - 1) / n )); [ "$per" -lt 1 ] && per=1
+  for s in $all; do
+    case "$line" in
+      1) segments="${segments}${segments:+ }$s" ;;
+      2) segments2="${segments2}${segments2:+ }$s" ;;
+      3) segments3="${segments3}${segments3:+ }$s" ;;
+    esac
+    i=$((i + 1))
+    if [ "$i" -ge "$per" ] && [ "$line" -lt "$n" ]; then line=$((line + 1)); i=0; fi
+  done
+}
+
 apply_layout_index() {
+  # Always recombine first so switching layouts (or navigating past them in the
+  # menu) never drops segments that were parked on line 2/3.
+  local all
+  all=$(normalize_segments "$segments $segments2 $segments3")
   case "$1" in
-    0) layout="auto"; max_lines=3; segments2=""; segments3="" ;;
-    1) layout="auto"; max_lines=1; segments2=""; segments3="" ;;
-    2) layout="fixed"; max_lines=3; segments="dir git model"; segments2="ctx limit5h limit7d cost clock"; segments3="" ;;
-    3) layout="fixed"; max_lines=3; segments="dir git model"; segments2="ctx limit5h limit7d"; segments3="cost clock" ;;
+    0) layout="auto";  max_lines=3; segments="$all"; segments2=""; segments3="" ;;
+    1) layout="auto";  max_lines=1; segments="$all"; segments2=""; segments3="" ;;
+    2) layout="fixed"; max_lines=3; split_segments 2 "$all" ;;
+    3) layout="fixed"; max_lines=3; split_segments 3 "$all" ;;
   esac
 }
 
@@ -700,7 +743,7 @@ choose_layout_screen() {
     [ "$selected" = "3" ] && draw_option 1 "$mark" "fixed three lines" || draw_option 0 "$mark" "fixed three lines"
     draw_screen_footer
     clear_tail
-    key=$(read_key) || return 1
+    read_key || return 1; key="$KEY"
     case "$key" in
       up|down) selected=$(menu_move "$selected" "$key" 4) ;;
       enter) apply_layout_index "$selected"; return 0 ;;
@@ -717,9 +760,10 @@ choose_details_screen() {
       dirty=0
     fi
     draw_details_menu "$selected"
-    key=$(read_key) || return 1
+    read_key || return 1; key="$KEY"
     case "$key" in
       up|down) selected=$(menu_move "$selected" "$key" "$count") ;;
+      resize) dirty=1 ;;
       enter) return 0 ;;
       space)
         case "$selected" in
@@ -729,6 +773,8 @@ choose_details_screen() {
           3) [ "$clock_seconds" = "1" ] && clock_seconds=0 || clock_seconds=1; dirty=1 ;;
           4) [ "$ascii_mode" = "1" ] && ascii_mode=0 || ascii_mode=1; dirty=1 ;;
           5)
+            # Drop to cooked mode for the prompt so the cursor, echo and backspace
+            # all work normally (an in-TUI digit editor has no visible cursor).
             leave_screen
             name_max=$(ask "Max chars for project/git names, 0 disables truncation" "$name_max")
             case "$name_max" in ''|*[!0-9]*) name_max=0 ;; esac
@@ -754,7 +800,8 @@ draw_details_menu() {
   [ "$selected" = "3" ] && draw_option 1 "$mark" "seconds" || draw_option 0 "$mark" "seconds"
   [ "$ascii_mode" = "0" ] && mark="✓" || mark=" "
   [ "$selected" = "4" ] && draw_option 1 "$mark" "Nerd Font" || draw_option 0 "$mark" "Nerd Font"
-  [ "$selected" = "5" ] && draw_option 1 " " "name max: $name_max" || draw_option 0 " " "name max: $name_max"
+  [ "$name_max" != "0" ] && mark="✓" || mark=" "
+  [ "$selected" = "5" ] && draw_option 1 "$mark" "name max (0=off): $name_max" || draw_option 0 "$mark" "name max (0=off): $name_max"
   draw_screen_footer toggle
   clear_tail
 }
@@ -831,7 +878,12 @@ toggle_segment() {
     done
     segments="$next"
   else
-    segments="${segments}${segments:+ }$target"
+    # Re-emit in the canonical SEGMENT_CHOICES order so a newly enabled segment
+    # lands in its defined position instead of being appended in toggle order.
+    for s in $SEGMENT_CHOICES; do
+      { has_segment "$s" || [ "$s" = "$target" ]; } && next="${next}${next:+ }$s"
+    done
+    segments="$next"
   fi
 }
 
@@ -889,6 +941,7 @@ choose_layout() {
         layout="auto"
         rows=$(ask_choice "Maximum rows" 3 3)
         max_lines="$rows"
+        segments=$(normalize_segments "$segments $segments2 $segments3")
         segments2=""
         segments3=""
         show_step "Layout selected" 80
@@ -896,6 +949,7 @@ choose_layout() {
       2)
         layout="auto"
         max_lines=1
+        segments=$(normalize_segments "$segments $segments2 $segments3")
         segments2=""
         segments3=""
         show_step "Layout selected" 80
@@ -1062,9 +1116,10 @@ main_menu_screen() {
       drawn=1
     fi
     draw_main_menu "$selected"
-    key=$(read_key) || return 1
+    read_key || return 1; key="$KEY"
     case "$key" in
       up|down) selected=$(menu_move "$selected" "$key" "$count") ;;
+      resize) drawn=0 ;;
       enter)
         leave_screen
         if [ -f "$P10K_FILE" ]; then
@@ -1170,6 +1225,7 @@ done
 
 trap 'cleanup' EXIT
 trap 'cleanup; exit 130' INT TERM
+trap 'resized=1' WINCH
 
 [ "$install_only" = "1" ] && exit 0
 

--- a/configure.sh
+++ b/configure.sh
@@ -887,11 +887,11 @@ draw_main_menu() {
     printf ' %s [%s] Import p10k\n' "$pointer" "$mark"
     [ "$selected" = "2" ] && pointer="❯" || pointer=" "
     [ "$selected" = "2" ] && mark="✓" || mark=" "
-    printf ' %s [%s] Wizard\n' "$pointer" "$mark"
+    printf ' %s [%s] Configure Wizard\n' "$pointer" "$mark"
   else
     [ "$selected" = "1" ] && pointer="❯" || pointer=" "
     [ "$selected" = "1" ] && mark="✓" || mark=" "
-    printf ' %s [%s] Wizard\n' "$pointer" "$mark"
+    printf ' %s [%s] Configure Wizard\n' "$pointer" "$mark"
   fi
   clear_tail
 }

--- a/configure.sh
+++ b/configure.sh
@@ -354,7 +354,11 @@ render_preview() {
   tmp=$(mktemp "${TMPDIR:-/tmp}/coralline-config.XXXXXX") || exit 1
   input=$(mktemp "${TMPDIR:-/tmp}/coralline-input.XXXXXX") || exit 1
   write_candidate_config "$tmp"
-  jq --arg cwd "$SCRIPT_DIR" '.cwd = $cwd | .workspace.current_dir = $cwd' "$sample" > "$input" 2>/dev/null || cp "$sample" "$input"
+  if [ -n "$sample" ]; then
+    jq --arg cwd "$SCRIPT_DIR" '.cwd = $cwd | .workspace.current_dir = $cwd' "$sample" > "$input" 2>/dev/null || cp "$sample" "$input"
+  else
+    jq -n --arg cwd "$SCRIPT_DIR" '{cwd: $cwd, workspace: {current_dir: $cwd}}' > "$input"
+  fi
   printf '\nPreview (%s cols):\n' "$cols"
   CORALLINE_CONFIG="$tmp" COLUMNS="$cols" bash "$statusline" < "$input"
   rm -f "$tmp" "$input"
@@ -915,11 +919,14 @@ update_settings() {
   if [ -f "$SETTINGS_FILE" ]; then
     backup="$SETTINGS_FILE.bak.$(date +%Y%m%d%H%M%S)"
     cp "$SETTINGS_FILE" "$backup"
-    jq --arg command "bash $TARGET_DIR/statusline.sh" '.statusLine = {
+    if ! jq --arg command "bash $TARGET_DIR/statusline.sh" '.statusLine = {
       "type": "command",
       "command": $command,
       "refreshInterval": 1
-    }' "$SETTINGS_FILE" > "$tmp"
+    }' "$SETTINGS_FILE" > "$tmp"; then
+      rm -f "$tmp"
+      die "failed to parse $SETTINGS_FILE; original left unchanged, backup written to $backup"
+    fi
   else
     cat > "$tmp" <<EOF
 {
@@ -936,11 +943,19 @@ EOF
 }
 
 verify_render() {
-  local statusline sample
+  local statusline sample input
   statusline=$(runtime_statusline)
   sample=$(runtime_sample)
   printf '\nVerification render:\n'
-  CORALLINE_CONFIG="$CONFIG_FILE" COLUMNS=120 bash "$statusline" < "$sample"
+  if [ -n "$sample" ]; then
+    need_file "$sample"
+    CORALLINE_CONFIG="$CONFIG_FILE" COLUMNS=120 bash "$statusline" < "$sample"
+  else
+    input=$(mktemp "${TMPDIR:-/tmp}/coralline-input.XXXXXX") || exit 1
+    jq -n --arg cwd "$SCRIPT_DIR" '{cwd: $cwd, workspace: {current_dir: $cwd}}' > "$input"
+    CORALLINE_CONFIG="$CONFIG_FILE" COLUMNS=120 bash "$statusline" < "$input"
+    rm -f "$input"
+  fi
 }
 
 main_menu_screen() {

--- a/configure.sh
+++ b/configure.sh
@@ -946,3 +946,4 @@ main_menu
 write_final_config || exit 0
 verify_render
 printf '\nDone. Restart Claude Code or open a new session to see coralline.\n'
+printf 'Reconfigure anytime with:\n  bash %s/configure.sh\n' "$TARGET_DIR"

--- a/configure.sh
+++ b/configure.sh
@@ -35,6 +35,15 @@ setup_mode=""
 screen_active=0
 old_stty=""
 
+T_RESET=$(printf '\033[0m')
+T_BOLD=$(printf '\033[1m')
+T_DIM=$(printf '\033[2m')
+T_BLUE=$(printf '\033[38;5;81m')
+T_GREEN=$(printf '\033[38;5;114m')
+T_MAUVE=$(printf '\033[38;5;183m')
+T_CORAL=$(printf '\033[38;5;173m')
+T_WARN=$(printf '\033[38;5;179m')
+
 usage() {
   cat <<'EOF'
 coralline configure
@@ -361,13 +370,16 @@ step_header() {
 }
 
 show_current_state() {
-  printf 'Theme: %s · Style: %s · Layout: %s' "$theme" "$style" "$layout"
+  printf '%sTheme%s: %s%s%s · %sStyle%s: %s%s%s · %sLayout%s: %s' \
+    "$T_DIM" "$T_RESET" "$T_BOLD" "$theme" "$T_RESET" \
+    "$T_DIM" "$T_RESET" "$T_BOLD" "$style" "$T_RESET" \
+    "$T_DIM" "$T_RESET" "$layout"
   if [ "$layout" = "auto" ]; then printf ':%s' "$max_lines"; fi
-  printf ' · Clock: %s' "$clock_mode"
+  printf ' · %sClock%s: %s' "$T_DIM" "$T_RESET" "$clock_mode"
   if [ "$clock_mode" != "off" ]; then
     [ "$clock_seconds" = "1" ] && printf '+seconds' || printf '-seconds'
   fi
-  [ "$ascii_mode" = "1" ] && printf ' · ASCII' || printf ' · Nerd Font'
+  [ "$ascii_mode" = "1" ] && printf ' · %sASCII%s' "$T_WARN" "$T_RESET" || printf ' · %sNerd Font%s' "$T_GREEN" "$T_RESET"
   printf '\n'
 }
 
@@ -381,11 +393,29 @@ draw_screen_header() {
   local preview
   preview=$(render_preview "${2:-120}")
   clear_screen
-  printf 'coralline configure  ·  %s\n' "$1"
-  printf '↑/↓ move · Space toggle · Enter accept · q quit\n\n'
+  printf '%s%s%s %s·%s %s%s%s\n\n' "$T_BOLD" "$T_CORAL" "coralline configure" "$T_DIM" "$T_RESET" "$T_BOLD" "$1" "$T_RESET"
   show_current_state
-  printf '%s\n\n' "$preview"
+  printf '\n%s\n\n' "$preview"
   printf '\033[s'
+}
+
+draw_screen_footer() {
+  if [ "${1:-}" = "toggle" ]; then
+    printf '\n%s↑/↓%s move · %sSpace%s toggle · %sEnter%s accept · %sq%s quit%s\n' \
+      "$T_BLUE" "$T_RESET" "$T_BLUE" "$T_RESET" "$T_GREEN" "$T_RESET" "$T_CORAL" "$T_RESET" "$T_RESET"
+  else
+    printf '\n%s↑/↓%s move · %sEnter%s accept · %sq%s quit%s\n' \
+      "$T_BLUE" "$T_RESET" "$T_GREEN" "$T_RESET" "$T_CORAL" "$T_RESET" "$T_RESET"
+  fi
+}
+
+draw_option() {
+  local selected="$1" mark="$2" label="$3"
+  if [ "$selected" = "1" ]; then
+    printf ' %s❯%s %s[%s]%s %s%s%s\n' "$T_CORAL" "$T_RESET" "$T_GREEN" "$mark" "$T_RESET" "$T_BOLD" "$label" "$T_RESET"
+  else
+    printf '   %s[%s]%s %s\n' "$T_DIM" "$mark" "$T_RESET" "$label"
+  fi
 }
 
 theme_by_index() {
@@ -420,11 +450,11 @@ choose_theme_screen() {
     i="$start"
     while [ "$i" -lt "$end" ]; do
       t=$(theme_by_index "$i")
-      [ "$i" = "$selected" ] && pointer="❯" || pointer=" "
       [ "$i" = "$selected" ] && mark="✓" || mark=" "
-      printf ' %s [%s] %s\n' "$pointer" "$mark" "$t"
+      [ "$i" = "$selected" ] && draw_option 1 "$mark" "$t" || draw_option 0 "$mark" "$t"
       i=$((i + 1))
     done
+    draw_screen_footer
     clear_tail
     key=$(read_key) || return 1
     case "$key" in
@@ -441,12 +471,11 @@ choose_style_screen() {
   while :; do
     [ "$selected" = "1" ] && style="lean" || style="pill"
     draw_screen_header "Style" 120
-    [ "$selected" = "0" ] && pointer="❯" || pointer=" "
     [ "$selected" = "0" ] && mark="✓" || mark=" "
-    printf ' %s [%s] pill\n' "$pointer" "$mark"
-    [ "$selected" = "1" ] && pointer="❯" || pointer=" "
+    [ "$selected" = "0" ] && draw_option 1 "$mark" "pill" || draw_option 0 "$mark" "pill"
     [ "$selected" = "1" ] && mark="✓" || mark=" "
-    printf ' %s [%s] lean\n' "$pointer" "$mark"
+    [ "$selected" = "1" ] && draw_option 1 "$mark" "lean" || draw_option 0 "$mark" "lean"
+    draw_screen_footer
     clear_tail
     key=$(read_key) || return 1
     case "$key" in
@@ -506,14 +535,12 @@ draw_segments_menu() {
   printf 'Segments: %s\n\n' "$segments"
   for s in $SEGMENT_CHOICES; do
     has_segment "$s" && enabled=1 || enabled=0
-    [ "$i" = "$selected" ] && pointer="❯" || pointer=" "
-    printf ' %s [%s] %s\n' "$pointer" "$(flag_mark "$enabled")" "$s"
+    [ "$i" = "$selected" ] && draw_option 1 "$(flag_mark "$enabled")" "$s" || draw_option 0 "$(flag_mark "$enabled")" "$s"
     i=$((i + 1))
   done
   reorder_index=$i
-  [ "$selected" = "$reorder_index" ] && pointer="❯" || pointer=" "
-  printf ' %s [ ] reorder\n' "$pointer"
-  printf '\nEnter done · Space toggle\n'
+  [ "$selected" = "$reorder_index" ] && draw_option 1 " " "reorder" || draw_option 0 " " "reorder"
+  draw_screen_footer toggle
   clear_tail
 }
 
@@ -540,14 +567,15 @@ choose_layout_screen() {
     apply_layout_index "$selected"
     draw_screen_header "Layout" 80
     printf '80-column preview\n\n'
-    [ "$selected" = "0" ] && pointer="❯" || pointer=" "; [ "$selected" = "0" ] && mark="✓" || mark=" "
-    printf ' %s [%s] responsive wrap\n' "$pointer" "$mark"
-    [ "$selected" = "1" ] && pointer="❯" || pointer=" "; [ "$selected" = "1" ] && mark="✓" || mark=" "
-    printf ' %s [%s] always single line\n' "$pointer" "$mark"
-    [ "$selected" = "2" ] && pointer="❯" || pointer=" "; [ "$selected" = "2" ] && mark="✓" || mark=" "
-    printf ' %s [%s] fixed two lines\n' "$pointer" "$mark"
-    [ "$selected" = "3" ] && pointer="❯" || pointer=" "; [ "$selected" = "3" ] && mark="✓" || mark=" "
-    printf ' %s [%s] fixed three lines\n' "$pointer" "$mark"
+    [ "$selected" = "0" ] && mark="✓" || mark=" "
+    [ "$selected" = "0" ] && draw_option 1 "$mark" "responsive wrap" || draw_option 0 "$mark" "responsive wrap"
+    [ "$selected" = "1" ] && mark="✓" || mark=" "
+    [ "$selected" = "1" ] && draw_option 1 "$mark" "always single line" || draw_option 0 "$mark" "always single line"
+    [ "$selected" = "2" ] && mark="✓" || mark=" "
+    [ "$selected" = "2" ] && draw_option 1 "$mark" "fixed two lines" || draw_option 0 "$mark" "fixed two lines"
+    [ "$selected" = "3" ] && mark="✓" || mark=" "
+    [ "$selected" = "3" ] && draw_option 1 "$mark" "fixed three lines" || draw_option 0 "$mark" "fixed three lines"
+    draw_screen_footer
     clear_tail
     key=$(read_key) || return 1
     case "$key" in
@@ -593,20 +621,18 @@ draw_details_menu() {
   local selected="$1" pointer mark
   redraw_menu_area
   printf 'Details\n\n'
-  [ "$selected" = "0" ] && pointer="❯" || pointer=" "; [ "$clock_mode" = "12h" ] && mark="✓" || mark=" "
-  printf ' %s [%s] clock: 12h\n' "$pointer" "$mark"
-  [ "$selected" = "1" ] && pointer="❯" || pointer=" "; [ "$clock_mode" = "24h" ] && mark="✓" || mark=" "
-  printf ' %s [%s] clock: 24h\n' "$pointer" "$mark"
-  [ "$selected" = "2" ] && pointer="❯" || pointer=" "; [ "$clock_mode" = "off" ] && mark="✓" || mark=" "
-  printf ' %s [%s] clock: off\n' "$pointer" "$mark"
-  [ "$selected" = "3" ] && pointer="❯" || pointer=" "
-  printf ' %s [%s] seconds\n' "$pointer" "$(flag_mark "$clock_seconds")"
-  [ "$selected" = "4" ] && pointer="❯" || pointer=" "
+  [ "$clock_mode" = "12h" ] && mark="✓" || mark=" "
+  [ "$selected" = "0" ] && draw_option 1 "$mark" "clock: 12h" || draw_option 0 "$mark" "clock: 12h"
+  [ "$clock_mode" = "24h" ] && mark="✓" || mark=" "
+  [ "$selected" = "1" ] && draw_option 1 "$mark" "clock: 24h" || draw_option 0 "$mark" "clock: 24h"
+  [ "$clock_mode" = "off" ] && mark="✓" || mark=" "
+  [ "$selected" = "2" ] && draw_option 1 "$mark" "clock: off" || draw_option 0 "$mark" "clock: off"
+  mark=$(flag_mark "$clock_seconds")
+  [ "$selected" = "3" ] && draw_option 1 "$mark" "seconds" || draw_option 0 "$mark" "seconds"
   [ "$ascii_mode" = "0" ] && mark="✓" || mark=" "
-  printf ' %s [%s] Nerd Font\n' "$pointer" "$mark"
-  [ "$selected" = "5" ] && pointer="❯" || pointer=" "
-  printf ' %s [ ] name max: %s\n' "$pointer" "$name_max"
-  printf '\nEnter done · Space toggle\n'
+  [ "$selected" = "4" ] && draw_option 1 "$mark" "Nerd Font" || draw_option 0 "$mark" "Nerd Font"
+  [ "$selected" = "5" ] && draw_option 1 " " "name max: $name_max" || draw_option 0 " " "name max: $name_max"
+  draw_screen_footer toggle
   clear_tail
 }
 
@@ -929,21 +955,18 @@ draw_main_menu() {
   local selected="$1" pointer mark
   redraw_menu_area
   printf 'Setup\n\n'
-  [ "$selected" = "0" ] && pointer="❯" || pointer=" "
   [ "$selected" = "0" ] && mark="✓" || mark=" "
-  printf ' %s [%s] Default\n' "$pointer" "$mark"
+  [ "$selected" = "0" ] && draw_option 1 "$mark" "Default" || draw_option 0 "$mark" "Default"
   if [ -f "$P10K_FILE" ]; then
-    [ "$selected" = "1" ] && pointer="❯" || pointer=" "
     [ "$selected" = "1" ] && mark="✓" || mark=" "
-    printf ' %s [%s] Import p10k\n' "$pointer" "$mark"
-    [ "$selected" = "2" ] && pointer="❯" || pointer=" "
+    [ "$selected" = "1" ] && draw_option 1 "$mark" "Import p10k" || draw_option 0 "$mark" "Import p10k"
     [ "$selected" = "2" ] && mark="✓" || mark=" "
-    printf ' %s [%s] Configure Wizard\n' "$pointer" "$mark"
+    [ "$selected" = "2" ] && draw_option 1 "$mark" "Configure Wizard" || draw_option 0 "$mark" "Configure Wizard"
   else
-    [ "$selected" = "1" ] && pointer="❯" || pointer=" "
     [ "$selected" = "1" ] && mark="✓" || mark=" "
-    printf ' %s [%s] Configure Wizard\n' "$pointer" "$mark"
+    [ "$selected" = "1" ] && draw_option 1 "$mark" "Configure Wizard" || draw_option 0 "$mark" "Configure Wizard"
   fi
+  draw_screen_footer
   clear_tail
 }
 

--- a/configure.sh
+++ b/configure.sh
@@ -13,6 +13,8 @@ CONFIG_FILE="${CORALLINE_CONFIG:-$HOME/.claude/coralline.conf}"
 SETTINGS_FILE="${CLAUDE_SETTINGS:-$HOME/.claude/settings.json}"
 P10K_FILE="${P10K_CONFIG:-$HOME/.p10k.zsh}"
 
+# Fallback list, used only when the runtime statusline cannot be scanned.
+# The live list is derived from statusline.sh's seg_* functions by load_segment_choices.
 SEGMENT_CHOICES="dir project git model ctx limit5h limit7d cost clock lines style duration effort stash"
 DEFAULT_SEGMENTS="dir git model ctx limit5h limit7d cost clock"
 
@@ -100,6 +102,25 @@ theme_list() {
 
 theme_count() {
   theme_list | wc -l | tr -d ' '
+}
+
+# Derive the segment menu from the runtime's seg_* functions so a new segment in
+# statusline.sh shows up here automatically — mirrors the theme auto-scan above.
+load_segment_choices() {
+  local statusline names
+  statusline=$(runtime_statusline)
+  [ -f "$statusline" ] || return 0
+  names=$(grep -oE '^seg_[A-Za-z0-9_]+' "$statusline" \
+    | sed 's/^seg_//' \
+    | grep -Ev '^(len|limit)$' \
+    | tr '\n' ' ')
+  names="${names% }"
+  [ -n "$names" ] && SEGMENT_CHOICES="$names"
+}
+
+segment_total() {
+  set -- $SEGMENT_CHOICES
+  printf '%s\n' "$#"
 }
 
 runtime_sample() {
@@ -496,7 +517,10 @@ choose_style_screen() {
 }
 
 choose_segments_screen() {
-  local selected=0 key count=15 dirty=1 reorder_index=14
+  local selected=0 key seg_n reorder_index count dirty=1
+  seg_n=$(segment_total)
+  reorder_index=$seg_n          # the reorder row sits right after the segments
+  count=$((seg_n + 1))          # segments + reorder row
   while :; do
     if [ "$dirty" = "1" ]; then
       draw_screen_header "Segments" 120
@@ -508,7 +532,7 @@ choose_segments_screen() {
       up|down) selected=$(menu_move "$selected" "$key" "$count") ;;
       enter) return 0 ;;
       space)
-        if [ "$selected" -lt 14 ]; then
+        if [ "$selected" -lt "$seg_n" ]; then
           local i=0 s
           i=0
           for s in $SEGMENT_CHOICES; do
@@ -742,7 +766,7 @@ choose_segments() {
           if [ "$i" = "$answer" ]; then toggle_segment "$s"; break; fi
           i=$((i + 1))
         done
-        if [ "$i" -gt 14 ]; then printf 'Choose a segment number from 1 to 14.\n' >&2; fi ;;
+        if [ "$i" -gt "$(segment_total)" ]; then printf 'Choose a segment number from 1 to %s.\n' "$(segment_total)" >&2; fi ;;
     esac
   done
 }
@@ -1039,6 +1063,7 @@ trap 'leave_screen; exit 130' INT TERM
 
 [ "$install_only" = "1" ] && exit 0
 
+load_segment_choices
 main_menu
 write_final_config || exit 0
 verify_render

--- a/configure.sh
+++ b/configure.sh
@@ -353,6 +353,27 @@ map_p10k_color() {
   add_extra "$coralline_name" "$color"
 }
 
+shell_quote() {
+  printf '%q' "$1"
+}
+
+write_assign() {
+  printf '%s=%s\n' "$1" "$(shell_quote "$2")"
+}
+
+known_segment() {
+  case " $SEGMENT_CHOICES " in *" $1 "*) return 0 ;; *) return 1 ;; esac
+}
+
+normalize_segments() {
+  local raw="$1" s next=""
+  for s in $raw; do
+    known_segment "$s" || continue
+    next="${next}${next:+ }$s"
+  done
+  printf '%s\n' "$next"
+}
+
 import_p10k() {
   local wizard_options time_fmt
   [ -f "$P10K_FILE" ] || die "cannot import; $P10K_FILE does not exist"
@@ -394,26 +415,25 @@ import_p10k() {
 write_candidate_config() {
   local out="$1" theme_dir
   theme_dir=$(runtime_theme_dir)
-  cat > "$out" <<EOF
-# coralline config
-. "$theme_dir/$theme.conf"
-
-VL_STYLE="$style"
-VL_LAYOUT="$layout"
-VL_MAX_LINES=$max_lines
-VL_WRAP_MARGIN=4
-VL_SEGMENTS="$segments"
-VL_SEGMENTS2="$segments2"
-VL_SEGMENTS3="$segments3"
-VL_CLOCK="$clock_mode"
-VL_CLOCK_SECONDS=$clock_seconds
-VL_BAR_WIDTH=5
-VL_COST_DECIMALS=2
-VL_PATH_DEPTH=4
-VL_NAME_MAX=$name_max
-VL_ASCII=$ascii_mode
-VL_LEAN_SEP="$lean_sep"
-EOF
+  {
+    printf '# coralline config\n'
+    printf '. %s\n\n' "$(shell_quote "$theme_dir/$theme.conf")"
+    write_assign VL_STYLE "$style"
+    write_assign VL_LAYOUT "$layout"
+    printf 'VL_MAX_LINES=%s\n' "$max_lines"
+    printf 'VL_WRAP_MARGIN=4\n'
+    write_assign VL_SEGMENTS "$segments"
+    write_assign VL_SEGMENTS2 "$segments2"
+    write_assign VL_SEGMENTS3 "$segments3"
+    write_assign VL_CLOCK "$clock_mode"
+    printf 'VL_CLOCK_SECONDS=%s\n' "$clock_seconds"
+    printf 'VL_BAR_WIDTH=5\n'
+    printf 'VL_COST_DECIMALS=2\n'
+    printf 'VL_PATH_DEPTH=4\n'
+    printf 'VL_NAME_MAX=%s\n' "$name_max"
+    printf 'VL_ASCII=%s\n' "$ascii_mode"
+    write_assign VL_LEAN_SEP "$lean_sep"
+  } > "$out"
   if [ -n "$extra_config" ]; then
     printf '\n# Imported p10k color hints.\n' >> "$out"
     printf '%s' "$extra_config" >> "$out"
@@ -623,7 +643,7 @@ choose_segments_screen() {
           leave_screen
           local answer
           answer=$(ask "Segments in order" "$segments")
-          [ -n "$answer" ] && segments="$answer"
+          [ -n "$answer" ] && segments=$(normalize_segments "$answer")
           enter_screen
           dirty=1
         fi ;;
@@ -837,7 +857,7 @@ choose_segments() {
       d|D|'') return 0 ;;
       r|R)
         answer=$(ask "Segments in order" "$segments")
-        [ -n "$answer" ] && segments="$answer" ;;
+        [ -n "$answer" ] && segments=$(normalize_segments "$answer") ;;
       ''|*[!0-9]*) printf 'Choose a segment number, r, or d.\n' >&2 ;;
       *)
         i=1
@@ -883,17 +903,17 @@ choose_layout() {
       3)
         layout="fixed"
         max_lines=3
-        segments=$(ask "Line 1 segments" "dir git model")
-        segments2=$(ask "Line 2 segments" "ctx limit5h limit7d cost clock")
+        segments=$(normalize_segments "$(ask "Line 1 segments" "dir git model")")
+        segments2=$(normalize_segments "$(ask "Line 2 segments" "ctx limit5h limit7d cost clock")")
         segments3=""
         show_step "Layout selected" 80
         return 0 ;;
       4)
         layout="fixed"
         max_lines=3
-        segments=$(ask "Line 1 segments" "dir git model")
-        segments2=$(ask "Line 2 segments" "ctx limit5h limit7d")
-        segments3=$(ask "Line 3 segments" "cost clock")
+        segments=$(normalize_segments "$(ask "Line 1 segments" "dir git model")")
+        segments2=$(normalize_segments "$(ask "Line 2 segments" "ctx limit5h limit7d")")
+        segments3=$(normalize_segments "$(ask "Line 3 segments" "cost clock")")
         show_step "Layout selected" 80
         return 0 ;;
       *) printf 'Choose a layout number from 1 to 4.\n' >&2 ;;

--- a/install.sh
+++ b/install.sh
@@ -11,9 +11,31 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)
 WORK_DIR=""
 TEMP_DIR=""
 
+if [ -t 1 ]; then
+  BOLD=$(printf '\033[1m')
+  DIM=$(printf '\033[2m')
+  GREEN=$(printf '\033[32m')
+  BLUE=$(printf '\033[34m')
+  RESET=$(printf '\033[0m')
+else
+  BOLD=""
+  DIM=""
+  GREEN=""
+  BLUE=""
+  RESET=""
+fi
+
 die() {
   printf 'error: %s\n' "$*" >&2
   exit 1
+}
+
+info() {
+  printf '%s%s%s %s\n' "$BLUE" "$BOLD" "coralline" "$RESET$*"
+}
+
+ok() {
+  printf '%s%s%s %s\n' "$GREEN" "$BOLD" "coralline" "$RESET$*"
 }
 
 need_cmd() {
@@ -34,6 +56,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
+info "installing statusline"
+printf '%s\n' "${DIM}Checking prerequisites...${RESET}"
 need_jq
 
 if [ -f "$SCRIPT_DIR/configure.sh" ] \
@@ -41,11 +65,13 @@ if [ -f "$SCRIPT_DIR/configure.sh" ] \
   && [ -f "$SCRIPT_DIR/test/sample-input.json" ] \
   && [ -d "$SCRIPT_DIR/themes" ]; then
   WORK_DIR="$SCRIPT_DIR"
+  printf '%s\n' "${DIM}Using local checkout: $WORK_DIR${RESET}"
 else
   need_cmd curl
   TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/coralline-install.XXXXXX") || exit 1
   WORK_DIR="$TEMP_DIR"
   mkdir -p "$WORK_DIR/themes" "$WORK_DIR/test"
+  printf '%s\n' "${DIM}Downloading runtime files from $BASE_URL${RESET}"
   download "$BASE_URL/configure.sh" "$WORK_DIR/configure.sh"
   download "$BASE_URL/statusline.sh" "$WORK_DIR/statusline.sh"
   download "$BASE_URL/test/sample-input.json" "$WORK_DIR/test/sample-input.json"
@@ -54,5 +80,8 @@ else
   done
 fi
 
-chmod +x "$WORK_DIR/configure.sh" "$WORK_DIR/statusline.sh"
+ok "starting visual setup"
+if [ -r /dev/tty ] && [ -t 1 ]; then
+  exec bash "$WORK_DIR/configure.sh" --install "$@" < /dev/tty
+fi
 exec bash "$WORK_DIR/configure.sh" --install "$@"

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,6 @@ set -u
 REPO="${CORALLINE_REPO:-Nanako0129/coralline}"
 REF="${CORALLINE_REF:-main}"
 BASE_URL="${CORALLINE_BASE_URL:-}"
-THEMES="claude-coral catppuccin-mocha nord gruvbox-dark tokyo-night dracula mono"
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)
 WORK_DIR=""
 TEMP_DIR=""
@@ -73,6 +72,43 @@ need_jq() {
 download() {
   local src="$1" dst="$2"
   curl -fsSL "$src" -o "$dst" || die "failed to download $src"
+}
+
+download_themes() {
+  local paths path dst count=0 local_base default_base
+  default_base="https://raw.githubusercontent.com/$REPO/$REF"
+  case "$BASE_URL" in
+    file://*)
+      local_base="${BASE_URL#file://}"
+      paths=$(cd "$local_base" 2>/dev/null && find themes -type f -name '*.conf' | sort || true)
+      ;;
+    "$default_base")
+      paths=$(curl -fsSL "https://api.github.com/repos/$REPO/git/trees/$REF?recursive=1" \
+        | jq -r '.tree[]? | select(.type == "blob" and (.path | test("^themes/.+\\.conf$"))) | .path' 2>/dev/null || true)
+      ;;
+    *)
+      paths=""
+      ;;
+  esac
+  if [ -z "$paths" ]; then
+    paths="themes/claude-coral.conf
+themes/catppuccin-mocha.conf
+themes/nord.conf
+themes/gruvbox-dark.conf
+themes/tokyo-night.conf
+themes/dracula.conf
+themes/mono.conf"
+  fi
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    dst="$WORK_DIR/$path"
+    mkdir -p "$(dirname "$dst")"
+    download "$BASE_URL/$path" "$dst"
+    count=$((count + 1))
+  done <<THEMES
+$paths
+THEMES
+  [ "$count" -gt 0 ] || die "no themes found"
 }
 
 while [ "$#" -gt 0 ]; do
@@ -156,9 +192,7 @@ else
   download "$BASE_URL/configure.sh" "$WORK_DIR/configure.sh"
   download "$BASE_URL/statusline.sh" "$WORK_DIR/statusline.sh"
   download "$BASE_URL/test/sample-input.json" "$WORK_DIR/test/sample-input.json"
-  for theme in $THEMES; do
-    download "$BASE_URL/themes/$theme.conf" "$WORK_DIR/themes/$theme.conf"
-  done
+  download_themes
 fi
 
 if [ "$CONFIGURE_MODE" = "--install-only" ]; then

--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
 # coralline installer. Works from a local clone or via:
 #   curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
+# Test a fork with:
+#   curl -fsSL https://raw.githubusercontent.com/YOU/coralline/main/install.sh | bash -s -- --repo YOU/coralline
 
 set -u
 
+REPO="${CORALLINE_REPO:-Nanako0129/coralline}"
 REF="${CORALLINE_REF:-main}"
-BASE_URL="${CORALLINE_BASE_URL:-https://raw.githubusercontent.com/Nanako0129/coralline/$REF}"
+BASE_URL="${CORALLINE_BASE_URL:-}"
 THEMES="claude-coral catppuccin-mocha nord gruvbox-dark tokyo-night dracula mono"
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)
 WORK_DIR=""
 TEMP_DIR=""
+CONFIGURE_MODE=""
 
 if [ -t 1 ]; then
   BOLD=$(printf '\033[1m')
@@ -28,6 +32,26 @@ fi
 die() {
   printf 'error: %s\n' "$*" >&2
   exit 1
+}
+
+usage() {
+  cat <<EOF
+coralline installer
+
+Usage:
+  bash install.sh [--repo owner/repo] [--ref branch-or-tag]
+  curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
+
+Options:
+  --repo owner/repo   Download runtime files from this GitHub repo.
+  --ref ref          Download runtime files from this branch, tag, or commit.
+  --base-url url     Download runtime files from this raw file base URL.
+  --install-only     Install runtime files and Claude settings, then exit.
+  --default          Install the default coralline config without opening the setup menu.
+  --import-p10k      Import ~/.p10k.zsh without opening the setup menu.
+  --wizard           Open the visual wizard directly after installing.
+  -h, --help         Show this help.
+EOF
 }
 
 info() {
@@ -50,6 +74,63 @@ download() {
   local src="$1" dst="$2"
   curl -fsSL "$src" -o "$dst" || die "failed to download $src"
 }
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      [ "$#" -ge 2 ] || die "--repo requires owner/repo"
+      REPO="$2"
+      shift 2
+      ;;
+    --repo=*)
+      REPO="${1#--repo=}"
+      shift
+      ;;
+    --ref)
+      [ "$#" -ge 2 ] || die "--ref requires a branch, tag, or commit"
+      REF="$2"
+      shift 2
+      ;;
+    --ref=*)
+      REF="${1#--ref=}"
+      shift
+      ;;
+    --base-url)
+      [ "$#" -ge 2 ] || die "--base-url requires a URL"
+      BASE_URL="$2"
+      shift 2
+      ;;
+    --base-url=*)
+      BASE_URL="${1#--base-url=}"
+      shift
+      ;;
+    --install-only)
+      CONFIGURE_MODE="--install-only"
+      shift
+      ;;
+    --default)
+      CONFIGURE_MODE="--default"
+      shift
+      ;;
+    --import-p10k)
+      CONFIGURE_MODE="--import-p10k"
+      shift
+      ;;
+    --wizard)
+      CONFIGURE_MODE="--wizard"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+done
+
+[ -n "$BASE_URL" ] || BASE_URL="https://raw.githubusercontent.com/$REPO/$REF"
 
 cleanup() {
   [ -n "$TEMP_DIR" ] && [ -d "$TEMP_DIR" ] && rm -rf "$TEMP_DIR"
@@ -80,8 +161,12 @@ else
   done
 fi
 
-ok "starting visual setup"
-if [ -r /dev/tty ] && [ -t 1 ]; then
-  exec bash "$WORK_DIR/configure.sh" --install "$@" < /dev/tty
+if [ "$CONFIGURE_MODE" = "--install-only" ]; then
+  ok "installing runtime files"
+else
+  ok "starting setup"
 fi
-exec bash "$WORK_DIR/configure.sh" --install "$@"
+if [ -r /dev/tty ] && [ -t 1 ]; then
+  exec bash "$WORK_DIR/configure.sh" --install $CONFIGURE_MODE < /dev/tty
+fi
+exec bash "$WORK_DIR/configure.sh" --install $CONFIGURE_MODE

--- a/install.sh
+++ b/install.sh
@@ -74,37 +74,27 @@ download() {
   curl -fsSL "$src" -o "$dst" || die "failed to download $src"
 }
 
+github_theme_paths() {
+  local tree_sha
+  tree_sha=$(curl -fsSL "https://api.github.com/repos/$REPO/commits/$REF" \
+    | jq -r '.commit.tree.sha // empty' 2>/dev/null || true)
+  [ -n "$tree_sha" ] || return 0
+  curl -fsSL "https://api.github.com/repos/$REPO/git/trees/$tree_sha?recursive=1" \
+    | jq -r '.tree[]? | select(.type == "blob" and (.path | test("^themes/.+\\.conf$"))) | .path' 2>/dev/null || true
+}
+
 download_themes() {
-  local paths path dst count=0 local_base default_base tree_sha
-  default_base="https://raw.githubusercontent.com/$REPO/$REF"
+  local paths path dst count=0 local_base
   case "$BASE_URL" in
     file://*)
       local_base="${BASE_URL#file://}"
       paths=$(cd "$local_base" 2>/dev/null && find themes -type f -name '*.conf' | sort || true)
       ;;
-    "$default_base")
-      tree_sha=$(curl -fsSL "https://api.github.com/repos/$REPO/commits/$REF" \
-        | jq -r '.commit.tree.sha // empty' 2>/dev/null || true)
-      if [ -n "$tree_sha" ]; then
-        paths=$(curl -fsSL "https://api.github.com/repos/$REPO/git/trees/$tree_sha?recursive=1" \
-          | jq -r '.tree[]? | select(.type == "blob" and (.path | test("^themes/.+\\.conf$"))) | .path' 2>/dev/null || true)
-      else
-        paths=""
-      fi
-      ;;
     *)
-      paths=""
+      paths=$(github_theme_paths)
       ;;
   esac
-  if [ -z "$paths" ]; then
-    paths="themes/claude-coral.conf
-themes/catppuccin-mocha.conf
-themes/nord.conf
-themes/gruvbox-dark.conf
-themes/tokyo-night.conf
-themes/dracula.conf
-themes/mono.conf"
-  fi
+  [ -n "$paths" ] || die "no themes found for $REPO@$REF"
   while IFS= read -r path; do
     [ -n "$path" ] || continue
     dst="$WORK_DIR/$path"
@@ -205,6 +195,12 @@ if [ "$CONFIGURE_MODE" = "--install-only" ]; then
   ok "installing runtime files"
 else
   ok "starting setup"
+fi
+if [ "$CONFIGURE_MODE" = "--install-only" ]; then
+  if [ -r /dev/tty ] && [ -t 1 ]; then
+    exec bash "$WORK_DIR/configure.sh" --install-only < /dev/tty
+  fi
+  exec bash "$WORK_DIR/configure.sh" --install-only
 fi
 if [ -r /dev/tty ] && [ -t 1 ]; then
   exec bash "$WORK_DIR/configure.sh" --install $CONFIGURE_MODE < /dev/tty

--- a/install.sh
+++ b/install.sh
@@ -75,7 +75,7 @@ download() {
 }
 
 download_themes() {
-  local paths path dst count=0 local_base default_base
+  local paths path dst count=0 local_base default_base tree_sha
   default_base="https://raw.githubusercontent.com/$REPO/$REF"
   case "$BASE_URL" in
     file://*)
@@ -83,8 +83,14 @@ download_themes() {
       paths=$(cd "$local_base" 2>/dev/null && find themes -type f -name '*.conf' | sort || true)
       ;;
     "$default_base")
-      paths=$(curl -fsSL "https://api.github.com/repos/$REPO/git/trees/$REF?recursive=1" \
-        | jq -r '.tree[]? | select(.type == "blob" and (.path | test("^themes/.+\\.conf$"))) | .path' 2>/dev/null || true)
+      tree_sha=$(curl -fsSL "https://api.github.com/repos/$REPO/commits/$REF" \
+        | jq -r '.commit.tree.sha // empty' 2>/dev/null || true)
+      if [ -n "$tree_sha" ]; then
+        paths=$(curl -fsSL "https://api.github.com/repos/$REPO/git/trees/$tree_sha?recursive=1" \
+          | jq -r '.tree[]? | select(.type == "blob" and (.path | test("^themes/.+\\.conf$"))) | .path' 2>/dev/null || true)
+      else
+        paths=""
+      fi
       ;;
     *)
       paths=""

--- a/install.sh
+++ b/install.sh
@@ -71,16 +71,35 @@ need_jq() {
 
 download() {
   local src="$1" dst="$2"
-  curl -fsSL "$src" -o "$dst" || die "failed to download $src"
+  case "$src" in
+    file://*)
+      cp "${src#file://}" "$dst" || die "failed to copy $src"
+      ;;
+    *)
+      curl -fsSL "$src" -o "$dst" || die "failed to download $src"
+      ;;
+  esac
 }
 
-github_theme_paths() {
-  local tree_sha
-  tree_sha=$(curl -fsSL "https://api.github.com/repos/$REPO/commits/$REF" \
-    | jq -r '.commit.tree.sha // empty' 2>/dev/null || true)
-  [ -n "$tree_sha" ] || return 0
-  curl -fsSL "https://api.github.com/repos/$REPO/git/trees/$tree_sha?recursive=1" \
-    | jq -r '.tree[]? | select(.type == "blob" and (.path | test("^themes/.+\\.conf$"))) | .path' 2>/dev/null || true
+download_theme_archive() {
+  local archive extract src rel dst count=0
+  need_cmd tar
+  archive=$(mktemp "${TMPDIR:-/tmp}/coralline-themes.XXXXXX.tar.gz") || exit 1
+  extract=$(mktemp -d "${TMPDIR:-/tmp}/coralline-themes.XXXXXX") || exit 1
+  download "https://codeload.github.com/$REPO/tar.gz/$REF" "$archive"
+  tar -xzf "$archive" -C "$extract" || die "failed to extract theme archive"
+  while IFS= read -r src; do
+    rel="${src#"$extract"/}"
+    rel="${rel#*/themes/}"
+    dst="$WORK_DIR/themes/$rel"
+    mkdir -p "$(dirname "$dst")"
+    cp "$src" "$dst"
+    count=$((count + 1))
+  done <<THEMES
+$(find "$extract" -type f -path '*/themes/*.conf' | sort)
+THEMES
+  rm -rf "$archive" "$extract"
+  [ "$count" -gt 0 ] || die "no themes found for $REPO@$REF"
 }
 
 download_themes() {
@@ -91,7 +110,8 @@ download_themes() {
       paths=$(cd "$local_base" 2>/dev/null && find themes -type f -name '*.conf' | sort || true)
       ;;
     *)
-      paths=$(github_theme_paths)
+      download_theme_archive
+      return 0
       ;;
   esac
   [ -n "$paths" ] || die "no themes found for $REPO@$REF"
@@ -169,7 +189,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-info "installing statusline"
+info "installing coralline"
 printf '%s\n' "${DIM}Checking prerequisites...${RESET}"
 need_jq
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# coralline installer. Works from a local clone or via:
+#   curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
+
+set -u
+
+REF="${CORALLINE_REF:-main}"
+BASE_URL="${CORALLINE_BASE_URL:-https://raw.githubusercontent.com/Nanako0129/coralline/$REF}"
+THEMES="claude-coral catppuccin-mocha nord gruvbox-dark tokyo-night dracula mono"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)
+WORK_DIR=""
+TEMP_DIR=""
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required"
+}
+
+need_jq() {
+  command -v jq >/dev/null 2>&1 || die "jq is required. Install it first (macOS: brew install jq), then rerun this installer."
+}
+
+download() {
+  local src="$1" dst="$2"
+  curl -fsSL "$src" -o "$dst" || die "failed to download $src"
+}
+
+cleanup() {
+  [ -n "$TEMP_DIR" ] && [ -d "$TEMP_DIR" ] && rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+need_jq
+
+if [ -f "$SCRIPT_DIR/configure.sh" ] \
+  && [ -f "$SCRIPT_DIR/statusline.sh" ] \
+  && [ -f "$SCRIPT_DIR/test/sample-input.json" ] \
+  && [ -d "$SCRIPT_DIR/themes" ]; then
+  WORK_DIR="$SCRIPT_DIR"
+else
+  need_cmd curl
+  TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/coralline-install.XXXXXX") || exit 1
+  WORK_DIR="$TEMP_DIR"
+  mkdir -p "$WORK_DIR/themes" "$WORK_DIR/test"
+  download "$BASE_URL/configure.sh" "$WORK_DIR/configure.sh"
+  download "$BASE_URL/statusline.sh" "$WORK_DIR/statusline.sh"
+  download "$BASE_URL/test/sample-input.json" "$WORK_DIR/test/sample-input.json"
+  for theme in $THEMES; do
+    download "$BASE_URL/themes/$theme.conf" "$WORK_DIR/themes/$theme.conf"
+  done
+fi
+
+chmod +x "$WORK_DIR/configure.sh" "$WORK_DIR/statusline.sh"
+exec bash "$WORK_DIR/configure.sh" --install "$@"


### PR DESCRIPTION
## 摘要
- 新增視覺化設定精靈，可預覽並調整主題、區段與版面
- 新增 `curl` 一鍵安裝流程，支援人類 TUI 與 Claude 的 install-only bootstrap
- 自動掃描 `themes/**/*.conf` 主題庫，新增主題不需要再改 wizard 清單
- 自動探索 `statusline.sh` 的可用區段，新增 segment 不需要同步修改 wizard 清單
- 更新 README / INSTALL 文件，說明 Claude 訪談式設定、p10k 匯入與重新設定路徑

## 驗證
- `bash -n install.sh configure.sh statusline.sh`
- `bash test/test-width.sh`
- 使用臨時 HOME 手動驗證 install-only、p10k opt-in、TUI 啟動、巢狀主題安裝與區段清單流程
