### PR TITLE
feat: agent-guided upgrade path (UPGRADE.md) + installer "what's new" detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,34 @@ Then add to `~/.claude/settings.json`:
 > installers bundle every theme; after a manual install, copy the rest of
 > `~/.claude/coralline-src/themes/*.conf` into `~/.claude/coralline/themes/` to switch themes.
 
+### Updating
+
+Two ways to update, both driven by the same installer. Either way your
+`~/.claude/coralline.conf` is preserved and the previous `statusline.sh` is backed up
+under `~/.claude/coralline/` (the 3 newest are kept).
+
+#### Ask Claude (recommended)
+
+Paste this into Claude Code:
+
+```text
+Please update coralline for me:
+fetch https://raw.githubusercontent.com/Nanako0129/coralline/main/UPGRADE.md
+and follow the playbook in it.
+```
+
+Claude re-runs the installer, reads the "new since your installed copy" report, and
+offers to turn on any new opt-in features for you.
+
+#### Update it yourself
+
+Re-run the installer — it prints a short "new since your installed copy" report when
+something new shipped:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash -s -- --install-only
+```
+
 ## Setup
 
 Both paths use the same installer. Humans run it with no mode and get the visual setup. Claude

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -91,6 +91,31 @@ cp ~/.claude/coralline-src/themes/claude-coral.conf ~/.claude/coralline/themes/
 > **注意：** 上面的指令只複製 `claude-coral` 一個主題。「請 Claude 安裝」與一行安裝會帶上全部主題；
 > 手動安裝後若要換主題，把 `~/.claude/coralline-src/themes/*.conf` 其餘的也複製進 `~/.claude/coralline/themes/`。
 
+### 更新
+
+兩種更新方式，都由同一支 installer 驅動。無論哪種，你的 `~/.claude/coralline.conf`
+都會被保留，舊的 `statusline.sh` 會備份在 `~/.claude/coralline/` 下（保留最近 3 份）。
+
+#### 請 Claude 更新（推薦）
+
+把這段貼進 Claude Code：
+
+```text
+Please update coralline for me:
+fetch https://raw.githubusercontent.com/Nanako0129/coralline/main/UPGRADE.md
+and follow the playbook in it.
+```
+
+Claude 會重跑 installer、讀取「new since your installed copy」報告，並主動問你要不要開啟新出現的 opt-in 功能。
+
+#### 自己更新
+
+重跑 installer —— 有新東西時它會印出一段簡短的「new since your installed copy」報告：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash -s -- --install-only
+```
+
 ## 設定
 
 兩種方式都使用同一支 installer。人類不帶模式參數執行時會進入視覺化設定；

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,83 @@
+# coralline — AI Upgrade Playbook
+
+> **You are an AI coding assistant** helping a user update coralline. The installer
+> backs up the old `statusline.sh` and never touches `~/.claude/coralline.conf`. It
+> only *reports* what is new; you enable the new opt-in features additively, with the
+> user's consent.
+
+## Overview
+
+"Upgrade" means: re-run the installer in install-only mode, read the
+"new since your installed copy" report it prints, and offer to enable the new
+segments/options. The renderer (`statusline.sh`) is replaced; `coralline.conf` is
+preserved; the prior `statusline.sh` is backed up to
+`~/.claude/coralline/statusline.sh.bak.<ts>` (the 3 newest are kept).
+
+## Prerequisites
+
+`jq` and a Nerd Font terminal (or `VL_ASCII=1`). Same as install.
+
+## Fast Path
+
+Re-install the runtime without opening the wizard, capturing its stdout:
+
+    curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash -s -- --install-only
+
+From a local clone instead:
+
+    bash configure.sh --install-only
+
+Keep that output — the report it prints is the source of truth for the next step.
+
+## Read the delta
+
+The report is plain text (no color when piped) shaped as:
+
+    coralline upgrade — new since your installed copy:
+      segment  burn
+      option   VL_FLOAT=1       1 = also write a plain-text readout to VL_FLOAT_FILE
+    ~/.claude/coralline.conf preserved · backup at ~/.claude/coralline/statusline.sh.bak.20260622-100501
+
+Contract: each item line is `  <kind>  <token>  <free-text description>`. `<kind>`
+is `segment` or `option`. For `segment`, `<token>` is the segment name. For
+`option`, `<token>` is the exact assignment to add (e.g. `VL_FLOAT=1`). Everything
+after `<token>` is a human description that may contain spaces and `=` — do not
+parse it. If there is no report, the install is already current — stop here.
+
+## Enable interview
+
+For each new segment and option, ask the user whether to enable it, briefly
+explaining what it does (use the description plus your knowledge of coralline; a
+description may be a clipped first sentence). Enable only what the user approves.
+
+## Write Config
+
+First read `~/.claude/coralline.conf`. Find the existing `VL_SEGMENTS`,
+`VL_SEGMENTS2`, and `VL_SEGMENTS3` assignments (coralline aggregates all three at
+render time). Then apply only what the user approved, additively:
+
+- New segment: append it to whichever of `VL_SEGMENTS`/`VL_SEGMENTS2`/`VL_SEGMENTS3`
+  the user already uses (default: `VL_SEGMENTS`). Never add a segment already
+  present in **any** of the three, and never reorder or drop existing segments.
+- New option: append the exact enabling assignment from the report (e.g.
+  `VL_FLOAT=1`). Never change a knob the user has already set.
+
+If `coralline.conf` does not exist, create it with just the approved additions.
+
+## Verification
+
+Render once with the bundled sample to confirm it still renders and the new
+segments are present:
+
+    cat ~/.claude/coralline/sample-input.json | bash ~/.claude/coralline/statusline.sh
+
+A newly added segment like `burn` may show a neutral "warming" glyph until real
+usage data accrues — that is expected. Then tell the user to restart Claude Code
+or open a new session.
+
+## Manual fallback
+
+If the user prefers to do it themselves: rerun the wizard with
+`bash ~/.claude/coralline/configure.sh`, or edit `~/.claude/coralline.conf` by
+hand. To roll back the renderer, copy a
+`~/.claude/coralline/statusline.sh.bak.<ts>` back over `statusline.sh`.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -53,23 +53,35 @@ description may be a clipped first sentence). Enable only what the user approves
 ## Write Config
 
 First read `~/.claude/coralline.conf`. Find the existing `VL_SEGMENTS`,
-`VL_SEGMENTS2`, and `VL_SEGMENTS3` assignments (coralline aggregates all three at
-render time). Then apply only what the user approved, additively:
+`VL_SEGMENTS2`, `VL_SEGMENTS3`, and `VL_LAYOUT` assignments. Layout matters for
+where a new segment goes: in `fixed` layout (the default) all three lists render
+as separate lines, but in `auto` layout **only `VL_SEGMENTS` is rendered** —
+`VL_SEGMENTS2`/`VL_SEGMENTS3` do not display. Then apply only what the user
+approved, additively:
 
-- New segment: append it to whichever of `VL_SEGMENTS`/`VL_SEGMENTS2`/`VL_SEGMENTS3`
-  the user already uses (default: `VL_SEGMENTS`). Never add a segment already
-  present in **any** of the three, and never reorder or drop existing segments.
+- New segment: append it to `VL_SEGMENTS` by default. Only use `VL_SEGMENTS2` or
+  `VL_SEGMENTS3` when `VL_LAYOUT` is `fixed` **and** the user already populates
+  that line (in `auto` layout a segment added to `2`/`3` would never show). Never
+  add a segment already present in **any** of the three, and never reorder or drop
+  existing segments.
 - New option: append the exact enabling assignment from the report (e.g.
   `VL_FLOAT=1`). Never change a knob the user has already set.
 
-If `coralline.conf` does not exist, create it with just the approved additions.
+If `coralline.conf` does not exist, do **not** write a bare `VL_SEGMENTS="<new
+segment>"` — any `VL_SEGMENTS` assignment replaces the built-in default list, so
+that would hide every default segment. Seed the shipped default list first, then
+append the approved segments:
+
+    VL_SEGMENTS="dir git model ctx limit5h limit7d cost clock <approved segments>"
+
+followed by one line per approved option.
 
 ## Verification
 
 Render once with the bundled sample to confirm it still renders and the new
 segments are present:
 
-    cat ~/.claude/coralline/sample-input.json | bash ~/.claude/coralline/statusline.sh
+    cat ~/.claude/coralline/sample-input.json | CORALLINE_NO_SAMPLE=1 bash ~/.claude/coralline/statusline.sh
 
 A newly added segment like `burn` may show a neutral "warming" glyph until real
 usage data accrues — that is expected. Then tell the user to restart Claude Code

--- a/configure.sh
+++ b/configure.sh
@@ -1179,6 +1179,18 @@ install_files() {
   need_file "$SCRIPT_DIR/test/sample-input.json"
   [ -d "$SCRIPT_DIR/themes" ] || die "missing themes directory"
 
+  # Upgrade path: on a real overwrite, back up the old statusline.sh, and (only
+  # in install-only/agent mode, so the interactive wizard's alt-screen isn't
+  # clobbered) report what is new. Gated on a real change so identical re-runs
+  # leave no backup.
+  local _bak=""
+  if [ -f "$TARGET_DIR/statusline.sh" ] \
+    && ! cmp -s "$TARGET_DIR/statusline.sh" "$SCRIPT_DIR/statusline.sh"; then
+    _bak=$(backup_statusline "$TARGET_DIR")
+    if [ "$install_only" = "1" ]; then
+      report_upgrade_delta "$TARGET_DIR/statusline.sh" "$SCRIPT_DIR/statusline.sh" "$_bak"
+    fi
+  fi
   mkdir -p "$TARGET_DIR/themes"
   cp "$SCRIPT_DIR/statusline.sh" "$TARGET_DIR/statusline.sh"
   cp "$SCRIPT_DIR/configure.sh" "$TARGET_DIR/configure.sh"
@@ -1349,7 +1361,7 @@ main_menu() {
 for arg in "$@"; do
   case "$arg" in
     --install) install_files; update_settings ;;
-    --install-only) install_files; update_settings; install_only=1 ;;
+    --install-only) install_only=1; install_files; update_settings ;;
     --default) setup_mode="default" ;;
     --import-p10k) setup_mode="import-p10k" ;;
     --wizard) setup_mode="wizard" ;;

--- a/configure.sh
+++ b/configure.sh
@@ -129,6 +129,8 @@ theme_count() {
 
 # Derive the segment menu from the runtime's seg_* functions so a new segment in
 # statusline.sh shows up here automatically — mirrors the theme auto-scan above.
+# NOTE: segment_names() below mirrors this seg_* discovery pattern for the upgrade
+# report; keep the two in sync if the discovery regex changes.
 load_segment_choices() {
   local statusline discovered s ordered=""
   statusline=$(runtime_statusline)

--- a/configure.sh
+++ b/configure.sh
@@ -155,14 +155,16 @@ segment_names() {  # $1=statusline file
     | sed 's/^seg_//' | grep -Ev '^(len|limit)$' | sort -u | tr '\n' ' '
 }
 
-# Space-separated, sorted-unique opt-in knob names: VL_/CORALLINE_ assignments
-# whose shipped default is exactly 0 and whose line is not tagged "internal".
-# This excludes color knobs (non-0 defaults like "r,g,b") and internal vars,
-# which would otherwise flood the upgrade report. A numeric 0-default knob can
-# slip through, but such knobs pre-exist and so never appear as "new".
+# Space-separated, sorted-unique BOOLEAN opt-in knob names: VL_/CORALLINE_
+# assignments whose shipped default is exactly 0 and whose line is not tagged
+# "internal". This excludes color knobs (non-0 defaults like "r,g,b") and
+# internal vars. It also excludes value knobs whose comment documents "0 = off"
+# (e.g. VL_NAME_MAX): for those, enabling via "<knob>=1" is meaningless, and the
+# report renders every listed knob as "<knob>=1", so they must not be listed.
 knob_names() {  # $1=statusline file
   grep -E '^(VL_|CORALLINE_)[A-Za-z0-9_]+=0([[:space:]]|$)' "$1" 2>/dev/null \
     | grep -iv 'internal' \
+    | grep -v '#.*0[[:space:]]*=' \
     | sed -E 's/=0.*$//' | sort -u | tr '\n' ' '
 }
 
@@ -196,8 +198,19 @@ knob_desc() {  # $1=statusline file $2=knob name
   [ -n "$first" ] || return 0
   first=$(printf '%s\n' "$first" | sed 's/^[[:space:]]*#[[:space:]]*//')
   # Keep just the first sentence so a multi-line block yields a clean summary
