### PR TITLE
perf(git): set GIT_OPTIONAL_LOCKS=0 for statusline git probes

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -467,6 +467,11 @@ now_strftime() {  # → _T ; $1=strftime fmt. Fork-free on bash 4.2+, one date c
 }
 
 # ── Git state (single subprocess, parsed once, used by git/stash segments) ──
+# All git below is read-only probing. Disable git's optional index lock so a
+# frequently-refreshed statusline never rewrites the index or contends for
+# index.lock with a real git operation (notably on Windows). Set once, inherited
+# by every git call here.
+export GIT_OPTIONAL_LOCKS=0
 GIT_BRANCH="" GIT_MARKS="" GIT_AB="" GIT_DIRTY=0 GIT_ROOT=""
 read_git() {
   local line oid="" head="" a="" b="" staged=0 unstaged=0 untracked=0


### PR DESCRIPTION
## What

Export `GIT_OPTIONAL_LOCKS=0` once in the git-state section so every git probe in the statusline inherits it.

## Why

The statusline's git calls are all read-only (`status`, `rev-parse`, `rev-list`), but `git status` takes git's optional index lock to refresh the index stat cache. A frequently-refreshed statusline therefore rewrites the index on every render and can contend for `index.lock` with a real git operation (notably stale `index.lock` on Windows when probes pile up). Disabling the optional lock is the standard prompt/statusline practice (p10k, starship). No change to rendered output.

## Credit

Adopts the portable half of #26 by @ArchonVII (which was withdrawn). The PR's other half, a `timeout`-bounded probe, is intentionally left out: macOS has no `timeout` / `gtimeout` by default, so it silently ran unbounded there (Codex flagged the same on that PR).

## Verification

`bash statusline.sh` renders the git segment correctly on bash 3.2 and 5.x; full test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)