### PR TITLE
perf(limit): parse ISO resets_at fork-free instead of shelling out to date

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -194,31 +194,44 @@ fmt_tok() {
 # non-standard shape falls back to one date call. The epoch-int branch is
 # fork-free for callers that already hold epoch.
 to_epoch() {
-  local t="$1" s d tm Y Mo D H Mi S yy era yoe doy doe days
+  local t="$1" s tm Y Mo D H Mi S yy era yoe doy doe days dim
   [ -z "$t" ] && return 1
   case "$t" in
-    *T*)  # ISO 8601 — assume UTC (resets_at is always "…Z"; tz offset, if any,
-          # is dropped, matching the previous date-based behavior).
-      s="${t%%[.+]*}" ; s="${s%Z}"          # 2026-06-24T15:20:00
-      d="${s%%T*}" ; tm="${s#*T}"
-      Y="${d%%-*}" ; D="${d##*-}" ; Mo="${d#*-}" ; Mo="${Mo%%-*}"
-      H="${tm%%:*}" ; S="${tm##*:}" ; Mi="${tm#*:}" ; Mi="${Mi%%:*}"
-      case "$Y$Mo$D$H$Mi$S" in
-        ''|*[!0-9]*) ;;                      # unexpected shape → date fallback
+    *T*)  # ISO 8601. Fast-path ONLY the canonical UTC shape
+          #   YYYY-MM-DDTHH:MM:SS  with an optional .fraction and optional Z.
+          # Anything else (a timezone offset, missing seconds, an impossible
+          # date) falls through to date so behavior matches the old path exactly.
+      tm="${t#*T}"
+      case "$tm" in
+        *[+-]*) ;;                            # tz offset present → date fallback
         *)
