### PR TITLE
fix(burn): loosen the slope span guard so real fast burns still show

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -258,7 +258,11 @@ burn_eta_5h() {  # → _B5_STATE _B5_ETA _B5_RATE _B5_TTR ; trims $BURN_FILE
         le = cord[m]; lp = pct[le]
         ttr = cur - now; if (ttr < 0) ttr = 0
         cwin = now - win
-        minspan = int(win / 4)   # crossings must span this long to trust a slope
+        # Crossings must span at least this long to trust a slope. Cache-lag
+        # jitter between sessions is second-scale, so a sub-minute span is noise;
+        # a genuine fast burn still rises over many seconds and clears this, so
+        # the guard rejects only second-scale noise, not real fast consumption.
+        minspan = int(win / 10)
         fc_t = 0; fc_p = -1; lc_t = 0; lc_p = -1; ncross = 0; anycross = 0
         for (i = start + 1; i <= m; i++) {
           a = int(pct[cord[i-1]]); b = int(pct[cord[i]])

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -97,6 +97,13 @@ eq "5h jitter ttr"   "$_B5_TTR"   "999600"
 run5h "1000000\t9\t2000000\n1000398\t10\t2000000\n1000400\t11\t2000000\n" 1000400
 eq "5h short-span guard" "$_B5_STATE" "warming"
 
+# but a genuine fast burn that spans more than the guard (win/10=60s) must show,
+# not be hidden as warming: 1→5→9→10 over 90s. fc=(1000010,5) lc=(1000100,10),
+# span=90s ≥ 60s → rate=5/90, lp=10 → ETA=90/(5/90)=1620.
+run5h "1000000\t1\t2000000\n1000010\t5\t2000000\n1000070\t9\t2000000\n1000100\t10\t2000000\n" 1000100
+eq "5h fast-burn shows state" "$_B5_STATE" "active"
+eq "5h fast-burn shows eta"   "$_B5_ETA"   "1620"
+
 # trim: 5 rows, trim=3 → file keeps last 3
 BURN_TRIM=3
 run5h "1\t6\t9\n2\t6\t9\n3\t7\t9\n4\t7\t9\n5\t8\t9\n" 6


### PR DESCRIPTION
Follow-up to #21, addressing the Codex P2 raised there.

## Problem

The min-span guard added in #21 was `win/4` (150s at the default window). That suppressed genuine fast consumption: a run crossing several integer percents inside ~90s (`1→5→9→10`) has `ncross >= 2` and a clearly high rate, but fell through to `warming` until the burst had lasted 2.5 minutes, hiding the warning exactly when the limit is depleting fastest.

## Fix

Cache-lag jitter between concurrent sessions is second-scale, so only a sub-minute crossing span is noise. Lower the guard to `win/10` (60s).

| Case | `win/4` = 150s (#21) | `win/10` = 60s (this PR) |
|---|---|---|
| Fast burn `1→5→9→10` over 90s | warming (hidden) | active (shown) |
| Real jitter, span 161s (#21 case) | 44m | 44m |
| Second-scale desync cluster, span 2s | warming | warming |

The primary jitter fix from #21 (`start = 1`) is unchanged; this only relaxes the secondary span filter. Adds a regression that a 90s `1→5→9→10` burst renders active, while the existing 2s-span noise case still falls back to warming. Burn suite green.

cc @redtear1115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
