### PR TITLE
fix(limit): stop preview renders from poisoning the cross-session store (#32)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -224,7 +224,9 @@ bash ~/.claude/coralline/configure.sh --install
 The installer verifies rendering automatically. For a manual check, run:
 
 ```bash
-bash ~/.claude/coralline/statusline.sh < ~/.claude/coralline/sample-input.json
+CORALLINE_NO_SAMPLE=1 bash ~/.claude/coralline/statusline.sh < ~/.claude/coralline/sample-input.json
 ```
+
+`CORALLINE_NO_SAMPLE=1` makes the render read-only, so the sample's preview values are never written to the cross-session limit/burn stores. Without it, `sample-input.json`'s far-future sentinel reset would poison `limit5h`/`limit7d` when `VL_LIMIT_SYNC=1`.
 
 Success means exit code `0`, a rendered statusline on stdout, and no error text on stderr.

--- a/configure.sh
+++ b/configure.sh
@@ -486,7 +486,9 @@ render_preview() {
   cache=$(preview_cache_path "$tmp" "$cols")
   printf '\nPreview (%s cols):\n' "$cols"
   if [ ! -f "$cache" ]; then
-    if ! CORALLINE_CONFIG="$tmp" COLUMNS="$cols" bash "$statusline" < "$input" > "$cache"; then
+    # CORALLINE_NO_SAMPLE: a preview must never write to the cross-session limit/
+    # burn stores, or the wizard would poison real sessions every keystroke (#32).
+    if ! CORALLINE_NO_SAMPLE=1 CORALLINE_CONFIG="$tmp" COLUMNS="$cols" bash "$statusline" < "$input" > "$cache"; then
       rm -f "$cache" "$tmp"
       return 1
     fi
@@ -1125,13 +1127,16 @@ verify_render() {
   statusline=$(runtime_statusline)
   sample=$(runtime_sample)
   printf '\nVerification render:\n'
+  # CORALLINE_NO_SAMPLE: the verification render must not mutate the cross-session
+  # stores; sample-input.json carries a year-2030 sentinel reset that would poison
+  # the real high-water otherwise (#32).
   if [ -n "$sample" ]; then
     need_file "$sample"
-    CORALLINE_CONFIG="$CONFIG_FILE" COLUMNS=120 bash "$statusline" < "$sample"
+    CORALLINE_NO_SAMPLE=1 CORALLINE_CONFIG="$CONFIG_FILE" COLUMNS=120 bash "$statusline" < "$sample"
   else
     input=$(mktemp "${TMPDIR:-/tmp}/coralline-input.XXXXXX") || exit 1
     jq -n --arg cwd "$SCRIPT_DIR" '{cwd: $cwd, workspace: {current_dir: $cwd}}' > "$input"
-    CORALLINE_CONFIG="$CONFIG_FILE" COLUMNS=120 bash "$statusline" < "$input"
+    CORALLINE_NO_SAMPLE=1 CORALLINE_CONFIG="$CONFIG_FILE" COLUMNS=120 bash "$statusline" < "$input"
     rm -f "$input"
   fi
 }

--- a/statusline.sh
+++ b/statusline.sh
@@ -228,6 +228,10 @@ fmt_eta() {  # → _ETA ; $1=seconds (mirrors fmt_countdown's d/h/m formatting)
 burn_sample() {  # append one 5h sample; $1=now $2=pct(raw) $3=resets_at(raw)
   [ -n "$2" ] || return 0
   to_epoch "$3" || return 0
+  # Reject an implausibly-far-future reset (corrupt/sentinel snapshot): a 5h
+  # window cannot reset more than ~7 days out, so anything past now+8d would
+  # otherwise poison the burn projection permanently (see #32).
+  [ "$_EP" -le "$(( $1 + 8*86400 ))" ] || return 0
   # [ -d ] is a builtin (steady state stays fork-free); mkdir forks only on the
   # first render after a fresh install, when ~/.claude/coralline/ doesn't exist.
   [ -d "${BURN_FILE%/*}" ] || mkdir -p "${BURN_FILE%/*}" 2>/dev/null
@@ -250,6 +254,11 @@ rl_dir() { _RLD="${1%.tsv}.d"; }
 rl_sample() {  # $1=file $2=pct(raw int/float) $3=resets_at(raw)
   [ -n "$2" ] || return 0
   to_epoch "$3" || return 0
+  # Reject an implausibly-far-future reset (corrupt/sentinel snapshot): a 5h/7d
+  # window cannot reset more than ~7 days out, so a value past now+8d would win
+  # rl_latest's high-water forever and rmdir every real entry (see #32). Guarded
+  # on NOW being set so direct unit calls without a clock keep recording.
+  [ -z "${NOW:-}" ] || [ "$_EP" -le "$(( NOW + 8*86400 ))" ] || return 0
   rl_dir "$1"
   if [ ! -d "$_RLD" ]; then
     mkdir -p "$_RLD" 2>/dev/null
@@ -771,14 +780,21 @@ term_cols() {  # → _COLS
 # single source of truth, so enabling burn in configure.sh just works. _SEG_SCAN
 # also covers VL_FLOAT_SEGMENTS, so burn samples even when it's only in the float
 # readout (mirrors how read_git is gated above).
-case "$_SEG_SCAN" in *" burn "*) burn_sample "$NOW" "$fh_pct" "$fh_rst" ;; esac
-# limit-sync records to its own high-water store (separate from the burn file),
-# only for the limit segment that is actually shown.
-if [ "$VL_LIMIT_SYNC" = "1" ]; then
-  case "$_SEG_SCAN" in *" limit5h "*) rl_sample "$RL5H_FILE" "$fh_pct" "$fh_rst" ;; esac
-  # burn also consumes the synced 7d (below), so sample it whenever burn shows too,
-  # otherwise burn would read a stale/older synced 7d instead of this render's value.
-  case "$_SEG_SCAN" in *" limit7d "*|*" burn "*) rl_sample "$RL7D_FILE" "$wd_pct" "$wd_rst" ;; esac
+#
+# CORALLINE_NO_SAMPLE=1 makes a render read-only: it skips every write to the
+# cross-session stores. A preview/verification render (sample-input.json carries
+# a year-2030 sentinel reset) would otherwise win the high-water forever and prune
+# the real entries, so the documented preview commands set this flag (see #32).
+if [ "${CORALLINE_NO_SAMPLE:-0}" != 1 ]; then
+  case "$_SEG_SCAN" in *" burn "*) burn_sample "$NOW" "$fh_pct" "$fh_rst" ;; esac
+  # limit-sync records to its own high-water store (separate from the burn file),
+  # only for the limit segment that is actually shown.
+  if [ "$VL_LIMIT_SYNC" = "1" ]; then
+    case "$_SEG_SCAN" in *" limit5h "*) rl_sample "$RL5H_FILE" "$fh_pct" "$fh_rst" ;; esac
+    # burn also consumes the synced 7d (below), so sample it whenever burn shows too,
+    # otherwise burn would read a stale/older synced 7d instead of this render's value.
+    case "$_SEG_SCAN" in *" limit7d "*|*" burn "*) rl_sample "$RL7D_FILE" "$wd_pct" "$wd_rst" ;; esac
+  fi
 fi
 case "$_SEG_SCAN" in *" burn "*) burn_estimate ;; esac
 