-  # instead of a mid-sentence clause.
-  printf '%s\n' "${first%%. *}"
+  # instead of a mid-sentence clause. Stop at the first word ending in . ! or ?,
+  # but NOT on a known abbreviation (vs. e.g. i.e. etc.) so "5h vs. 7d windows."
+  # is not clipped to "5h vs".
+  printf '%s\n' "$first" | awk '{
+    n = split($0, w, " "); out = ""
+    for (i = 1; i <= n; i++) {
+      out = (out == "" ? w[i] : out " " w[i])
+      if (w[i] ~ /[.!?]$/ && w[i] !~ /^(vs|e\.g|i\.e|etc|cf|approx|al)\.$/) {
+        sub(/[.!?]+$/, "", out); print out; exit
+      }
+    }
+    print out
+  }'
 }
 
 # Print a "new since your installed copy" report when the new statusline adds
@@ -1181,12 +1194,15 @@ install_files() {
   need_file "$SCRIPT_DIR/test/sample-input.json"
   [ -d "$SCRIPT_DIR/themes" ] || die "missing themes directory"
 
-  # Upgrade path: on a real overwrite, back up the old statusline.sh, and (only
-  # in install-only/agent mode, so the interactive wizard's alt-screen isn't
-  # clobbered) report what is new. Gated on a real change so identical re-runs
-  # leave no backup.
+  # Upgrade path: on a real, readable overwrite, back up the old statusline.sh,
+  # and (only in install-only/agent mode) report what is new. --install drops into
+  # the menu afterward, which would scroll the report away, so it shows only for
+  # --install-only. The [ -r ] guard matters: without it an UNREADABLE old file
+  # makes cmp -s exit non-zero (read like "differs"), and segment_names/knob_names
+  # would then read it as empty and flood the report with every segment/knob as
+  # "new". Gated on a real change so identical re-runs leave no backup.
   local _bak=""
-  if [ -f "$TARGET_DIR/statusline.sh" ] \
+  if [ -f "$TARGET_DIR/statusline.sh" ] && [ -r "$TARGET_DIR/statusline.sh" ] \
     && ! cmp -s "$TARGET_DIR/statusline.sh" "$SCRIPT_DIR/statusline.sh"; then
     _bak=$(backup_statusline "$TARGET_DIR")
     if [ "$install_only" = "1" ]; then
@@ -1194,7 +1210,11 @@ install_files() {
     fi
   fi
   mkdir -p "$TARGET_DIR/themes"
-  cp "$SCRIPT_DIR/statusline.sh" "$TARGET_DIR/statusline.sh"
+  # Fail loud if the runtime overwrite cannot happen (e.g. an unreadable/unwritable
+  # old statusline.sh) instead of reporting a successful, feature-adding upgrade
+  # that never replaced the file.
+  cp "$SCRIPT_DIR/statusline.sh" "$TARGET_DIR/statusline.sh" \
+    || die "could not write $TARGET_DIR/statusline.sh (check permissions on the existing file)"
   cp "$SCRIPT_DIR/configure.sh" "$TARGET_DIR/configure.sh"
   cp "$SCRIPT_DIR/test/sample-input.json" "$TARGET_DIR/sample-input.json"
   theme_dir="$SCRIPT_DIR/themes"

--- a/configure.sh
+++ b/configure.sh
@@ -234,6 +234,24 @@ report_upgrade_delta() {  # $1=old statusline $2=new statusline $3=backup path (
   printf '\n%senable: rerun configure.sh, or let Claude wire them in (see UPGRADE.md)%s\n' "$cd" "$cr"
 }
 
+# Back up an install dir's statusline.sh to statusline.sh.bak.<ts> (mirrors the
+# settings.json.bak.<ts> convention), keep only the 3 newest, and echo the new
+# backup path. Echo nothing on failure or when statusline.sh is absent (fail
+# open). A single-file copy, so a symlinked install dir is harmless.
+backup_statusline() {  # $1=install dir
+  # Keep the N newest timestamped backups; prune older ones. A rollback safety
+  # net, not history — a few recent copies cover slip-ups without piling up.
+  local dir="$1" src="$1/statusline.sh" bak old keep_backups=3
+  [ -f "$src" ] || return 0
+  bak="${src}.bak.$(date +%Y%m%d-%H%M%S)"
+  [ -e "$bak" ] && bak="${bak}.$$"
+  cp "$src" "$bak" 2>/dev/null || return 0
+  printf '%s\n' "$bak"
+  ls -1t "${src}".bak.* 2>/dev/null | tail -n +$((keep_backups + 1)) | while IFS= read -r old; do
+    rm -f "$old" 2>/dev/null
+  done
+}
+
 segment_total() {
   set -- $SEGMENT_CHOICES
   printf '%s\n' "$#"

--- a/configure.sh
+++ b/configure.sh
@@ -198,6 +198,42 @@ knob_desc() {  # $1=statusline file $2=knob name
   printf '%s\n' "${first%%. *}"
 }
 
+# Print a "new since your installed copy" report when the new statusline adds
+# segments or opt-in knobs the old one lacked. Silent on fresh install or no
+# delta. Reports only — never writes config. Emits color only on a tty so the
+# piped/agent path gets clean, parseable text.
+report_upgrade_delta() {  # $1=old statusline $2=new statusline $3=backup path (may be empty)
+  local old="$1" new="$2" bak="${3:-}"
+  [ -f "$old" ] && [ -f "$new" ] || return 0
+  local cb="" cr="" cc="" cd=""
+  if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    cb="${T_BOLD:-}"; cr="${T_RESET:-}"; cc="${T_CORAL:-}"; cd="${T_DIM:-}"
+  fi
+  local IFS=' '
+  local old_segs new_segs old_knobs new_knobs s k d seglist="" knoblist=""
+  old_segs=" $(segment_names "$old") " ; new_segs=" $(segment_names "$new") "
+  for s in $new_segs; do
+    case "$old_segs" in *" $s "*) : ;; *) seglist="${seglist}${seglist:+ }$s" ;; esac
+  done
+  old_knobs=" $(knob_names "$old") " ; new_knobs=" $(knob_names "$new") "
+  for k in $new_knobs; do
+    case "$old_knobs" in *" $k "*) : ;; *) knoblist="${knoblist}${knoblist:+ }$k" ;; esac
+  done
+  [ -n "$seglist" ] || [ -n "$knoblist" ] || return 0
+  printf '\n%scoralline upgrade — new since your installed copy:%s\n' "$cb" "$cr"
+  for s in $seglist; do
+    d=$(segment_desc "$new" "$s")
+    printf '  segment  %s%-16s%s %s\n' "$cc" "$s" "$cr" "$d"
+  done
+  for k in $knoblist; do
+    d=$(knob_desc "$new" "$k")
+    printf '  option   %s%-16s%s %s\n' "$cc" "${k}=1" "$cr" "$d"
+  done
+  printf '%s~/.claude/coralline.conf preserved%s' "$cd" "$cr"
+  [ -n "$bak" ] && printf '%s · backup at %s%s' "$cd" "$bak" "$cr"
+  printf '\n%senable: rerun configure.sh, or let Claude wire them in (see UPGRADE.md)%s\n' "$cd" "$cr"
+}
+
 segment_total() {
   set -- $SEGMENT_CHOICES
   printf '%s\n' "$#"

--- a/configure.sh
+++ b/configure.sh
@@ -164,6 +164,40 @@ knob_names() {  # $1=statusline file
     | sed -E 's/=0.*$//' | sort -u | tr '\n' ' '
 }
 
+# Inline comment after `seg_<name>() {`, else empty.
+segment_desc() {  # $1=statusline file $2=segment name
+  local line
+  line=$(grep -E "^seg_$2\(\) \{" "$1" 2>/dev/null | head -1)
+  case "$line" in
+    *\#*) printf '%s\n' "${line#*\#}" | sed 's/^[[:space:]]*//' ;;
+  esac
+}
+
+# Trailing inline comment on the knob's declaration line; else the FIRST SENTENCE
+# of the contiguous # comment block immediately above it; else empty.
+knob_desc() {  # $1=statusline file $2=knob name
+  local file="$1" name="$2" ln line i first=""
+  ln=$(grep -nE "^$name=" "$file" 2>/dev/null | head -1 | cut -d: -f1)
+  [ -n "$ln" ] || return 0
+  line=$(sed -n "${ln}p" "$file")
+  case "$line" in
+    *\#*) printf '%s\n' "${line#*\#}" | sed 's/^[[:space:]]*//'; return 0 ;;
+  esac
+  i=$((ln - 1))
+  while [ "$i" -ge 1 ]; do
+    line=$(sed -n "${i}p" "$file")
+    case "$line" in
+      \#*|[[:space:]]*\#*) first="$line"; i=$((i - 1)) ;;
+      *) break ;;
+    esac
+  done
+  [ -n "$first" ] || return 0
+  first=$(printf '%s\n' "$first" | sed 's/^[[:space:]]*#[[:space:]]*//')
+  # Keep just the first sentence so a multi-line block yields a clean summary
+  # instead of a mid-sentence clause.
+  printf '%s\n' "${first%%. *}"
+}
+
 segment_total() {
   set -- $SEGMENT_CHOICES
   printf '%s\n' "$#"

--- a/configure.sh
+++ b/configure.sh
@@ -146,6 +146,24 @@ load_segment_choices() {
   SEGMENT_CHOICES="$ordered"
 }
 
+# Space-separated, sorted-unique segment names in a statusline file. Mirrors
+# load_segment_choices' discovery so detection and the wizard agree on "segment".
+segment_names() {  # $1=statusline file
+  grep -oE '^seg_[A-Za-z0-9_]+' "$1" 2>/dev/null \
+    | sed 's/^seg_//' | grep -Ev '^(len|limit)$' | sort -u | tr '\n' ' '
+}
+
+# Space-separated, sorted-unique opt-in knob names: VL_/CORALLINE_ assignments
+# whose shipped default is exactly 0 and whose line is not tagged "internal".
+# This excludes color knobs (non-0 defaults like "r,g,b") and internal vars,
+# which would otherwise flood the upgrade report. A numeric 0-default knob can
+# slip through, but such knobs pre-exist and so never appear as "new".
+knob_names() {  # $1=statusline file
+  grep -E '^(VL_|CORALLINE_)[A-Za-z0-9_]+=0([[:space:]]|$)' "$1" 2>/dev/null \
+    | grep -iv 'internal' \
+    | sed -E 's/=0.*$//' | sort -u | tr '\n' ' '
+}
+
 segment_total() {
   set -- $SEGMENT_CHOICES
   printf '%s\n' "$#"

--- a/test/test-upgrade.sh
+++ b/test/test-upgrade.sh
@@ -170,4 +170,14 @@ rc6=$?; chmod 700 "$home6/coralline" 2>/dev/null
 [ "$rc6" = "0" ] && check "E6 unwritable backup: install succeeds" 1 || check "E6 unwritable backup: install succeeds" 0
 printf '%s\n' "$out6" | grep -q 'backup at' && check "E6 unwritable backup: no backup line" 0 || check "E6 unwritable backup: no backup line" 1
 
+# ---- Section F: UPGRADE.md structure -------------------------------------
+UP="$REPO/UPGRADE.md"
+[ -f "$UP" ] && check "UPGRADE.md exists" 1 || check "UPGRADE.md exists" 0
+for h in '## Overview' '## Fast Path' '## Read the delta' '## Enable interview' '## Write Config' '## Verification' '## Manual fallback'; do
+  grep -qF "$h" "$UP" 2>/dev/null && check "UPGRADE.md has '$h'" 1 || check "UPGRADE.md has '$h'" 0
+done
+grep -q -- '--install-only' "$UP" 2>/dev/null && check "UPGRADE.md drives --install-only" 1 || check "UPGRADE.md drives --install-only" 0
+grep -q 'VL_SEGMENTS2' "$UP" 2>/dev/null && check "UPGRADE.md handles VL_SEGMENTS2/3" 1 || check "UPGRADE.md handles VL_SEGMENTS2/3" 0
+grep -qi 'AI coding assistant' "$UP" 2>/dev/null && check "UPGRADE.md has AI callout" 1 || check "UPGRADE.md has AI callout" 0
+
 if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "SOME FAILED"; exit 1; fi

--- a/test/test-upgrade.sh
+++ b/test/test-upgrade.sh
@@ -116,4 +116,58 @@ nbak=$(ls -1 "$tmp/inst/coralline"/statusline.sh.bak.* 2>/dev/null | wc -l | tr 
 mkdir -p "$tmp/inst/empty"
 [ -z "$(backup_statusline "$tmp/inst/empty")" ] && check "absent statusline → empty path" 1 || check "absent statusline → empty path" 0
 
+# ---- Section E: install_files integration (sandboxed) --------------------
+mk_old_install() {  # $1=home/.claude dir ; creates an OLD install missing seg_burn
+  mkdir -p "$1/coralline"
+  printf 'seg_dir() { :; }\nVL_ASCII=0\n' > "$1/coralline/statusline.sh"
+  printf 'VL_THEME="claude-coral"\n'       > "$1/coralline.conf"
+}
+
+# (E1) upgrade with new content → report + backup, conf preserved
+home="$tmp/h1/.claude"; mk_old_install "$home"
+conf_before=$(cat "$home/coralline.conf")
+out=$(CORALLINE_HOME="$home/coralline" CLAUDE_SETTINGS="$home/settings.json" \
+      bash "$CONF" --install-only 2>&1)
+printf '%s\n' "$out" | grep -q 'new since your installed copy' && check "E1 install-only prints report" 1 || check "E1 install-only prints report" 0
+printf '%s\n' "$out" | grep -qE 'segment +burn' && check "E1 report includes burn" 1 || check "E1 report includes burn" 0
+bak=$(ls -1 "$home"/coralline/statusline.sh.bak.* 2>/dev/null | head -1)
+[ -n "$bak" ] && [ "$(head -1 "$bak" 2>/dev/null)" = "seg_dir() { :; }" ] \
+  && check "E1 backup holds OLD statusline" 1 || check "E1 backup holds OLD statusline" 0
+[ "$(cat "$home/coralline.conf")" = "$conf_before" ] && check "E1 coralline.conf untouched" 1 || check "E1 coralline.conf untouched" 0
+grep -q 'seg_burn' "$home/coralline/statusline.sh" && check "E1 new runtime installed" 1 || check "E1 new runtime installed" 0
+
+# (E2) fresh install (no prior) → no report, no backup
+home2="$tmp/h2/.claude"; mkdir -p "$home2"
+out2=$(CORALLINE_HOME="$home2/coralline" CLAUDE_SETTINGS="$home2/settings.json" bash "$CONF" --install-only 2>&1)
+printf '%s\n' "$out2" | grep -q 'new since your installed copy' && check "E2 fresh: no report" 0 || check "E2 fresh: no report" 1
+ls "$home2"/coralline/statusline.sh.bak.* >/dev/null 2>&1 && check "E2 fresh: no backup" 0 || check "E2 fresh: no backup" 1
+
+# (E3) identical re-run → no backup, no report
+home3="$tmp/h3/.claude"; mkdir -p "$home3/coralline"
+cp "$REPO/statusline.sh" "$home3/coralline/statusline.sh"
+out3=$(CORALLINE_HOME="$home3/coralline" CLAUDE_SETTINGS="$home3/settings.json" bash "$CONF" --install-only 2>&1)
+printf '%s\n' "$out3" | grep -q 'new since your installed copy' && check "E3 identical: no report" 0 || check "E3 identical: no report" 1
+ls "$home3"/coralline/statusline.sh.bak.* >/dev/null 2>&1 && check "E3 identical: no backup" 0 || check "E3 identical: no backup" 1
+
+# (E4) bugfix-only overwrite (differs, but exposes no new seg/knob) → backup, NO report
+home4="$tmp/h4/.claude"; mkdir -p "$home4/coralline"
+sed '1s/^/# bugfix comment\n/' "$REPO/statusline.sh" > "$home4/coralline/statusline.sh"
+out4=$(CORALLINE_HOME="$home4/coralline" CLAUDE_SETTINGS="$home4/settings.json" bash "$CONF" --install-only 2>&1)
+printf '%s\n' "$out4" | grep -q 'new since your installed copy' && check "E4 bugfix-only: no report" 0 || check "E4 bugfix-only: no report" 1
+ls "$home4"/coralline/statusline.sh.bak.* >/dev/null 2>&1 && check "E4 bugfix-only: backup taken" 1 || check "E4 bugfix-only: backup taken" 0
+
+# (E5) unreadable old statusline → install still succeeds (fail-open)
+home5="$tmp/h5/.claude"; mk_old_install "$home5"; chmod 000 "$home5/coralline/statusline.sh"
+CORALLINE_HOME="$home5/coralline" CLAUDE_SETTINGS="$home5/settings.json" bash "$CONF" --install-only >/dev/null 2>&1
+rc=$?; chmod 644 "$home5/coralline/statusline.sh" 2>/dev/null
+[ "$rc" = "0" ] && check "E5 unreadable old: install succeeds" 1 || check "E5 unreadable old: install succeeds" 0
+
+# (E6) unwritable backup target → install still succeeds, no backup line (fail-open)
+home6="$tmp/h6/.claude"; mk_old_install "$home6"
+chmod 500 "$home6/coralline"   # dir read+exec only → cp of new bak fails
+out6=$(CORALLINE_HOME="$home6/coralline" CLAUDE_SETTINGS="$home6/settings.json" bash "$CONF" --install-only 2>&1)
+rc6=$?; chmod 700 "$home6/coralline" 2>/dev/null
+[ "$rc6" = "0" ] && check "E6 unwritable backup: install succeeds" 1 || check "E6 unwritable backup: install succeeds" 0
+printf '%s\n' "$out6" | grep -q 'backup at' && check "E6 unwritable backup: no backup line" 0 || check "E6 unwritable backup: no backup line" 1
+
 if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "SOME FAILED"; exit 1; fi

--- a/test/test-upgrade.sh
+++ b/test/test-upgrade.sh
@@ -96,4 +96,24 @@ rep3=$(T_BOLD=$'\033[1m' T_RESET=$'\033[0m' T_CORAL=$'\033[38;5;173m' T_DIM=$'\0
        report_upgrade_delta "$tmp/old.sh" "$tmp/new.sh" "")
 case "$rep3" in *$'\033'*) check "no ANSI when piped (non-tty)" 0 ;; *) check "no ANSI when piped (non-tty)" 1 ;; esac
 
+# ---- Section D: backup_statusline ----------------------------------------
+eval "$(sed -n '/^backup_statusline() {/,/^}/p' "$CONF")"
+
+mkdir -p "$tmp/inst/coralline"
+printf 'OLD-RUNTIME\n' > "$tmp/inst/coralline/statusline.sh"
+bpath=$(backup_statusline "$tmp/inst/coralline")
+[ -n "$bpath" ] && [ -f "$bpath" ] && check "backup file created" 1 || check "backup file created" 0
+[ "$(cat "$bpath" 2>/dev/null)" = "OLD-RUNTIME" ] && check "backup holds old statusline" 1 || check "backup holds old statusline" 0
+case "$bpath" in "$tmp/inst/coralline/statusline.sh.bak."*) check "backup path matches statusline.sh.bak.<ts>" 1 ;; *) check "backup path matches statusline.sh.bak.<ts>" 0 ;; esac
+
+# Keep only the 3 newest: seed 4 older backups, then back up once more.
+for n in 1 2 3 4; do : > "$tmp/inst/coralline/statusline.sh.bak.2020010${n}-000000"; done
+backup_statusline "$tmp/inst/coralline" >/dev/null
+nbak=$(ls -1 "$tmp/inst/coralline"/statusline.sh.bak.* 2>/dev/null | wc -l | tr -d ' ')
+[ "$nbak" = "3" ] && check "prunes to 3 newest backups" 1 || check "prunes to 3 newest backups (got $nbak)" 0
+
+# Absent statusline → empty, no crash.
+mkdir -p "$tmp/inst/empty"
+[ -z "$(backup_statusline "$tmp/inst/empty")" ] && check "absent statusline → empty path" 1 || check "absent statusline → empty path" 0
+
 if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "SOME FAILED"; exit 1; fi

