### PR TITLE
fix(burn): ignore same-window jitter so the slope can't explode

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -247,12 +247,18 @@ burn_eta_5h() {  # → _B5_STATE _B5_ETA _B5_RATE _B5_TTR ; trims $BURN_FILE
         for (i = 1; i <= n; i++) if (rst[ord[i]] > cur) cur = rst[ord[i]]
         m = 0
         for (i = 1; i <= n; i++) if (rst[ord[i]] == cur) cord[++m] = ord[i]
+        # Within the current window usage only ever rises until the window
+        # resets, so any decrease here is cache-lag jitter between concurrent
+        # sessions (their rate-limit caches refresh at different moments), NOT a
+        # reset — a real reset lands in a new window and was filtered out above.
+        # Anchoring the fit at the window start keeps a few jitter down-blips
+        # from collapsing it onto the last 1-2 samples and exploding the slope
+        # into a bogus ~1m ETA.
         start = 1
-        for (i = 2; i <= m; i++)
-          if (int(pct[cord[i]]) < int(pct[cord[i-1]])) start = i
         le = cord[m]; lp = pct[le]
         ttr = cur - now; if (ttr < 0) ttr = 0
         cwin = now - win
+        minspan = int(win / 4)   # crossings must span this long to trust a slope
         fc_t = 0; fc_p = -1; lc_t = 0; lc_p = -1; ncross = 0; anycross = 0
         for (i = start + 1; i <= m; i++) {
           a = int(pct[cord[i-1]]); b = int(pct[cord[i]])
@@ -264,7 +270,7 @@ burn_eta_5h() {  # → _B5_STATE _B5_ETA _B5_RATE _B5_TTR ; trims $BURN_FILE
             }
           }
         }
-        if (ncross >= 2 && lc_t > fc_t && lc_p > fc_p) {
+        if (ncross >= 2 && lc_t > fc_t && lc_p > fc_p && (lc_t - fc_t) >= minspan) {
           rate = (lc_p - fc_p) / (lc_t - fc_t)
           eta = (100 - lp) / rate; if (eta < 0) eta = 0
           printf "active %.0f %.10f %d\n", eta, rate, ttr

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -82,6 +82,21 @@ eq "5h cross-window state" "$_B5_STATE" "active"
 eq "5h cross-window eta"   "$_B5_ETA"   "16560"
 eq "5h cross-window ttr"   "$_B5_TTR"   "999640"
 
+# same-window jitter: concurrent sessions' caches disagree by a point or two, so
+# pct dips mid-window (13→12) though usage only ever rises. A decrease used to
+# reset `start` to the tail and fit the slope over the last 1-2 samples (1s apart)
+# → bogus ~1m ETA. Now the fit is anchored at the window start and spans the
+# first→last crossing: (1000150,11)→(1000400,16) = 5%/250s, lp=16 → ETA=84/0.02=4200.
+run5h "1000050\t10\t2000000\n1000150\t11\t2000000\n1000380\t13\t2000000\n1000398\t12\t2000000\n1000399\t14\t2000000\n1000400\t16\t2000000\n" 1000400
+eq "5h jitter state" "$_B5_STATE" "active"
+eq "5h jitter eta"   "$_B5_ETA"   "4200"
+eq "5h jitter ttr"   "$_B5_TTR"   "999600"
+
+# min-span guard: a tiny late burst (two crossings 2s apart, nothing earlier in
+# window) is too short to trust → warming, not a wild fast ETA.
+run5h "1000000\t9\t2000000\n1000398\t10\t2000000\n1000400\t11\t2000000\n" 1000400
+eq "5h short-span guard" "$_B5_STATE" "warming"
+
 # trim: 5 rows, trim=3 → file keeps last 3
 BURN_TRIM=3
 run5h "1\t6\t9\n2\t6\t9\n3\t7\t9\n4\t7\t9\n5\t8\t9\n" 6


### PR DESCRIPTION
Follow-up to #20.

## Still broken after #20

#20 isolated the current rate-limit window (dropping stale snapshots from other windows), but the `↗ 5h ⇢ 1m` artifact could still flash up. Looking at a real current-window slice, the pct bounces *within one window*:

```text
3 → 14 → 15 → 18 → 15 → 18 → 15 → 18 → 19 → 18
```

Usage only ever rises inside a window, so those dips aren't real. They are cache-lag jitter: concurrent sessions whose rate-limit caches refresh at different moments report a value a point or two apart.

## Root cause

`burn_eta_5h` reset its fit anchor (`start`) on every decrease, to discard pre-reset samples. Each jitter dip tripped that, pushing the anchor to the tail, so the slope got fit over the last one or two samples a second or two apart. A tiny denominator gives a near-vertical rate and a ~1m ETA, intermittently (a moment later it reads `↗ ✓`).

## Fix

The current-window filter from #20 already guarantees a genuine reset lands in a different window and is dropped, so any decrease left here is jitter, not a reset.

| Change | Effect |
|---|---|
| Anchor the fit at the window start (`start = 1`) | jitter dips no longer collapse the fit onto the tail |
| Require the first→last crossing to span at least `win/4` | a too-short burst falls back to warming instead of a wild ETA |

On the real jittery sample I captured, the `~1m` artifact becomes a sane `44m` (slope fit over the in-window crossings, 14→19 across 161s). Clean-data behaviour is unchanged (the existing active/idle/warming cases had no decreases, so `start` was already 1).

Adds two regressions to `test/test-burn.sh`: same-window jitter must not explode, and a tiny late burst is too short to trust. Burn suite green.

cc @redtear1115 — same area as #20, the same-window half of the concurrent-session story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
