### PR TITLE
fix(configure): restore the post-install verification render

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -1193,6 +1193,11 @@ write_final_config() {
   mv "$tmp" "$CONFIG_FILE"
   printf '%sWrote%s %s\n' "$T_GREEN" "$T_RESET" "$CONFIG_FILE"
   [ "$float_enabled" = "1" ] && print_float_help
+  # Return success explicitly: the trailing float test above is 1 when float is
+  # off (the default), which would otherwise make the caller's
+  # `write_final_config || exit 0` bail before the verification render. The only
+  # intentional non-zero exit is the "user declined overwrite" path above.
+  return 0
 }
 
 install_files() {

--- a/configure.sh
+++ b/configure.sh
@@ -1191,7 +1191,11 @@ write_final_config() {
   fi
   # Fail loud if the config cannot be written, rather than printing Wrote and
   # rendering against a stale config. Without these guards the unconditional
-  # return 0 below would report success even when mkdir/mv failed.
+  # return 0 below would report success even when the write did not land at
+  # $CONFIG_FILE. The -d check comes first: mv into a directory (or a symlink to
+  # one) "succeeds" by dropping the temp file inside it under its mktemp name,
+  # leaving $CONFIG_FILE a directory that statusline.sh never sources.
+  [ -d "$CONFIG_FILE" ] && die "config path $CONFIG_FILE is a directory, expected a file"
   mkdir -p "$(dirname "$CONFIG_FILE")" || die "could not create $(dirname "$CONFIG_FILE")"
   mv "$tmp" "$CONFIG_FILE" || die "could not write $CONFIG_FILE"
   printf '%sWrote%s %s\n' "$T_GREEN" "$T_RESET" "$CONFIG_FILE"

--- a/configure.sh
+++ b/configure.sh
@@ -1189,8 +1189,11 @@ write_final_config() {
       return 1
     fi
   fi
-  mkdir -p "$(dirname "$CONFIG_FILE")"
-  mv "$tmp" "$CONFIG_FILE"
+  # Fail loud if the config cannot be written, rather than printing Wrote and
+  # rendering against a stale config. Without these guards the unconditional
+  # return 0 below would report success even when mkdir/mv failed.
+  mkdir -p "$(dirname "$CONFIG_FILE")" || die "could not create $(dirname "$CONFIG_FILE")"
+  mv "$tmp" "$CONFIG_FILE" || die "could not write $CONFIG_FILE"
   printf '%sWrote%s %s\n' "$T_GREEN" "$T_RESET" "$CONFIG_FILE"
   [ "$float_enabled" = "1" ] && print_float_help
   # Return success explicitly: the trailing float test above is 1 when float is

--- a/test/test-final-render.sh
+++ b/test/test-final-render.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Regression: the post-install "Verification render:" must print after a
+# successful --install, regardless of VL_FLOAT.
+#
+# write_final_config used to end with `[ "$float_enabled" = "1" ] && print_float_help`,
+# whose exit status is 1 when float is off (the default). The caller runs
+# `write_final_config || exit 0`, so that non-zero status silently skipped the
+# verify_render step and the final render vanished. write_final_config now
+# returns 0 on the success path (the only intentional non-zero is a declined
+# overwrite). This test drives a real install and asserts the render prints.
+#   bash test/test-final-render.sh
+# Needs bash + jq (configure.sh merges Claude settings with jq).
+set -u
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+REPO=$(cd "$HERE/.." && pwd)
+fail=0
+check() { if [ "$2" = "1" ]; then printf 'ok    %s\n' "$1"; else printf 'FAIL  %s\n' "$1"; fail=1; fi; }
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP  jq not available"; exit 0; }
+
+# Fresh sandbox HOME, no pre-existing config -> float defaults off: the exact
+# case the regression hid. CORALLINE_NO_SAMPLE keeps the verify render from
+# touching the cross-session stores (#32).
+home=$(mktemp -d "${TMPDIR:-/tmp}/coralline-final-render.XXXXXX") || exit 1
+trap 'rm -rf "$home"' EXIT
+out=$(CORALLINE_NO_SAMPLE=1 HOME="$home" bash "$REPO/configure.sh" --install --default 2>&1)
+
+case "$out" in
+  *"Verification render:"*) check "post-install verification render prints (float off)" 1 ;;
+  *)                        check "post-install verification render prints (float off)" 0 ;;
+esac
+# Sanity: we reached the success path (config actually written), not the decline path.
+[ -f "$home/.claude/coralline.conf" ] && check "coralline.conf was written" 1 || check "coralline.conf was written" 0
+
+if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "SOME FAILED"; exit 1; fi

--- a/test/test-final-render.sh
+++ b/test/test-final-render.sh
@@ -55,4 +55,18 @@ case "$out2" in
 esac
 rm -rf "$h2"
 
+# --- Case 3: config path is a directory -> die before mv, no false success ---
+# mv into a directory would otherwise "succeed" (temp file dropped inside it),
+# leaving $CONFIG_FILE a directory that statusline.sh never sources.
+h3=$(mktemp -d "${TMPDIR:-/tmp}/coralline-final-render.XXXXXX") || exit 1
+mkdir -p "$h3/.claude/coralline.conf"             # a DIRECTORY at the config path
+out3=$(run_install "$h3" "$h3/.claude/coralline.conf"); rc3=$?
+[ "$rc3" -ne 0 ] && check "directory config path exits non-zero" 1 || check "directory config path exits non-zero" 0
+[ -d "$h3/.claude/coralline.conf" ] && check "directory config path left intact (no temp file dropped in)" "$([ -z "$(find "$h3/.claude/coralline.conf" -type f 2>/dev/null)" ] && echo 1 || echo 0)" || check "directory config path left intact" 0
+case "$out3" in
+  *"Verification render:"*) check "no verification render for a directory config path" 0 ;;
+  *)                        check "no verification render for a directory config path" 1 ;;
+esac
+rm -rf "$h3"
+
 if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "SOME FAILED"; exit 1; fi