-          # 10# forces base-10 so a leading zero (08, 09) is not read as octal
-          Y=$((10#$Y)); Mo=$((10#$Mo)); D=$((10#$D))
-          H=$((10#$H)); Mi=$((10#$Mi)); S=$((10#$S))
-          yy=$(( Y - (Mo <= 2) ))           # days-from-civil (Howard Hinnant), UTC
-          era=$(( (yy >= 0 ? yy : yy - 399) / 400 ))
-          yoe=$(( yy - era * 400 ))
-          doy=$(( (153 * (Mo + (Mo > 2 ? -3 : 9)) + 2) / 5 + D - 1 ))
-          doe=$(( yoe * 365 + yoe / 4 - yoe / 100 + doy ))
-          days=$(( era * 146097 + doe - 719468 ))
-          _EP=$(( days * 86400 + H * 3600 + Mi * 60 + S ))
-          return 0 ;;
+          s="${t%Z}" ; s="${s%%.*}"          # drop trailing Z and any fraction
+          case "$s" in
+            [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9])
+              # fixed offsets are safe now that the exact shape is confirmed.
+              # 10# forces base-10 so a leading zero (08, 09) is not read as octal.
+              Y=$((10#${s:0:4})); Mo=$((10#${s:5:2})); D=$((10#${s:8:2}))
+              H=$((10#${s:11:2})); Mi=$((10#${s:14:2})); S=$((10#${s:17:2}))
+              dim=31                          # days in month, for range validation
+              case $Mo in
+                4|6|9|11) dim=30 ;;
+                2) dim=$(( (Y % 4 == 0 && (Y % 100 != 0 || Y % 400 == 0)) ? 29 : 28 )) ;;
+              esac
+              if [ "$Mo" -ge 1 ] && [ "$Mo" -le 12 ] && [ "$D" -ge 1 ] && [ "$D" -le "$dim" ] \
+                 && [ "$H" -le 23 ] && [ "$Mi" -le 59 ] && [ "$S" -le 59 ]; then
+                yy=$(( Y - (Mo <= 2) ))       # days-from-civil (Howard Hinnant), UTC
+                era=$(( (yy >= 0 ? yy : yy - 399) / 400 ))
+                yoe=$(( yy - era * 400 ))
+                doy=$(( (153 * (Mo + (Mo > 2 ? -3 : 9)) + 2) / 5 + D - 1 ))
+                doe=$(( yoe * 365 + yoe / 4 - yoe / 100 + doy ))
+                days=$(( era * 146097 + doe - 719468 ))
+                _EP=$(( days * 86400 + H * 3600 + Mi * 60 + S ))
+                return 0
+              fi ;;
+          esac ;;
       esac
       _EP=$(date -u -d "$t" +%s 2>/dev/null) && return 0
+      s="${t%%[.+]*}" ; s="${s%Z}"
       _EP=$(date -ju -f '%Y-%m-%dT%H:%M:%S' "$s" +%s 2>/dev/null) && return 0
       return 1 ;;
     *[0-9]*) _EP="${t%%.*}" ; return 0 ;;

--- a/statusline.sh
+++ b/statusline.sh
@@ -188,16 +188,37 @@ fmt_tok() {
 }
 
 # Accepts epoch seconds (with or without decimals) or an ISO 8601 timestamp → _EP.
-# Claude Code sends rate-limit resets_at as ISO ("…Z"), so that branch shells out
-# to date once per call — the same fork seg_limit's countdown already pays. The
-# epoch-int branch is the fork-free path for callers that already hold epoch.
+# Claude Code sends rate-limit resets_at as ISO UTC ("…Z"). The common shape is
+# parsed fork-free with pure integer date math (days-from-civil), so the default
+# limit5h/limit7d countdowns no longer shell out to date on every render. A
+# non-standard shape falls back to one date call. The epoch-int branch is
+# fork-free for callers that already hold epoch.
 to_epoch() {
-  local t="$1" s
+  local t="$1" s d tm Y Mo D H Mi S yy era yoe doy doe days
   [ -z "$t" ] && return 1
   case "$t" in
-    *T*)  # ISO 8601 — try GNU date, then BSD date (assume UTC if tz lost)
+    *T*)  # ISO 8601 — assume UTC (resets_at is always "…Z"; tz offset, if any,
+          # is dropped, matching the previous date-based behavior).
+      s="${t%%[.+]*}" ; s="${s%Z}"          # 2026-06-24T15:20:00
+      d="${s%%T*}" ; tm="${s#*T}"
+      Y="${d%%-*}" ; D="${d##*-}" ; Mo="${d#*-}" ; Mo="${Mo%%-*}"
+      H="${tm%%:*}" ; S="${tm##*:}" ; Mi="${tm#*:}" ; Mi="${Mi%%:*}"
+      case "$Y$Mo$D$H$Mi$S" in
+        ''|*[!0-9]*) ;;                      # unexpected shape → date fallback
+        *)
+          # 10# forces base-10 so a leading zero (08, 09) is not read as octal
+          Y=$((10#$Y)); Mo=$((10#$Mo)); D=$((10#$D))
+          H=$((10#$H)); Mi=$((10#$Mi)); S=$((10#$S))
+          yy=$(( Y - (Mo <= 2) ))           # days-from-civil (Howard Hinnant), UTC
+          era=$(( (yy >= 0 ? yy : yy - 399) / 400 ))
+          yoe=$(( yy - era * 400 ))
+          doy=$(( (153 * (Mo + (Mo > 2 ? -3 : 9)) + 2) / 5 + D - 1 ))
+          doe=$(( yoe * 365 + yoe / 4 - yoe / 100 + doy ))
+          days=$(( era * 146097 + doe - 719468 ))
+          _EP=$(( days * 86400 + H * 3600 + Mi * 60 + S ))
+          return 0 ;;
+      esac
       _EP=$(date -u -d "$t" +%s 2>/dev/null) && return 0
-      s="${t%%[.+]*}" ; s="${s%Z}"
       _EP=$(date -ju -f '%Y-%m-%dT%H:%M:%S' "$s" +%s 2>/dev/null) && return 0
       return 1 ;;
     *[0-9]*) _EP="${t%%.*}" ; return 0 ;;

--- a/test/test-epoch.sh
+++ b/test/test-epoch.sh
@@ -25,17 +25,26 @@ ref_epoch() {
 }
 
 fail=0
-iso() {  # $1=ISO timestamp — assert to_epoch matches the system date
-  to_epoch "$1"; local got="$_EP" want; want=$(ref_epoch "$1")
-  if [ "$got" = "$want" ]; then
-    printf 'ok    %-30s %s\n' "$1" "$got"
+# Assert to_epoch matches the old date-based implementation exactly, in both the
+# result AND the return code. This proves the fork-free fast path and its
+# fallbacks are byte-for-byte equivalent to the date calls they replaced, for
+# valid, offset, reduced-precision, and impossible inputs alike.
+iso() {  # $1=ISO timestamp
+  local got grc want wrc
+  to_epoch "$1"; grc=$?; got="$_EP"      # capture rc BEFORE any other command
+  want=$(ref_epoch "$1"); wrc=$?
+  if [ "$grc" != 0 ] && [ "$wrc" != 0 ]; then
+    printf 'ok    %-32s <both reject>\n' "$1"; return  # parity: both decline
+  fi
+  if [ "$grc" = "$wrc" ] && [ "$got" = "$want" ]; then
+    printf 'ok    %-32s %s\n' "$1" "$got"
   else
-    printf 'FAIL  %-30s want=%s got=%s\n' "$1" "$want" "$got"; fail=1
+    printf 'FAIL  %-32s want=%s(rc%s) got=%s(rc%s)\n' "$1" "$want" "$wrc" "$got" "$grc"; fail=1
   fi
 }
 
-# Spread: epoch boundary, leap years, century non-leap, month edges, far future,
-# the 32-bit boundary, fractional seconds, and an explicit +00:00 offset.
+# Fast-path shapes: epoch boundary, leap years, century non-leap, month edges,
+# far future, the 32-bit boundary, fractional seconds.
 iso 1970-01-01T00:00:00Z
 iso 1999-12-31T23:59:59Z
 iso 2000-01-01T00:00:00Z
@@ -50,7 +59,15 @@ iso 2038-01-19T03:14:07Z
 iso 2099-12-31T23:59:59Z
 iso 2100-03-01T00:00:00Z
 iso 2026-06-24T15:20:00.123456Z
+# Fallback shapes (must match the date path, not the fast path): tz offsets,
+# fraction+offset, minute precision (no seconds), and impossible dates/times.
 iso 2026-06-24T15:20:00+00:00
+iso 2026-06-24T15:20:00+02:00
+iso 2026-06-24T15:20:00-05:00
+iso 2026-06-24T15:20:00.5+02:00
+iso 2026-06-24T15:20Z
+iso 2026-02-31T00:00:00Z
+iso 2026-01-01T24:00:00Z
 
 chk() { [ "$2" = "$3" ] && printf 'ok    %s\n' "$1" || { printf 'FAIL  %s want=%s got=%s\n' "$1" "$3" "$2"; fail=1; }; }
 

--- a/test/test-epoch.sh
+++ b/test/test-epoch.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Unit test for to_epoch() — the ISO 8601 / epoch parser behind the limit5h and
+# limit7d countdowns. Extracts the live function from statusline.sh so this test
+# can never drift from the implementation it checks.
+#
+#   bash test/test-epoch.sh
+#
+# The fork-free path is checked for byte-equality against the system `date`,
+# the reference it replaced. Needs only bash and date (no jq, no git).
+set -u
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+SCRIPT="$HERE/../statusline.sh"
+
+# Pull just the to_epoch function body out of the real script and define it here.
+eval "$(sed -n '/^to_epoch() {/,/^}/p' "$SCRIPT")"
+
+# Reference epoch via the system date (GNU first, BSD fallback) — what the old
+# implementation produced. The fork-free parser must match it exactly.
+ref_epoch() {
+  local r s
+  r=$(date -u -d "$1" +%s 2>/dev/null) && { echo "$r"; return; }
+  s="${1%%[.+]*}"; s="${s%Z}"
+  date -ju -f '%Y-%m-%dT%H:%M:%S' "$s" +%s 2>/dev/null
+}
+
+fail=0
+iso() {  # $1=ISO timestamp — assert to_epoch matches the system date
+  to_epoch "$1"; local got="$_EP" want; want=$(ref_epoch "$1")
+  if [ "$got" = "$want" ]; then
+    printf 'ok    %-30s %s\n' "$1" "$got"
+  else
+    printf 'FAIL  %-30s want=%s got=%s\n' "$1" "$want" "$got"; fail=1
+  fi
+}
+
+# Spread: epoch boundary, leap years, century non-leap, month edges, far future,
+# the 32-bit boundary, fractional seconds, and an explicit +00:00 offset.
+iso 1970-01-01T00:00:00Z
+iso 1999-12-31T23:59:59Z
+iso 2000-01-01T00:00:00Z
+iso 2000-02-29T12:00:00Z
+iso 2004-02-29T00:00:00Z
+iso 2024-02-29T23:59:59Z
+iso 2026-03-01T00:00:00Z
+iso 2026-06-24T15:20:00Z
+iso 2026-12-31T23:59:59Z
+iso 2030-01-01T09:30:00Z
+iso 2038-01-19T03:14:07Z
+iso 2099-12-31T23:59:59Z
+iso 2100-03-01T00:00:00Z
+iso 2026-06-24T15:20:00.123456Z
+iso 2026-06-24T15:20:00+00:00
+
+chk() { [ "$2" = "$3" ] && printf 'ok    %s\n' "$1" || { printf 'FAIL  %s want=%s got=%s\n' "$1" "$3" "$2"; fail=1; }; }
+
+# Epoch-int passthrough (callers that already hold epoch stay fork-free)
+to_epoch 1893490200;   chk "epoch-int passthrough" "$_EP" 1893490200
+to_epoch 1893490200.5; chk "epoch-float trims"     "$_EP" 1893490200
+# Empty input is rejected
+to_epoch ""; chk "empty returns non-zero" "$?" 1
+
+if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "SOME FAILED"; exit 1; fi


### PR DESCRIPTION
## Summary

`to_epoch` shelled out to `date` for every ISO 8601 timestamp. With the default
`limit5h`+`limit7d` segments that is 1-2 `date` forks on every render, on every
platform, that the segment gate never removes. Replace the canonical `...Z` UTC
shape with pure integer date math (days-from-civil); a timezone offset, reduced
precision, or an out-of-range date falls back to `date`.

This is a per-render fork removal: it speeds up a single session, and the saving
compounds under concurrent sessions (each renders on a 1s timer, so the forks
contend for CPU).

## Measured

Per-render, single session (60 renders):

| environment | before | after |
|---|---|---|
| macOS bash 5.3 | 55 ms | 45 ms |
| macOS bash 3.2 | 53 ms | 44 ms |
| Windows Git Bash | 158 ms | 120 ms |

The same saving under concurrent renders (wall-clock per N-render batch). The
per-render win is already present at N=1; the absolute gap widens with N as the
removed forks stop contending for CPU:

| N | macOS 5.3 | macOS 3.2 | Windows Git Bash |
|---|---|---|---|
| 1 | 68 -> 54 ms | 70 -> 57 ms | 159 -> 124 ms |
| 2 | 70 -> 58 ms | 77 -> 66 ms | 209 -> 163 ms |
| 4 | 89 -> 72 ms | 92 -> 79 ms | 255 -> 209 ms |
| 8 | 125 -> 105 ms | 142 -> 112 ms | 392 -> 339 ms |

Date forks per render drop from 2 to 0 on bash 4.2+/Git Bash/Linux (where `printf
'%(...)T'` already makes the clock and `NOW` fork-free), and from 4 to 2 on bash 3.2.

## Correctness

The fast path runs only for exactly `YYYY-MM-DDTHH:MM:SS` (optional `.fraction`,
optional `Z`) with in-range, real calendar fields. A tz offset, minute precision,
or an impossible date falls through to `date`, matching the old behavior on both
GNU and BSD date. `test/test-epoch.sh` asserts result- and return-code-parity with
the old date reference across epoch boundaries, leap years, the 2100 century
non-leap, the 32-bit boundary, fractional seconds, +/- offsets, fraction+offset,
minute precision, and impossible dates. Passes on bash 3.2.57, 5.3.15, and Git
Bash GNU date.

## Test plan

- [x] `bash -n` passes
- [x] All 8 test suites pass on bash 3.2 and 5.3
- [x] Canonical `...Z` shape verified fork-free (0 date forks/render via a date wrapper)
- [x] Parity verified on Git Bash GNU date (offsets applied correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhVjqMnx2NjVq5BFsTikWx