--- a/test/test-upgrade.sh
+++ b/test/test-upgrade.sh
@@ -71,4 +71,29 @@ eval "$(sed -n '/^knob_desc() {/,/^}/p'    "$CONF")"
 [ "$(knob_desc "$tmp/new.sh" VL_LIMIT_SYNC)" = "Cross-session limit sync (opt-in)" ] \
   && check "knob_desc reads first sentence of block (VL_LIMIT_SYNC)" 1 || check "knob_desc reads first sentence of block (VL_LIMIT_SYNC)" 0
 
+# ---- Section C: report_upgrade_delta -------------------------------------
+eval "$(sed -n '/^report_upgrade_delta() {/,/^}/p' "$CONF")"
+
+rep=$(report_upgrade_delta "$tmp/old.sh" "$tmp/new.sh" "/home/u/.claude/coralline/statusline.sh.bak.20260622-100501")
+printf '%s\n' "$rep" | grep -q 'new since your installed copy' && check "report has header" 1 || check "report has header" 0
+printf '%s\n' "$rep" | grep -qE 'segment +burn'                 && check "report lists burn segment" 1 || check "report lists burn segment" 0
+printf '%s\n' "$rep" | grep -qE 'option +VL_FLOAT=1'            && check "report lists VL_FLOAT=1" 1 || check "report lists VL_FLOAT=1" 0
+printf '%s\n' "$rep" | grep -q 'also write a plain-text readout' && check "report shows knob desc" 1 || check "report shows knob desc" 0
+printf '%s\n' "$rep" | grep -q 'backup at /home/u/.claude/coralline/statusline.sh.bak.20260622-100501' && check "report names backup path" 1 || check "report names backup path" 0
+printf '%s\n' "$rep" | grep -qE 'option +VL_BG_BURN' && check "report omits filtered color knob" 0 || check "report omits filtered color knob" 1
+
+# No backup path → no backup line, but still a report.
+rep2=$(report_upgrade_delta "$tmp/old.sh" "$tmp/new.sh" "")
+printf '%s\n' "$rep2" | grep -q 'backup at' && check "no backup line when path empty" 0 || check "no backup line when path empty" 1
+
+# Identical files → no delta → silent.
+[ -z "$(report_upgrade_delta "$tmp/new.sh" "$tmp/new.sh" "")" ] && check "silent when no new segments/knobs" 1 || check "silent when no new segments/knobs" 0
+# Missing old file → silent.
+[ -z "$(report_upgrade_delta "$tmp/nope.sh" "$tmp/new.sh" "")" ] && check "silent when old file absent" 1 || check "silent when old file absent" 0
+
+# No ANSI escapes when stdout is not a tty, even with real color vars set.
+rep3=$(T_BOLD=$'\033[1m' T_RESET=$'\033[0m' T_CORAL=$'\033[38;5;173m' T_DIM=$'\033[2m' \
+       report_upgrade_delta "$tmp/old.sh" "$tmp/new.sh" "")
+case "$rep3" in *$'\033'*) check "no ANSI when piped (non-tty)" 0 ;; *) check "no ANSI when piped (non-tty)" 1 ;; esac
+
 if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "SOME FAILED"; exit 1; fi