--- a/test/test-final-render.sh
+++ b/test/test-final-render.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # Regression: the post-install "Verification render:" must print after a
-# successful --install, regardless of VL_FLOAT.
+# successful --install, regardless of VL_FLOAT, and must NOT print when the
+# config write fails.
 #
 # write_final_config used to end with `[ "$float_enabled" = "1" ] && print_float_help`,
 # whose exit status is 1 when float is off (the default). The caller runs
 # `write_final_config || exit 0`, so that non-zero status silently skipped the
-# verify_render step and the final render vanished. write_final_config now
+# verify_render step and the final "Verification render:" vanished. It now
 # returns 0 on the success path (the only intentional non-zero is a declined
-# overwrite). This test drives a real install and asserts the render prints.
+# overwrite), but guards mkdir/mv with `|| die` so a failed write still stops
+# rather than reporting a false success.
 #   bash test/test-final-render.sh
 # Needs bash + jq (configure.sh merges Claude settings with jq).
 set -u
@@ -19,18 +21,38 @@ check() { if [ "$2" = "1" ]; then printf 'ok    %s\n' "$1"; else printf 'FAIL  %
 
 command -v jq >/dev/null 2>&1 || { echo "SKIP  jq not available"; exit 0; }
 
-# Fresh sandbox HOME, no pre-existing config -> float defaults off: the exact
-# case the regression hid. CORALLINE_NO_SAMPLE keeps the verify render from
-# touching the cross-session stores (#32).
-home=$(mktemp -d "${TMPDIR:-/tmp}/coralline-final-render.XXXXXX") || exit 1
-trap 'rm -rf "$home"' EXIT
-out=$(CORALLINE_NO_SAMPLE=1 HOME="$home" bash "$REPO/configure.sh" --install --default 2>&1)
+# Drive a real --install with every path pinned into the sandbox. Pinning
+# CORALLINE_HOME/CONFIG and CLAUDE_SETTINGS (not just HOME) keeps the test
+# hermetic even when a dev/CI shell exports those overrides, so it can never
+# write into the real ~/.claude. CORALLINE_NO_SAMPLE keeps the verify render off
+# the cross-session stores (#32).
+run_install() { # $1 = sandbox HOME, $2 = CONFIG_FILE path
+  CORALLINE_NO_SAMPLE=1 HOME="$1" \
+    CORALLINE_HOME="$1/.claude/coralline" \
+    CLAUDE_SETTINGS="$1/.claude/settings.json" \
+    CORALLINE_CONFIG="$2" \
+    bash "$REPO/configure.sh" --install --default 2>&1
+}
 
-case "$out" in
+# --- Case 1: fresh install, float OFF (the default) -> render must print ------
+h1=$(mktemp -d "${TMPDIR:-/tmp}/coralline-final-render.XXXXXX") || exit 1
+out1=$(run_install "$h1" "$h1/.claude/coralline.conf")
+case "$out1" in
   *"Verification render:"*) check "post-install verification render prints (float off)" 1 ;;
   *)                        check "post-install verification render prints (float off)" 0 ;;
 esac
-# Sanity: we reached the success path (config actually written), not the decline path.
-[ -f "$home/.claude/coralline.conf" ] && check "coralline.conf was written" 1 || check "coralline.conf was written" 0
+[ -f "$h1/.claude/coralline.conf" ] && check "coralline.conf was written" 1 || check "coralline.conf was written" 0
+rm -rf "$h1"
+
+# --- Case 2: unwritable config path -> die, no false success render ----------
+h2=$(mktemp -d "${TMPDIR:-/tmp}/coralline-final-render.XXXXXX") || exit 1
+: > "$h2/blocker"                                  # a regular file where a dir must be
+out2=$(run_install "$h2" "$h2/blocker/coralline.conf"); rc2=$?
+[ "$rc2" -ne 0 ] && check "failed config write exits non-zero" 1 || check "failed config write exits non-zero" 0
+case "$out2" in
+  *"Verification render:"*) check "no verification render after a failed write" 0 ;;
+  *)                        check "no verification render after a failed write" 1 ;;
+esac
+rm -rf "$h2"
 
 if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "SOME FAILED"; exit 1; fi


### PR DESCRIPTION
## What

The post-install "Verification render:" (the final preview of the config just written) stopped printing whenever the float readout was off, which is the default. A normal install / wizard / --default / --import-p10k run ended at "Wrote ..." with no closing render.

## Why

`write_final_config` ends with `[ "$float_enabled" = "1" ] && print_float_help`. With float off that test exits non-zero, so the function returns non-zero, and the caller `write_final_config || exit 0` exits before reaching `verify_render`. It regressed in 49912802 (the float-help line); before that the function's last statement was the `Wrote` printf, which returns 0, so the render always ran.

## Fix

Return 0 explicitly at the end of the success path. The one intentional non-zero exit, the declined-overwrite branch, is untouched, so declining still skips the render as before.

## Testing

Adds `test/test-final-render.sh`: drives a real `configure.sh --install --default` in a sandbox HOME (float off) and asserts the output contains "Verification render:". Confirmed it fails on the pre-fix code and passes after. Full `test/*.sh` suite green on macOS bash 3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5hLzQXCX3gKGVsqaezcrv