--- a/statusline.sh
+++ b/statusline.sh
@@ -62,6 +62,12 @@ BURN_TRIM=1500                  # internal: max rows kept in the sample file
 VL_LIMIT_SYNC=0
 RL5H_FILE="${CORALLINE_RL5H_FILE:-$HOME/.claude/coralline/limit-5h.tsv}"
 RL7D_FILE="${CORALLINE_RL7D_FILE:-$HOME/.claude/coralline/limit-7d.tsv}"
+# Per-window ceilings for the sentinel guard (#32): a reset further out than its
+# window can possibly be is corrupt (e.g. sample-input.json's 2030 value) and must
+# never become the high-water. Kept per window because a stale 5h value a couple of
+# days out would clear a shared 7d-sized bound, so the 5h path needs its own.
+RL_MAX_5H=$(( 6 * 3600 ))       # internal: 5h window resets within ~5h (6h = +1h skew margin)
+RL_MAX_7D=$(( 8 * 86400 ))      # internal: 7d window resets within 7d (8d = +1d skew margin)
 
 # Powerline glyphs (printf -v keeps these fork-free; cleared when VL_ASCII=1)
 printf -v VL_CAP_L '\xee\x82\xb6'   # U+E0B6 left rounded cap
@@ -228,10 +234,10 @@ fmt_eta() {  # → _ETA ; $1=seconds (mirrors fmt_countdown's d/h/m formatting)
 burn_sample() {  # append one 5h sample; $1=now $2=pct(raw) $3=resets_at(raw)
   [ -n "$2" ] || return 0
   to_epoch "$3" || return 0
-  # Reject an implausibly-far-future reset (corrupt/sentinel snapshot): a 5h
-  # window cannot reset more than ~7 days out, so anything past now+8d would
+  # Reject an implausibly-far-future reset (corrupt/sentinel snapshot): this is the
+  # 5h window, which resets within hours, so anything past now+RL_MAX_5H would
   # otherwise poison the burn projection permanently (see #32).
-  [ "$_EP" -le "$(( $1 + 8*86400 ))" ] || return 0
+  [ "$_EP" -le "$(( $1 + RL_MAX_5H ))" ] || return 0
   # [ -d ] is a builtin (steady state stays fork-free); mkdir forks only on the
   # first render after a fresh install, when ~/.claude/coralline/ doesn't exist.
   [ -d "${BURN_FILE%/*}" ] || mkdir -p "${BURN_FILE%/*}" 2>/dev/null
@@ -251,14 +257,15 @@ burn_sample() {  # append one 5h sample; $1=now $2=pct(raw) $3=resets_at(raw)
 #          untouched, so a concurrent higher add is never lost (no lock needed).
 rl_dir() { _RLD="${1%.tsv}.d"; }
 
-rl_sample() {  # $1=file $2=pct(raw int/float) $3=resets_at(raw)
+rl_sample() {  # $1=file $2=pct(raw int/float) $3=resets_at(raw) $4=max secs ahead
   [ -n "$2" ] || return 0
   to_epoch "$3" || return 0
-  # Reject an implausibly-far-future reset (corrupt/sentinel snapshot): a 5h/7d
-  # window cannot reset more than ~7 days out, so a value past now+8d would win
-  # rl_latest's high-water forever and rmdir every real entry (see #32). Guarded
-  # on NOW being set so direct unit calls without a clock keep recording.
-  [ -z "${NOW:-}" ] || [ "$_EP" -le "$(( NOW + 8*86400 ))" ] || return 0
+  # Reject an implausibly-far-future reset (corrupt/sentinel snapshot): a value past
+  # now plus this window's ceiling ($4) would win rl_latest's high-water forever and
+  # rmdir every real entry (see #32). The caller passes RL_MAX_5H or RL_MAX_7D so a
+  # stale 5h value days out is rejected, not just an absurd one. Guarded on NOW and
+  # on $4 being supplied so direct unit calls without a clock keep recording.
+  [ -z "${NOW:-}" ] || [ -z "${4:-}" ] || [ "$_EP" -le "$(( NOW + $4 ))" ] || return 0
   rl_dir "$1"
   if [ ! -d "$_RLD" ]; then
     mkdir -p "$_RLD" 2>/dev/null
@@ -273,7 +280,7 @@ rl_sample() {  # $1=file $2=pct(raw int/float) $3=resets_at(raw)
   return 0
 }
 
-rl_latest() {  # $1=file → _LL_PCT _LL_RST (epoch)
+rl_latest() {  # $1=file $2=max secs ahead → _LL_PCT _LL_RST (epoch)
   _LL_PCT=""; _LL_RST=""
   rl_dir "$1"; [ -d "$_RLD" ] || return 0
   # ONE snapshot for both the max and the GC. A second listing could include an
@@ -283,11 +290,12 @@ rl_latest() {  # $1=file → _LL_PCT _LL_RST (epoch)
   local snap hi d cut="" kept=""
   # A store poisoned before this fix (a 2030 sentinel written by an old preview)
   # would still pin every read: rl_latest picks the max reset and rmdirs the rest.
-  # So drop entries beyond NOW+8d on read too. That keeps the sentinel out of the
-  # high-water AND prunes it, so the store self-heals (#32). Guarded on NOW so
-  # direct unit calls without a clock keep every entry. A real reset is never that
-  # far out, so a concurrent legitimate add is never a pruning candidate.
-  [ -z "${NOW:-}" ] || cut=$(( NOW + 8*86400 ))
+  # So drop entries beyond now plus this window's ceiling ($2) on read too. That
+  # keeps the sentinel out of the high-water AND prunes it, so the store self-heals
+  # (#32). Guarded on NOW (and on $2 being supplied) so direct unit calls without a
+  # clock keep every entry. A real reset is never that far out, so a concurrent
+  # legitimate add is never a pruning candidate.
+  [ -z "${NOW:-}" ] || [ -z "${2:-}" ] || cut=$(( NOW + $2 ))
   snap=$(ls -1 "$_RLD" 2>/dev/null | grep '^[0-9]' | sort)
   [ -n "$snap" ] || return 0
   for d in $snap; do
@@ -311,13 +319,13 @@ burn_eta_5h() {  # → _B5_STATE _B5_ETA _B5_RATE _B5_TTR ; trims $BURN_FILE
   [ -f "$BURN_FILE" ] || return 0
   local tmp="$BURN_FILE.$$.tmp" out
   out=$(awk -F'\t' -v now="$NOW" -v win="$CORALLINE_BURN_WINDOW" \
-            -v trim="$BURN_TRIM" -v tmp="$tmp" '
+            -v trim="$BURN_TRIM" -v tmp="$tmp" -v maxahead="$RL_MAX_5H" '
     $2 != "" {
       e = $1 + 0; r = $3 + 0
       # Drop a row whose reset is implausibly far out (a 2030 sentinel from an old
       # sample preview). Left in, it becomes the "current window" below and starves
       # the real samples; dropping it on read self-heals a pre-fix poisoned file (#32).
-      if (r > now + 8*86400) { dropped = 1; next }
+      if (r > now + maxahead) { dropped = 1; next }
       if (!(e in seen)) { ord[++n] = e; seen[e] = 1 }
       pct[e] = $2 + 0; rst[e] = r
     }
@@ -418,7 +426,7 @@ burn_estimate() {  # → _BURN_STATE _BURN_LABEL _BURN_ETA _BURN_RATE _BURN_TTR
   # limit-sync is on, project from the same synced value the limit7d segment shows
   # so burn and limit7d cannot contradict each other on a stale local snapshot.
   if [ "$VL_LIMIT_SYNC" = "1" ]; then
-    rl_latest "$RL7D_FILE"
+    rl_latest "$RL7D_FILE" "$RL_MAX_7D"
     if [ -n "$_LL_PCT" ]; then burn_eta_7d "$_LL_PCT" "$_LL_RST"; else burn_eta_7d; fi
   else
     burn_eta_7d
@@ -678,14 +686,14 @@ seg_limit() {  # $1=label $2=pct $3=resets_at $4=bg
 seg_limit5h() {
   local p="$fh_pct" r="$fh_rst"
   if [ "$VL_LIMIT_SYNC" = "1" ]; then
-    rl_latest "$RL5H_FILE"; [ -n "$_LL_PCT" ] && { p="$_LL_PCT"; r="$_LL_RST"; }
+    rl_latest "$RL5H_FILE" "$RL_MAX_5H"; [ -n "$_LL_PCT" ] && { p="$_LL_PCT"; r="$_LL_RST"; }
   fi
   seg_limit "5h" "$p" "$r" "$VL_BG_5H"
 }
 seg_limit7d() {
   local p="$wd_pct" r="$wd_rst"
   if [ "$VL_LIMIT_SYNC" = "1" ]; then
-    rl_latest "$RL7D_FILE"; [ -n "$_LL_PCT" ] && { p="$_LL_PCT"; r="$_LL_RST"; }
+    rl_latest "$RL7D_FILE" "$RL_MAX_7D"; [ -n "$_LL_PCT" ] && { p="$_LL_PCT"; r="$_LL_RST"; }
   fi
   seg_limit "7d" "$p" "$r" "$VL_BG_7D"
 }
@@ -810,10 +818,10 @@ if [ "${CORALLINE_NO_SAMPLE:-0}" != 1 ]; then
   # limit-sync records to its own high-water store (separate from the burn file),
   # only for the limit segment that is actually shown.
   if [ "$VL_LIMIT_SYNC" = "1" ]; then
-    case "$_SEG_SCAN" in *" limit5h "*) rl_sample "$RL5H_FILE" "$fh_pct" "$fh_rst" ;; esac
+    case "$_SEG_SCAN" in *" limit5h "*) rl_sample "$RL5H_FILE" "$fh_pct" "$fh_rst" "$RL_MAX_5H" ;; esac
     # burn also consumes the synced 7d (below), so sample it whenever burn shows too,
     # otherwise burn would read a stale/older synced 7d instead of this render's value.
-    case "$_SEG_SCAN" in *" limit7d "*|*" burn "*) rl_sample "$RL7D_FILE" "$wd_pct" "$wd_rst" ;; esac
+    case "$_SEG_SCAN" in *" limit7d "*|*" burn "*) rl_sample "$RL7D_FILE" "$wd_pct" "$wd_rst" "$RL_MAX_7D" ;; esac
   fi
 fi
 case "$_SEG_SCAN" in *" burn "*) burn_estimate ;; esac

--- a/statusline.sh
+++ b/statusline.sh
@@ -280,13 +280,28 @@ rl_latest() {  # $1=file → _LL_PCT _LL_RST (epoch)
   # entry added after `hi` was chosen, and the loop would rmdir that fresher (and
   # possibly higher) entry. Iterating the same snapshot means post-snapshot adds
   # are never deletion candidates, so a concurrent higher add is never lost.
-  local snap hi d
+  local snap hi d cut="" kept=""
+  # A store poisoned before this fix (a 2030 sentinel written by an old preview)
+  # would still pin every read: rl_latest picks the max reset and rmdirs the rest.
+  # So drop entries beyond NOW+8d on read too. That keeps the sentinel out of the
+  # high-water AND prunes it, so the store self-heals (#32). Guarded on NOW so
+  # direct unit calls without a clock keep every entry. A real reset is never that
+  # far out, so a concurrent legitimate add is never a pruning candidate.
+  [ -z "${NOW:-}" ] || cut=$(( NOW + 8*86400 ))
   snap=$(ls -1 "$_RLD" 2>/dev/null | grep '^[0-9]' | sort)
   [ -n "$snap" ] || return 0
-  hi=$(printf '%s\n' "$snap" | tail -n1)
+  for d in $snap; do
+    if [ -n "$cut" ] && [ "$(( 10#${d%_*} ))" -gt "$cut" ]; then
+      rmdir "$_RLD/$d" 2>/dev/null            # purge the poisoned sentinel entry
+    else
+      kept="${kept}${kept:+ }$d"
+    fi
+  done
+  [ -n "$kept" ] || return 0
+  hi="${kept##* }"             # kept is built in sorted order, so the last is the max
   _LL_RST=$(( 10#${hi%_*} ))   # 10# avoids the leading-zero octal trap on the reset
   _LL_PCT="${hi#*_}"           # keep as string so a fractional pct is preserved
-  for d in $snap; do
+  for d in $kept; do
     [ "$d" = "$hi" ] || rmdir "$_RLD/$d" 2>/dev/null
   done
 }
@@ -298,9 +313,13 @@ burn_eta_5h() {  # → _B5_STATE _B5_ETA _B5_RATE _B5_TTR ; trims $BURN_FILE
   out=$(awk -F'\t' -v now="$NOW" -v win="$CORALLINE_BURN_WINDOW" \
             -v trim="$BURN_TRIM" -v tmp="$tmp" '
     $2 != "" {
-      e = $1 + 0
+      e = $1 + 0; r = $3 + 0
+      # Drop a row whose reset is implausibly far out (a 2030 sentinel from an old
+      # sample preview). Left in, it becomes the "current window" below and starves
+      # the real samples; dropping it on read self-heals a pre-fix poisoned file (#32).
+      if (r > now + 8*86400) { dropped = 1; next }
       if (!(e in seen)) { ord[++n] = e; seen[e] = 1 }
-      pct[e] = $2 + 0; rst[e] = $3 + 0
+      pct[e] = $2 + 0; rst[e] = r
     }
     END {
       if (n == 0) { print "warming inf 0 0"; next_done = 1 }
@@ -356,8 +375,9 @@ burn_eta_5h() {  # → _B5_STATE _B5_ETA _B5_RATE _B5_TTR ; trims $BURN_FILE
         # bursts (resize storms) append same-second rows that n dedups away, so an
         # n-based cap would never fire and the file would grow unbounded. The
         # rewrite emits the deduped last-`trim` seconds, so it also collapses the
-        # burst rows. Fires only when the file actually exceeds the cap.
-        if (NR > trim) {
+        # burst rows. Fires when the file exceeds the cap, or when a sentinel row
+        # was dropped above, so the poisoned row is purged from the file too (#32).
+        if (NR > trim || dropped) {
           lo = n - trim + 1; if (lo < 1) lo = 1
           for (i = lo; i <= n; i++)
             printf "%d\t%s\t%d\n", ord[i], pct[ord[i]], rst[ord[i]] > tmp

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -94,6 +94,15 @@ rl_sample "$RLS" 99 1893490200                        # 2030 sentinel: dropped
 rl_latest "$RLS"
 eq "rl_sample drops sentinel pct" "$_LL_PCT" "030.000"
 eq "rl_sample drops sentinel rst" "$_LL_RST" "1781811000"
+# read-side heal: a store poisoned BEFORE this fix already holds the sentinel entry.
+# On read rl_latest must ignore it for the high-water AND rmdir it, so the next real
+# render recovers instead of staying pinned.
+RLH="$TMPD/limit-heal.tsv"; rl_dir "$RLH"; mkdir -p "$_RLD"
+mkdir "$_RLD/1781811000_030.000" "$_RLD/1893490200_099.000"   # real entry + 2030 sentinel
+rl_latest "$RLH"
+eq "rl_latest heals poisoned pct"  "$_LL_PCT" "030.000"
+eq "rl_latest heals poisoned rst"  "$_LL_RST" "1781811000"
+eq "rl_latest prunes sentinel dir" "$([ -d "$_RLD/1893490200_099.000" ] && echo present || echo gone)" "gone"
 # burn_sample applies the same bound, keyed off its own now ($1)
 BURN_FILE="$TMPD/burn-sentinel.tsv"
 burn_sample 1781794590 50 1781811000                  # real window: appended
@@ -111,6 +120,14 @@ run5h "1000000\t6\t1015900\n1000060\t7\t1015900\n1000300\t8\t1015900\n1000360\t8
 eq "5h active state" "$_B5_STATE" "active"
 eq "5h active eta"   "$_B5_ETA"   "22080"
 eq "5h ttr"          "$_B5_TTR"   "15540"
+
+# read-side heal: a burn file poisoned before this fix holds a far-future reset row.
+# burn_eta_5h must ignore it (fit the real window, not stay warming) and purge it,
+# so the same active fit lands and the sentinel row is gone from the file.
+run5h "1000000\t6\t1015900\n1000060\t7\t1015900\n1000300\t8\t1015900\n1000360\t8\t1015900\n9999000\t41\t99999999\n" 1000360
+eq "burn read ignores sentinel state" "$_B5_STATE" "active"
+eq "burn read ignores sentinel eta"   "$_B5_ETA"   "22080"
+eq "burn read purges sentinel" "$(grep -c 99999999 "$TMPD/b5.tsv" | tr -d ' ')" "0"
 
 # idle: only crossing is older than the 600s window (at +0s); now=+1200s
 run5h "1000000\t6\t1015900\n1000010\t7\t1015900\n1001200\t7\t1015900\n" 1001200
@@ -132,35 +149,35 @@ eq "5h empty state" "$_B5_STATE" "warming"
 eq "5h empty eta"   "$_B5_ETA"   "inf"
 
 # cross-window isolation: a shared file where an idle session's stale snapshots
-# (50,51 / older reset 1500000) are interleaved with the current window
-# (6,7,8 / later reset 2000000). The estimate must use ONLY the current window —
+# (50,51 / older reset 1010000) are interleaved with the current window
+# (6,7,8 / later reset 1015900). The estimate must use ONLY the current window —
 # pre-fix the mixed series mis-fit; now it fits the real 6→7→8 slope.
 # crossings (current window): (1000120,7),(1000300,8) → rate=1/180 %/s
 # now pct=8 → ETA=(100-8)*180=16560s
-run5h "1000000\t6\t2000000\n1000060\t50\t1500000\n1000120\t7\t2000000\n1000180\t51\t1500000\n1000300\t8\t2000000\n1000360\t8\t2000000\n" 1000360
+run5h "1000000\t6\t1015900\n1000060\t50\t1010000\n1000120\t7\t1015900\n1000180\t51\t1010000\n1000300\t8\t1015900\n1000360\t8\t1015900\n" 1000360
 eq "5h cross-window state" "$_B5_STATE" "active"
 eq "5h cross-window eta"   "$_B5_ETA"   "16560"
-eq "5h cross-window ttr"   "$_B5_TTR"   "999640"
+eq "5h cross-window ttr"   "$_B5_TTR"   "15540"
 
 # same-window jitter: concurrent sessions' caches disagree by a point or two, so
 # pct dips mid-window (13→12) though usage only ever rises. A decrease used to
 # reset `start` to the tail and fit the slope over the last 1-2 samples (1s apart)
 # → bogus ~1m ETA. Now the fit is anchored at the window start and spans the
 # first→last crossing: (1000150,11)→(1000400,16) = 5%/250s, lp=16 → ETA=84/0.02=4200.
-run5h "1000050\t10\t2000000\n1000150\t11\t2000000\n1000380\t13\t2000000\n1000398\t12\t2000000\n1000399\t14\t2000000\n1000400\t16\t2000000\n" 1000400
+run5h "1000050\t10\t1015900\n1000150\t11\t1015900\n1000380\t13\t1015900\n1000398\t12\t1015900\n1000399\t14\t1015900\n1000400\t16\t1015900\n" 1000400
 eq "5h jitter state" "$_B5_STATE" "active"
 eq "5h jitter eta"   "$_B5_ETA"   "4200"
-eq "5h jitter ttr"   "$_B5_TTR"   "999600"
+eq "5h jitter ttr"   "$_B5_TTR"   "15500"
 
 # min-span guard: a tiny late burst (two crossings 2s apart, nothing earlier in
 # window) is too short to trust → warming, not a wild fast ETA.
-run5h "1000000\t9\t2000000\n1000398\t10\t2000000\n1000400\t11\t2000000\n" 1000400
+run5h "1000000\t9\t1015900\n1000398\t10\t1015900\n1000400\t11\t1015900\n" 1000400
 eq "5h short-span guard" "$_B5_STATE" "warming"
 
 # but a genuine fast burn that spans more than the guard (win/10=60s) must show,
 # not be hidden as warming: 1→5→9→10 over 90s. fc=(1000010,5) lc=(1000100,10),
 # span=90s ≥ 60s → rate=5/90, lp=10 → ETA=90/(5/90)=1620.
-run5h "1000000\t1\t2000000\n1000010\t5\t2000000\n1000070\t9\t2000000\n1000100\t10\t2000000\n" 1000100
+run5h "1000000\t1\t1015900\n1000010\t5\t1015900\n1000070\t9\t1015900\n1000100\t10\t1015900\n" 1000100
 eq "5h fast-burn shows state" "$_B5_STATE" "active"
 eq "5h fast-burn shows eta"   "$_B5_ETA"   "1620"
 

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -85,6 +85,22 @@ rl_sample "$RLF" 12 2000
 eq "rl legacy flat-file removed" "$([ -e "$TMPD/limit.tsv" ] && echo present || echo gone)" "gone"
 eq "rl dir-set created"          "$([ -d "$TMPD/limit.d" ]  && echo yes || echo no)" "yes"
 
+# sentinel guard (#32): a far-future reset (e.g. sample-input.json's year-2030
+# preview value) must be dropped when NOW is known, so a preview render can never
+# win the high-water and prune the real window. NOW is set for these cases only.
+RLS="$TMPD/limit-sentinel.tsv"; NOW=1781794590        # cutoff = NOW + 8d
+rl_sample "$RLS" 30 1781811000                        # real ~4.5h window: kept
+rl_sample "$RLS" 99 1893490200                        # 2030 sentinel: dropped
+rl_latest "$RLS"
+eq "rl_sample drops sentinel pct" "$_LL_PCT" "030.000"
+eq "rl_sample drops sentinel rst" "$_LL_RST" "1781811000"
+# burn_sample applies the same bound, keyed off its own now ($1)
+BURN_FILE="$TMPD/burn-sentinel.tsv"
+burn_sample 1781794590 50 1781811000                  # real window: appended
+burn_sample 1781794590 99 1893490200                  # 2030 sentinel: dropped
+eq "burn_sample drops sentinel" "$([ -f "$BURN_FILE" ] && wc -l < "$BURN_FILE" | tr -d ' ' || echo 0)" "1"
+NOW=""
+
 # helper: write a fixture and run the estimator at a given "now"
 run5h() { BURN_FILE="$TMPD/b5.tsv"; printf '%b' "$1" > "$BURN_FILE"; NOW="$2"; burn_eta_5h; }
 
@@ -298,11 +314,18 @@ eq "neither-reported renders nothing" "${#SEG_TXT[@]}" "0"
 # Drives the whole statusline.sh so the top-level gate is exercised end to end.
 if command -v jq >/dev/null 2>&1; then
   gate_run() {  # $1=VL_SEGMENTS → "written" if a sample landed, else "absent"
-    local conf="$TMPD/conf.sh" bf="$TMPD/gate/burn.tsv"
+    local conf="$TMPD/conf.sh" bf="$TMPD/gate/burn.tsv" in="$TMPD/gate-input.json" soon
     rm -rf "$TMPD/gate"
     printf 'VL_SEGMENTS=%q\n' "$1" > "$conf"
+    # Give the fixture a plausible near-future reset (raw epoch; to_epoch accepts
+    # it) so the sentinel guard (#32) doesn't correctly drop the sample and mask
+    # the gate under test. The bundled sample-input.json keeps its 2030 sentinel.
+    soon=$(( $(date +%s) + 10800 ))
+    jq --arg r "$soon" \
+       '.rate_limits.five_hour.resets_at=$r | .rate_limits.seven_day.resets_at=$r' \
+       "$HERE/sample-input.json" > "$in"
     CORALLINE_CONFIG="$conf" CORALLINE_BURN_FILE="$bf" \
-      bash "$SCRIPT" < "$HERE/sample-input.json" >/dev/null 2>&1
+      bash "$SCRIPT" < "$in" >/dev/null 2>&1
     [ -f "$bf" ] && echo written || echo absent
   }
   eq "gate: burn listed → samples"    "$(gate_run 'dir burn clock')" "written"

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -17,6 +17,9 @@ eval "$(sed -n '/^to_epoch() {/,/^}/p'     "$SCRIPT")"
 eval "$(sed -n '/^fmt_eta() {/,/^}/p'       "$SCRIPT")"
 eval "$(sed -n '/^burn_sample() {/,/^}/p'   "$SCRIPT")"
 
+# Per-window sentinel ceilings the samplers reference (mirrors statusline.sh; #32).
+RL_MAX_5H=$(( 6 * 3600 )); RL_MAX_7D=$(( 8 * 86400 ))
+
 # fmt_eta
 fmt_eta 0;       eq "fmt_eta 0m"     "$_ETA" "0m"
 fmt_eta 2820;    eq "fmt_eta 47m"    "$_ETA" "47m"
@@ -88,22 +91,29 @@ eq "rl dir-set created"          "$([ -d "$TMPD/limit.d" ]  && echo yes || echo 
 # sentinel guard (#32): a far-future reset (e.g. sample-input.json's year-2030
 # preview value) must be dropped when NOW is known, so a preview render can never
 # win the high-water and prune the real window. NOW is set for these cases only.
-RLS="$TMPD/limit-sentinel.tsv"; NOW=1781794590        # cutoff = NOW + 8d
-rl_sample "$RLS" 30 1781811000                        # real ~4.5h window: kept
-rl_sample "$RLS" 99 1893490200                        # 2030 sentinel: dropped
-rl_latest "$RLS"
+RLS="$TMPD/limit-sentinel.tsv"; NOW=1781794590
+rl_sample "$RLS" 30 1781811000 "$RL_MAX_5H"           # real ~4.5h window: kept
+rl_sample "$RLS" 99 1893490200 "$RL_MAX_5H"           # 2030 sentinel: dropped
+rl_latest "$RLS" "$RL_MAX_5H"
 eq "rl_sample drops sentinel pct" "$_LL_PCT" "030.000"
 eq "rl_sample drops sentinel rst" "$_LL_RST" "1781811000"
+# per-window ceiling: a 5h reset days out is corrupt (a 5h window resets within
+# hours), but the same offset is valid for the 7d window. The ceiling is the caller's.
+RLW="$TMPD/limit-window.tsv"; twodays=$(( NOW + 2*86400 ))
+rl_sample "$RLW" 20 "$twodays" "$RL_MAX_5H"           # 2d out under 5h ceiling: dropped
+rl_latest "$RLW" "$RL_MAX_5H"; eq "rl 5h ceiling drops 2d reset" "$_LL_PCT" ""
+rl_sample "$RLW" 20 "$twodays" "$RL_MAX_7D"           # 2d out under 7d ceiling: kept
+rl_latest "$RLW" "$RL_MAX_7D"; eq "rl 7d ceiling keeps 2d reset" "$_LL_PCT" "020.000"
 # read-side heal: a store poisoned BEFORE this fix already holds the sentinel entry.
 # On read rl_latest must ignore it for the high-water AND rmdir it, so the next real
 # render recovers instead of staying pinned.
 RLH="$TMPD/limit-heal.tsv"; rl_dir "$RLH"; mkdir -p "$_RLD"
 mkdir "$_RLD/1781811000_030.000" "$_RLD/1893490200_099.000"   # real entry + 2030 sentinel
-rl_latest "$RLH"
+rl_latest "$RLH" "$RL_MAX_5H"
 eq "rl_latest heals poisoned pct"  "$_LL_PCT" "030.000"
 eq "rl_latest heals poisoned rst"  "$_LL_RST" "1781811000"
 eq "rl_latest prunes sentinel dir" "$([ -d "$_RLD/1893490200_099.000" ] && echo present || echo gone)" "gone"
-# burn_sample applies the same bound, keyed off its own now ($1)
+# burn_sample applies the 5h bound, keyed off its own now ($1)
 BURN_FILE="$TMPD/burn-sentinel.tsv"
 burn_sample 1781794590 50 1781811000                  # real window: appended
 burn_sample 1781794590 99 1893490200                  # 2030 sentinel: dropped


### PR DESCRIPTION
## Summary

With `VL_LIMIT_SYNC` enabled, a single documented preview of `sample-input.json` through `statusline.sh` writes the file's year-2030 sentinel resets into the per-host high-water store and prunes the real window. From then on every session's `limit5h` / `limit7d` is pinned to the sample's high-water, and the corruption is self-perpetuating: each real render writes its correct value but `rl_latest` immediately re-prunes it because the 2030 reset always wins. This PR applies defense in depth: a no-write switch (A) plus a sampler upper bound (B). Closes #32.

> **Impact:** the store is per-host (every session on the machine shares it), and the `INSTALL.md` post-install verification command triggers this on current `main`, so anyone who enables `VL_LIMIT_SYNC` and follows the docs is hit.

## Root cause

| Mechanism | Location | Problem |
|---|---|---|
| Preview render persists state | `statusline.sh` sampling block | Every render writes the store; it cannot tell a real session from a sample preview |
| Store treats max reset as the current window | `rl_sample` / `rl_latest` | Keeps the lexicographically max entry (max reset epoch) as the high-water and `rmdir`s the rest |
| Sample carries a far-future sentinel | `sample-input.json` | Resets are in 2030, so the sample wins forever and deletes the real 2026 entries |

## Fix

| Direction | Change |
|---|---|
| **A. No-write switch** | Add `CORALLINE_NO_SAMPLE` to make a render read-only (no writes to the cross-session stores). Used by the `statusline.sh` sampling block, the `configure.sh` `render_preview` and `verify_render` paths, and the `INSTALL.md` command |
| **B. Upper bound (defense in depth)** | `rl_sample` / `burn_sample` reject any reset past `now+8d`. A 5h/7d window can never reset that far out, so no single bad snapshot can become a permanent high-water |

> **Note:** the `configure.sh` `render_preview` (wizard live preview) and `verify_render` (post-install verification) paths also poisoned the real store. The issue only named `INSTALL.md`; this PR fixes all three.

## Trigger paths and fixes

| Trigger | Fix |
|---|---|
| `INSTALL.md` post-install verification command | Prefix with `CORALLINE_NO_SAMPLE=1` |
| `configure.sh` `render_preview` | Render with `CORALLINE_NO_SAMPLE=1` |
| `configure.sh` `verify_render` | Render with `CORALLINE_NO_SAMPLE=1` |
| Any input with a bad reset | Sampler upper bound (fix B) drops it |

## Verification

`bash -n` passes on all three scripts and all six `test/*.sh` files are green (added sentinel regression tests; updated the existing gate test to use a plausible near-future reset so it isolates the gate behavior). Running the same isolated repro against the old and new code:

| Version | Store after sample render | Real render output |
|---|---|---|
| Old (HEAD, unfixed) | Becomes the 2030 sentinel | Pinned to `41%` / `79%`, ↺1289d |
| New (this PR) | Keeps the real 2026 window | Correct `33%` / `50%` |

Fix A and fix B each block the poisoning independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4RACiULqniDYmRhnnuMJr