--- a/test/test-upgrade.sh
+++ b/test/test-upgrade.sh
@@ -57,4 +57,18 @@ case "$knobs" in *" VL_LIMIT_SYNC "*) check "knob_names finds VL_LIMIT_SYNC" 1 ;
 case "$knobs" in *" VL_BG_BURN "*)    check "knob_names EXCLUDES color knob (non-0 default)" 0 ;; *) check "knob_names EXCLUDES color knob (non-0 default)" 1 ;; esac
 case "$knobs" in *" VL_NOCOLOR "*)    check "knob_names EXCLUDES internal-tagged knob" 0 ;; *) check "knob_names EXCLUDES internal-tagged knob" 1 ;; esac
 
+# ---- Section B: description extractors ------------------------------------
+eval "$(sed -n '/^segment_desc() {/,/^}/p' "$CONF")"
+eval "$(sed -n '/^knob_desc() {/,/^}/p'    "$CONF")"
+
+[ "$(segment_desc "$tmp/new.sh" effort)" = "reasoning effort level (low/medium/high)" ] \
+  && check "segment_desc reads inline comment (effort)" 1 || check "segment_desc reads inline comment (effort)" 0
+[ -z "$(segment_desc "$tmp/new.sh" burn)" ] \
+  && check "segment_desc empty when no comment (burn)" 1 || check "segment_desc empty when no comment (burn)" 0
+
+[ "$(knob_desc "$tmp/new.sh" VL_FLOAT)" = "1 = also write a plain-text readout to VL_FLOAT_FILE" ] \
+  && check "knob_desc reads inline comment (VL_FLOAT)" 1 || check "knob_desc reads inline comment (VL_FLOAT)" 0
+[ "$(knob_desc "$tmp/new.sh" VL_LIMIT_SYNC)" = "Cross-session limit sync (opt-in)" ] \
+  && check "knob_desc reads first sentence of block (VL_LIMIT_SYNC)" 1 || check "knob_desc reads first sentence of block (VL_LIMIT_SYNC)" 0
+
 if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "SOME FAILED"; exit 1; fi

