### PR TITLE
fix(float): make file_mtime robust to GNU vs BSD stat

### DIFF
--- a/example/float-display-iterm2/coralline-float
+++ b/example/float-display-iterm2/coralline-float
@@ -38,9 +38,18 @@ emit() {
   printf '\033]1337;SetUserVar=coralline=%s\007' "$b64" > "$TTY"
 }
 
-# Portable mtime in epoch seconds (BSD then GNU).
+# Portable mtime in epoch seconds, robust to whichever stat is on PATH.
+# GNU coreutils (-c) is tried first: BSD's `stat -f %m` is misread by GNU stat as
+# --file-system and "succeeds" with non-numeric junk, so a BSD-first chain breaks
+# on machines that have GNU stat installed (e.g. via Nix/Homebrew coreutils).
+# The numeric guard keeps any stray output from reaching arithmetic under set -u.
 file_mtime() {
-  stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null
+  local mt
+  mt=$(stat -c %Y "$1" 2>/dev/null) || mt=$(stat -f %m "$1" 2>/dev/null)
+  case "$mt" in
+    ''|*[!0-9]*) ;;          # not a clean integer → emit nothing (treated as stale)
+    *) printf '%s' "$mt" ;;
+  esac
 }
 
 # Compute the value to push: contents if fresh, empty if stale/missing.


### PR DESCRIPTION
Split out of #37 so each PR stays one concern (per review).

## Problem

`example/float-display-iterm2/coralline-float`'s `file_mtime` did
`stat -f %m || stat -c %Y` (BSD-first). On machines with GNU coreutils, GNU
`stat` misreads `-f %m` as `--file-system` and "succeeds" with non-numeric
junk, so the BSD-first chain returns garbage that then reaches arithmetic and
breaks under `set -u`.

## Fix

Try GNU `-c %Y` first, fall back to BSD `-f %m`, and numeric-guard the result
so any stray output is treated as stale rather than fed into arithmetic.

Verified `bash test/test-float-companion.sh` passes on bash 3.2 and 5.x.