### PR TITLE
fix(burn): fit the 5h slope over the current window only

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -236,17 +236,28 @@ burn_eta_5h() {  # → _B5_STATE _B5_ETA _B5_RATE _B5_TTR ; trims $BURN_FILE
     END {
       if (n == 0) { print "warming inf 0 0"; next_done = 1 }
       if (!next_done) {
+        # Fit the slope over the CURRENT window only. The sample file is shared
+        # by every concurrent session writing to this host; idle ones keep
+        # appending stale snapshots from earlier windows (a different reset).
+        # Mixing windows lets the fit pair two samples seconds apart but tens of
+        # percent apart, giving a near-vertical rate and a bogus ~1m ETA. The
+        # current window is the one with the latest reset; keep only its samples
+        # (cord[1..m]) in file order, then run the recent-slope fit over them.
+        cur = 0
+        for (i = 1; i <= n; i++) if (rst[ord[i]] > cur) cur = rst[ord[i]]
+        m = 0
+        for (i = 1; i <= n; i++) if (rst[ord[i]] == cur) cord[++m] = ord[i]
         start = 1
-        for (i = 2; i <= n; i++)
-          if (int(pct[ord[i]]) < int(pct[ord[i-1]])) start = i
-        le = ord[n]; lp = pct[le]
-        ttr = rst[le] - now; if (ttr < 0) ttr = 0
+        for (i = 2; i <= m; i++)
+          if (int(pct[cord[i]]) < int(pct[cord[i-1]])) start = i
+        le = cord[m]; lp = pct[le]
+        ttr = cur - now; if (ttr < 0) ttr = 0
         cwin = now - win
         fc_t = 0; fc_p = -1; lc_t = 0; lc_p = -1; ncross = 0; anycross = 0
-        for (i = start + 1; i <= n; i++) {
-          a = int(pct[ord[i-1]]); b = int(pct[ord[i]])
+        for (i = start + 1; i <= m; i++) {
+          a = int(pct[cord[i-1]]); b = int(pct[cord[i]])
           if (b > a) {
-            anycross = 1; ct = ord[i]
+            anycross = 1; ct = cord[i]
             if (ct >= cwin && ct <= now) {
               if (fc_p < 0) { fc_t = ct; fc_p = b }
               lc_t = ct; lc_p = b; ncross++

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -71,6 +71,17 @@ run5h "" 1000000
 eq "5h empty state" "$_B5_STATE" "warming"
 eq "5h empty eta"   "$_B5_ETA"   "inf"
 
+# cross-window isolation: a shared file where an idle session's stale snapshots
+# (50,51 / older reset 1500000) are interleaved with the current window
+# (6,7,8 / later reset 2000000). The estimate must use ONLY the current window —
+# pre-fix the mixed series mis-fit; now it fits the real 6→7→8 slope.
+# crossings (current window): (1000120,7),(1000300,8) → rate=1/180 %/s
+# now pct=8 → ETA=(100-8)*180=16560s
+run5h "1000000\t6\t2000000\n1000060\t50\t1500000\n1000120\t7\t2000000\n1000180\t51\t1500000\n1000300\t8\t2000000\n1000360\t8\t2000000\n" 1000360
+eq "5h cross-window state" "$_B5_STATE" "active"
+eq "5h cross-window eta"   "$_B5_ETA"   "16560"
+eq "5h cross-window ttr"   "$_B5_TTR"   "999640"
+
 # trim: 5 rows, trim=3 → file keeps last 3
 BURN_TRIM=3
 run5h "1\t6\t9\n2\t6\t9\n3\t7\t9\n4\t7\t9\n5\t8\t9\n" 6


### PR DESCRIPTION
## The bug

With multiple Claude sessions open on one host, the `burn` segment can show a wildly wrong ETA — e.g. `↗ 5h ⇢ 1m` while the 5h limit is at ~10% with 3h55m to reset:

<img width="560" alt="burn showing a bogus 1m" src="https://github.com/Nanako0129/coralline/blob/main/assets/burn-segment.png?raw=true">

*(the real screenshot showed `5h … 10% ↺3h55m … ↗ 5h ⇢ 1m`)*

## Root cause

`~/.claude/coralline/burn-5h.tsv` is shared by every session writing on the host. Idle sessions keep appending **stale** rate-limit snapshots from earlier windows (an older `resets_at`). In a real file I found, within one 600s lookback, six incoherent `(pct, reset)` series at once:

| pct | reset | source |
|---|---|---|
| 9% / 10% | resets in ~3h52m | current (real) |
| 21% / 25% / 34% / 51% | resets **hours in the past** | stale snapshots from idle sessions |

`burn_eta_5h` fit its recent slope across *all* of them. With values bouncing between windows, the fit could pair two samples seconds apart but tens of percent apart → near-vertical rate → bogus ~1m ETA. It was also unstable (a moment later: `↗ ✓`).

## Fix

Restrict the slope fit to the **current window** — the samples whose reset equals the latest reset seen (`cord[1..m]`) — and take `lp`/`ttr` from that window's last sample. Cross-window stale snapshots are ignored.

Validated against the real polluted file: the `1m` artifact becomes a correct `↗ ✓` (10% with a gentle climb can't run the window dry). Adds a cross-window isolation regression to `test/test-burn.sh` (interleaved stale 50/51% samples must not perturb the current 6→7→8 fit). Burn suite: 53 assertions, all green.

## Design: shared file vs per-session

> The rate-limit `%` is account-wide — the API returns the account aggregate, not per-session usage. So any one session's `(time, %)` stream is enough to fit the burn rate; extra sessions only record the same number redundantly. That is the lens for the choice below.

| Dimension | Shared file (this PR) | Per-session (alternative) |
|---|---|---|
| New session | Inherits existing history, no warmup | Cold-starts (~10 min to a usable slope) |
| Files & cleanup | One file, no lifecycle | One file per `session_id`, needs orphan-sweep |
| Cross-session contamination | Possible — fixed here by current-window isolation | Impossible by construction |
| Multiple accounts | Can't distinguish (tracks the latest-reset window) | Correct (each session is independent) |
| Sampling | Dense (every session contributes) | Redundant (N files, same number) |

Since the data is account-aggregate, per-session's only real win is the multiple-accounts case, which is uncommon — so this PR takes the smaller shared-file fix instead of introducing a per-file lifecycle. `session_id` is already in the statusline JSON, so switching later stays cheap.

cc @redtear1115 — this is the concurrent-session case you mentioned wanting to look at. Happy to go the per-session route instead if you would rather own the shared-file story differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