--- a/test/test-upgrade.sh
+++ b/test/test-upgrade.sh
@@ -36,7 +36,7 @@ seg_effort() {  # reasoning effort level (low/medium/high)
   :
 }
 VL_ASCII=0
-VL_NAME_MAX=0
+VL_NAME_MAX=0                   # max chars for names before truncation (0 = off)
 VL_BG_DIR="0,0,0"
 VL_BG_BURN="1,2,3"
 VL_FLOAT=0                      # 1 = also write a plain-text readout to VL_FLOAT_FILE
@@ -56,6 +56,7 @@ case "$knobs" in *" VL_FLOAT "*)      check "knob_names finds VL_FLOAT"      1 ;
 case "$knobs" in *" VL_LIMIT_SYNC "*) check "knob_names finds VL_LIMIT_SYNC" 1 ;; *) check "knob_names finds VL_LIMIT_SYNC" 0 ;; esac
 case "$knobs" in *" VL_BG_BURN "*)    check "knob_names EXCLUDES color knob (non-0 default)" 0 ;; *) check "knob_names EXCLUDES color knob (non-0 default)" 1 ;; esac
 case "$knobs" in *" VL_NOCOLOR "*)    check "knob_names EXCLUDES internal-tagged knob" 0 ;; *) check "knob_names EXCLUDES internal-tagged knob" 1 ;; esac
