### PR TITLE
fix(dir): drop stray backslash before ~ in home-relative path

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -596,7 +596,7 @@ seg_project() {  # repo-root name in a repo; falls back to dir outside one (unle
 
 seg_dir() {
   [ -n "$cwd" ] || return 0
-  local short="${cwd/#"$HOME"/\~}" n last
+  local tilde='~'; local short="${cwd/#"$HOME"/$tilde}" n last
   local IFS='/'; set -- $short; n=$#
   if [ "$n" -gt "$VL_PATH_DEPTH" ]; then
     eval "last=\${$n}"


### PR DESCRIPTION
## Problem

The `dir` segment renders a literal backslash before the tilde — `\~/path` instead of `~/path`. Because `project` falls back to `dir` outside a git repo, anyone using either segment sees it whenever the cwd is under `$HOME`.

## Root cause

This is a follow-up to 18d523a. That commit quoted `"$HOME"` to stop bash 5.3 from treating the `${cwd/#$HOME/~}` pattern as a glob — that part is correct and is kept. But it also changed the replacement from `~` to `\~` to "escape the tilde", and that escape is both unnecessary and harmful:

- Tilde expansion never happens in the replacement text of `${var/pat/repl}`, and the whole expression is already double-quoted (where `~` never expands anyway). Nothing needed escaping.
- In a double-quoted string, `\` only escapes `$`, `` ` ``, `"`, `\`, and newline — **not** `~`. So `\~` is kept verbatim, and the segment prints `\~/path`.

Reproduced on macOS's default **bash 3.2.57**:

```console
$ HOME=/h cwd=/h/p; printf '[%s]\n' "${cwd/#"$HOME"/\~}"
[\~/p]
```

## Fix

Keep the `"$HOME"` quoting (still glob-safe on 5.3) and put the tilde in a local so the replacement is an unambiguous literal — self-documenting, so the escape doesn't get re-added:

```bash
local tilde='~'; local short="${cwd/#"$HOME"/$tilde}"
```

```console
$ HOME=/h cwd=/h/p tilde='~'; printf '[%s]\n' "${cwd/#"$HOME"/$tilde}"
[~/p]
```

## Verification

- `bash -n statusline.sh` passes.
- Rendered output on bash 3.2.57 now shows ` ~/litellm-claude ` (previously ` \~/litellm-claude `).
- Edge cases checked: cwd exactly `$HOME` → `~`; cwd outside `$HOME` → unchanged absolute path.

Fixes #28.