+case "$knobs" in *" VL_NAME_MAX "*)   check "knob_names EXCLUDES numeric 0=off value knob" 0 ;; *) check "knob_names EXCLUDES numeric 0=off value knob" 1 ;; esac
 
 # ---- Section B: description extractors ------------------------------------
 eval "$(sed -n '/^segment_desc() {/,/^}/p' "$CONF")"
@@ -117,6 +118,10 @@ mkdir -p "$tmp/inst/empty"
 [ -z "$(backup_statusline "$tmp/inst/empty")" ] && check "absent statusline → empty path" 1 || check "absent statusline → empty path" 0
 
 # ---- Section E: install_files integration (sandboxed) --------------------
+# Permission-bit cases (E5/E6) behave differently under root: UID 0 bypasses the
+# mode bits, so the cp neither fails nor is blocked. Gate those assertions on a
+# non-root uid and assert the root-equivalent outcome otherwise.
+IS_ROOT=0; [ "$(id -u 2>/dev/null)" = "0" ] && IS_ROOT=1
 mk_old_install() {  # $1=home/.claude dir ; creates an OLD install missing seg_burn
   mkdir -p "$1/coralline"
   printf 'seg_dir() { :; }\nVL_ASCII=0\n' > "$1/coralline/statusline.sh"
@@ -126,7 +131,7 @@ mk_old_install() {  # $1=home/.claude dir ; creates an OLD install missing seg_b
 # (E1) upgrade with new content → report + backup, conf preserved
 home="$tmp/h1/.claude"; mk_old_install "$home"
 conf_before=$(cat "$home/coralline.conf")
-out=$(CORALLINE_HOME="$home/coralline" CLAUDE_SETTINGS="$home/settings.json" \
+out=$(CORALLINE_HOME="$home/coralline" CORALLINE_CONFIG="$home/coralline.conf" CLAUDE_SETTINGS="$home/settings.json" \
       bash "$CONF" --install-only 2>&1)
 printf '%s\n' "$out" | grep -q 'new since your installed copy' && check "E1 install-only prints report" 1 || check "E1 install-only prints report" 0
 printf '%s\n' "$out" | grep -qE 'segment +burn' && check "E1 report includes burn" 1 || check "E1 report includes burn" 0
@@ -156,11 +161,20 @@ out4=$(CORALLINE_HOME="$home4/coralline" CLAUDE_SETTINGS="$home4/settings.json" 
 printf '%s\n' "$out4" | grep -q 'new since your installed copy' && check "E4 bugfix-only: no report" 0 || check "E4 bugfix-only: no report" 1
 ls "$home4"/coralline/statusline.sh.bak.* >/dev/null 2>&1 && check "E4 bugfix-only: backup taken" 1 || check "E4 bugfix-only: backup taken" 0
 
-# (E5) unreadable old statusline → install still succeeds (fail-open)
+# (E5) unreadable old statusline.sh → installer FAILS LOUDLY (the overwrite cp
+# cannot replace a mode-000 file) and prints NO flood "everything is new" report.
+# Previously it silently exited 0 while the runtime was never actually replaced.
 home5="$tmp/h5/.claude"; mk_old_install "$home5"; chmod 000 "$home5/coralline/statusline.sh"
-CORALLINE_HOME="$home5/coralline" CLAUDE_SETTINGS="$home5/settings.json" bash "$CONF" --install-only >/dev/null 2>&1
+out5=$(CORALLINE_HOME="$home5/coralline" CORALLINE_CONFIG="$home5/coralline.conf" CLAUDE_SETTINGS="$home5/settings.json" bash "$CONF" --install-only 2>&1)
 rc=$?; chmod 644 "$home5/coralline/statusline.sh" 2>/dev/null
-[ "$rc" = "0" ] && check "E5 unreadable old: install succeeds" 1 || check "E5 unreadable old: install succeeds" 0
+if [ "$IS_ROOT" = "1" ]; then
+  # root reads/writes the mode-000 file, so the upgrade goes through normally.
+  { [ "$rc" = "0" ] && grep -q 'seg_burn' "$home5/coralline/statusline.sh"; } \
+    && check "E5 (root) unreadable old: upgrade still installs" 1 || check "E5 (root) unreadable old: upgrade still installs" 0
+else
+  [ "$rc" != "0" ] && check "E5 unreadable old: install fails loudly" 1 || check "E5 unreadable old: install fails loudly" 0
+  printf '%s\n' "$out5" | grep -q 'new since your installed copy' && check "E5 unreadable old: no flood report" 0 || check "E5 unreadable old: no flood report" 1
+fi
 
 # (E6) unwritable backup target → install still succeeds, no backup line (fail-open)
 home6="$tmp/h6/.claude"; mk_old_install "$home6"
@@ -168,7 +182,11 @@ chmod 500 "$home6/coralline"   # dir read+exec only → cp of new bak fails
 out6=$(CORALLINE_HOME="$home6/coralline" CLAUDE_SETTINGS="$home6/settings.json" bash "$CONF" --install-only 2>&1)
 rc6=$?; chmod 700 "$home6/coralline" 2>/dev/null
 [ "$rc6" = "0" ] && check "E6 unwritable backup: install succeeds" 1 || check "E6 unwritable backup: install succeeds" 0
-printf '%s\n' "$out6" | grep -q 'backup at' && check "E6 unwritable backup: no backup line" 0 || check "E6 unwritable backup: no backup line" 1
+if [ "$IS_ROOT" != "1" ]; then
+  # root bypasses the unwritable dir and would create the backup, so only assert
+  # the "no backup line" fail-open behavior when the mode bits actually apply.
+  printf '%s\n' "$out6" | grep -q 'backup at' && check "E6 unwritable backup: no backup line" 0 || check "E6 unwritable backup: no backup line" 1
+fi
 
 # ---- Section F: UPGRADE.md structure -------------------------------------
 UP="$REPO/UPGRADE.md"

--- a/test/test-upgrade.sh
+++ b/test/test-upgrade.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Unit + integration tests for the agent-guided upgrade detection in configure.sh.
+#   bash test/test-upgrade.sh
+# Needs bash + jq + coreutils (grep/sed/cmp/cp).
+set -u
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+REPO=$(cd "$HERE/.." && pwd)
+CONF="$REPO/configure.sh"
+fail=0
+check() { if [ "$2" = "1" ]; then printf 'ok    %s\n' "$1"; else printf 'FAIL  %s\n' "$1"; fail=1; fi; }
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/coralline-upgrade-test.XXXXXX") || exit 1
+trap 'rm -rf "$tmp"' EXIT
+
+# Color vars the report reads — left empty here; the no-ANSI test sets real ones.
+T_BOLD="" ; T_RESET="" ; T_CORAL="" ; T_DIM=""
+
+# Pull the pure functions out of configure.sh so the test cannot drift.
+eval "$(sed -n '/^segment_names() {/,/^}/p' "$CONF")"
+eval "$(sed -n '/^knob_names() {/,/^}/p'    "$CONF")"
+
+# ---- fixtures: an OLD and a NEW statusline.sh -----------------------------
+cat > "$tmp/old.sh" <<'OLD'
+seg_dir() { :; }
+seg_model() { :; }
+VL_ASCII=0
+VL_NAME_MAX=0
+VL_BG_DIR="0,0,0"
+OLD
+cat > "$tmp/new.sh" <<'NEW'
+seg_dir() { :; }
+seg_model() { :; }
+seg_burn() { :; }
+seg_effort() {  # reasoning effort level (low/medium/high)
+  :
+}
+VL_ASCII=0
+VL_NAME_MAX=0
+VL_BG_DIR="0,0,0"
+VL_BG_BURN="1,2,3"
+VL_FLOAT=0                      # 1 = also write a plain-text readout to VL_FLOAT_FILE
+VL_NOCOLOR=0                    # internal: fg()/bg() emit nothing when 1
+# Cross-session limit sync (opt-in). Records high-water across sessions so
+# idle sessions converge when they next redraw.
+VL_LIMIT_SYNC=0
+NEW
+
+# ---- Section A: name extractors ------------------------------------------
+segs=" $(segment_names "$tmp/new.sh") "
+case "$segs" in *" burn "*)   check "segment_names finds burn"   1 ;; *) check "segment_names finds burn"   0 ;; esac
+case "$segs" in *" effort "*) check "segment_names finds effort" 1 ;; *) check "segment_names finds effort" 0 ;; esac
+
+knobs=" $(knob_names "$tmp/new.sh") "
+case "$knobs" in *" VL_FLOAT "*)      check "knob_names finds VL_FLOAT"      1 ;; *) check "knob_names finds VL_FLOAT"      0 ;; esac
+case "$knobs" in *" VL_LIMIT_SYNC "*) check "knob_names finds VL_LIMIT_SYNC" 1 ;; *) check "knob_names finds VL_LIMIT_SYNC" 0 ;; esac
+case "$knobs" in *" VL_BG_BURN "*)    check "knob_names EXCLUDES color knob (non-0 default)" 0 ;; *) check "knob_names EXCLUDES color knob (non-0 default)" 1 ;; esac
+case "$knobs" in *" VL_NOCOLOR "*)    check "knob_names EXCLUDES internal-tagged knob" 0 ;; *) check "knob_names EXCLUDES internal-tagged knob" 1 ;; esac
+
+if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "SOME FAILED"; exit 1; fi


### PR DESCRIPTION
## What

Adds an **agent-guided upgrade path**, mirroring the existing `INSTALL.md` playbook. On a re-install over an existing `~/.claude/coralline`, `configure.sh` presence-diffs the installed vs new `statusline.sh` to detect **new segments and new opt-in options**, backs up the old `statusline.sh`, and prints a report. The installer only **reports + backs up**; a new `UPGRADE.md` playbook drives an agent to enable the new features into `coralline.conf` **additively**.

The report the installer prints in `--install-only` mode (this is real output from upgrading a v0.4.0 install to current):

```
coralline upgrade — new since your installed copy:
  segment  burn
  option   VL_FLOAT=1       1 = also write a plain-text readout to VL_FLOAT_FILE (bring your own carrier)
  option   VL_LIMIT_SYNC=1  Cross-session limit sync (opt-in)
~/.claude/coralline.conf preserved · backup at ~/.claude/coralline/statusline.sh.bak.<ts>
enable: rerun configure.sh, or let Claude wire them in (see UPGRADE.md)
```

## Why

Today "update" is an implicit, undocumented "re-run the installer." It copies fresh files, but there is no `UPGRADE.md` / `CHANGELOG` / version string, so a user who installed a while ago has no signal they're behind — and coralline's best recent additions (the `burn` segment, `VL_FLOAT`, cross-session `VL_LIMIT_SYNC`) are off by default, so they **ship dark**: re-running gets the new `statusline.sh`, but the user never learns the new opt-ins exist. The gap isn't the copy mechanic; it's **guidance + new-feature surfacing + a one-step path to enable**, exactly what `INSTALL.md` already nails for first install.

## How it works

- **Detection** (`report_upgrade_delta`, presence-diff of installed vs new `statusline.sh`):
  - **New segments** — diff `seg_*` function names (`segment_names`), reusing `load_segment_choices`' existing discovery; the two carry cross-reference comments to avoid drift.
  - **New options** — diff `VL_`/`CORALLINE_` knobs (`knob_names`), **filtered to genuine boolean opt-ins**: default `0`, not tagged `internal`. Descriptions come from each item's inline comment (or the first sentence of the block above).
- **Backup** (`backup_statusline`) — on a real overwrite (gated by `cmp -s`), copy `statusline.sh` → `statusline.sh.bak.<ts>`, keep the 3 newest, **fail-open**. Single-file, mirroring the existing `settings.json.bak.<ts>` convention.
- **Wiring** — both run in `install_files()` before the `cp`. The report prints **only in `--install-only` mode** (so the interactive wizard's alt-screen TUI isn't clobbered); the backup runs in both modes.
- **`UPGRADE.md`** — the agent drives `--install-only`, reads the report, interviews the user, and appends approved segments to `VL_SEGMENTS` (deduping across `VL_SEGMENTS`/`2`/`3`) and approved options as `=1` — never rewriting existing config.

## Design choices

- **Default-off, no behavior change.** Fresh install and identical re-run produce no report and no backup; output is unchanged. The new code only fires when an existing install is genuinely being overwritten.
- **Installer reports, agent enables.** Mirrors the existing `INSTALL.md` / `configure.sh` split and keeps the installer change small — the "interview + write config" intelligence lives in the playbook, not the installer.
- **Conservative knob filter.** Unfiltered, the current runtime's 49 column-0 knobs would surface the entire `VL_BG_*`/`VL_FG_*` color palette and internal vars as bogus "options." Restricting to default-`0`, non-`internal` knobs reduces that to the handful that are genuine boolean toggles, so the report stays signal — segments remain the primary source of truth.
- **Parseable report.** No ANSI escapes when stdout isn't a tty, so an agent gets clean text; a documented `<kind> <token> <description>` line contract.
- **Bounded, non-destructive backup.** A single `statusline.sh.bak.<ts>` file (not a full-dir copy), keep-3, fail-open — `statusline.sh` is the only file both overwritten and potentially hand-edited (themes are additive, `coralline.conf` is untouched).
- **Pure-bash, fork-frugal, bash 3.2 / macOS-safe, no new dependency.** Detection is `grep`/`sed`; backup adds one `cmp`/`date`/`cp`/prune, all at install time, never on the render path.
- **Feature-presence detection**, not version-based — no version scheme needed to ship.

## Enabling / usage

Nothing to enable — re-running the installer surfaces the report automatically when something is new:

```bash
curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash -s -- --install-only
```

`README.md` gains an "Updating" section, and `UPGRADE.md` is the agent playbook (fetch it and follow it, like `INSTALL.md`).

## Testing

`test/test-upgrade.sh` — unit tests (the four extractors incl. the knob filter excluding color/internal knobs; `report_upgrade_delta` incl. the no-ANSI-when-piped guarantee with real color vars set; `backup_statusline` create + prune-to-3) plus a **sandboxed `--install-only` integration** (`CORALLINE_HOME`/`CLAUDE_SETTINGS` redirected) covering: upgrade with new content, fresh install, identical re-run, bugfix-only overwrite (backup but no report), unreadable old `statusline.sh`, and unwritable backup target — asserting fail-open and that `coralline.conf` is never touched. All suites pass (`test-upgrade`, `test-configure-float`, `test-float`, `test-burn`); `bash -n configure.sh` clean.

## Scope note

This is the MVP. A version stamp (`CORALLINE_VERSION`) + `CHANGELOG` ("what's new since vX.Y") is intentionally left as a follow-up PR layered on top of the feature-presence detection. Happy to adjust the surfaced output, the defaults, or split anything out.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

