### PR TITLE
feat: native PowerShell statusline for Windows without Git Bash

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,10 +1,13 @@
 # coralline — AI Installation Playbook
 
 > **You are an AI coding assistant** and a user asked you to install coralline.
-> Humans and AI use the same installer entrypoint, but not the same setup UX.
-> For AI installs, bootstrap the runtime with `install.sh --install-only`, interview
-> the user, write `~/.claude/coralline.conf`, and verify. Do not operate the human TUI
-> unless the user explicitly asks to customize visually.
+> This playbook installs the Bash renderer on macOS, Linux, or Windows with Bash.
+> On PowerShell-only Windows (no Git Bash or WSL), do not run `install.sh`; use the
+> native archive procedure in the README's
+> [Windows without Git Bash](README.md#windows-without-git-bash) section instead.
+> For Bash-based AI installs, bootstrap the runtime with `install.sh --install-only`,
+> interview the user, write `~/.claude/coralline.conf`, and verify. Do not operate the
+> human TUI unless the user explicitly asks to customize visually.
 
 > **Before running anything:** tell the user what will be installed and where (the
 > Overview table below), and offer the choice between a pinned release (`--ref`, latest
@@ -17,9 +20,10 @@
 
 ## Overview
 
-coralline is a powerline-style statusline for Claude Code. Installation places the
-renderer under `~/.claude/coralline`, writes `~/.claude/coralline.conf`, and merges
-the `statusLine` command into `~/.claude/settings.json`.
+coralline is a powerline-style statusline for Claude Code. This Bash installation path
+places the renderer under `~/.claude/coralline`, writes
+`~/.claude/coralline.conf`, and merges the `statusLine` command into
+`~/.claude/settings.json`.
 
 | Artifact | Destination | Purpose |
 |---|---|---|
@@ -103,15 +107,17 @@ curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.s
 
 When installing for a user:
 
-1. Ask the user to choose setup mode before installing. Use the runtime's native choice UI
+1. Confirm that this is a Bash-capable environment. If it is PowerShell-only Windows, stop
+   this playbook and use the native README procedure linked at the top.
+2. Ask the user to choose setup mode before installing. Use the runtime's native choice UI
    when available; otherwise show the text menu below and wait for a reply.
-2. Run the fast-path installer with `--install-only`.
-3. If it fails because `jq` is missing, explain the package-manager command and rerun after
+3. Run the fast-path installer with `--install-only`.
+4. If it fails because `jq` is missing, explain the package-manager command and rerun after
    the user installs it.
-4. Follow the selected setup mode.
-5. Write `~/.claude/coralline.conf` unless the user chose the visual wizard.
-6. Verify with the bundled sample input.
-7. After success, tell the user to restart Claude Code or open a new session if the statusline
+5. Follow the selected setup mode.
+6. Write `~/.claude/coralline.conf` unless the user chose the visual wizard.
+7. Verify with the bundled sample input.
+8. After success, tell the user to restart Claude Code or open a new session if the statusline
    does not appear immediately, and mention they can rerun
    `bash ~/.claude/coralline/configure.sh` to customize it later.
 
@@ -230,8 +236,10 @@ VL_ASCII=0
 VL_LEAN_SEP=""
 ```
 
-Adjust the values based on the interview. If the config already exists, preserve the user's
-manual edits when possible, or show the change before overwriting.
+Adjust the values based on the interview. Create the config only when it is absent and after
+showing the complete proposed file. If it already exists, leave it byte-for-byte unchanged by
+default. For any user-approved customization, show a bounded additive diff first, preserve
+unrelated assignments and comments, and make a timestamped backup before an atomic replacement.
 
 ## Manual Fallback
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ that skepticism is inspection, not trust:
 
 ### Uninstall
 
-If you enabled themed subagent rows, remove their settings entry before deleting the tools:
+For a Bash-capable install, remove themed subagent rows before deleting the tools:
 
 ```bash
 bash ~/.claude/coralline/configure.sh --subagent-rows=off
@@ -309,6 +309,23 @@ rm -rf ~/.claude/coralline ~/.claude/coralline.conf
 
 Then delete the `statusLine` block from `~/.claude/settings.json` (or restore the newest
 `settings.json.bak.*`). If you skipped the first command, also delete `subagentStatusLine`.
+
+For a PowerShell-only native archive install, close Claude Code and back up the settings file:
+
+```powershell
+$settings = Join-Path $HOME '.claude\settings.json'
+Copy-Item -LiteralPath $settings -Destination "$settings.bak.$(Get-Date -Format yyyyMMddHHmmss)"
+notepad.exe $settings
+```
+
+In Notepad, delete the `statusLine` object whose command points to
+`~/.claude/coralline/statusline.ps1`. Also delete `subagentStatusLine` if its command points
+into coralline, then save valid JSON. Finally remove the installed runtime and optional config:
+
+```powershell
+Remove-Item -LiteralPath (Join-Path $HOME '.claude\coralline') -Recurse -Force
+Remove-Item -LiteralPath (Join-Path $HOME '.claude\coralline.conf') -Force -ErrorAction SilentlyContinue
+```
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -330,12 +330,15 @@ operate that TUI unless you explicitly ask for visual customization.
 
 ### Reconfigure
 
-Every install path copies the wizard into `~/.claude/coralline`, so you can rerun it anytime to
-restyle:
+Both Bash install paths copy the wizard into `~/.claude/coralline`, so Bash-capable users can
+rerun it anytime to restyle:
 
 ```bash
 bash ~/.claude/coralline/configure.sh
 ```
+
+PowerShell-only installs do not include a native wizard. Back up and edit
+`$HOME\.claude\coralline.conf` manually, or reuse a config produced on a Bash-capable host.
 
 ### Testing a fork
 

--- a/README.md
+++ b/README.md
@@ -187,17 +187,24 @@ a native Windows PowerShell 5.1 port that needs neither: no bash, no `jq`, only 
 version too).
 
 It reads the exact same `~/.claude/coralline.conf` (and theme file) a bash install already
-wrote, so nothing about the config format changes; only the renderer is new. See
-[coralline-8-scope.md](../../handoff/coralline-8-scope.md) in the factory notes for the segment
-parity matrix and what is not ported yet (`lean`/`classic` styles, the `auto` responsive-wrap
-layout, the `burn` segment, and the `--subagent` panel-row protocol; unsupported style/layout
-values fall back to `pill`/`fixed` instead of erroring).
+wrote, so nothing about the config format changes; only the renderer is new. The native main
+bar supports the same segments, `pill`/`lean`/`classic` styles, `fixed`/`auto` layouts, burn
+history, limit sync, and float publication as the bash renderer. The `--subagent` panel-row
+protocol remains bash-only and exits without output in `statusline.ps1`.
 
 ```powershell
-git clone https://github.com/Nanako0129/coralline C:\Users\you\.claude\coralline-src
-New-Item -ItemType Directory -Force C:\Users\you\.claude\coralline\themes
-Copy-Item C:\Users\you\.claude\coralline-src\statusline.ps1 C:\Users\you\.claude\coralline\
-Copy-Item C:\Users\you\.claude\coralline-src\themes\*.conf C:\Users\you\.claude\coralline\themes\
+$download = Join-Path $env:TEMP ("coralline-" + [guid]::NewGuid())
+$archive = Join-Path $download "coralline-main.zip"
+New-Item -ItemType Directory -Force $download | Out-Null
+Invoke-WebRequest https://github.com/Nanako0129/coralline/archive/refs/heads/main.zip -UseBasicParsing -OutFile $archive
+Expand-Archive $archive -DestinationPath $download
+
+$source = Join-Path $download "coralline-main"
+$target = Join-Path $HOME ".claude\coralline"
+New-Item -ItemType Directory -Force (Join-Path $target "themes") | Out-Null
+Copy-Item (Join-Path $source "statusline.ps1") $target
+Copy-Item (Join-Path $source "themes\*.conf") (Join-Path $target "themes")
+Remove-Item $download -Recurse -Force
 ```
 
 Then add to `~/.claude/settings.json`:
@@ -206,13 +213,16 @@ Then add to `~/.claude/settings.json`:
 {
   "statusLine": {
     "type": "command",
-    "command": "powershell -NoProfile -File C:/Users/you/.claude/coralline/statusline.ps1"
+    "command": "powershell -NoProfile -ExecutionPolicy Bypass -File C:/Users/you/.claude/coralline/statusline.ps1"
   }
 }
 ```
 
 Run the wizard-written config from a bash install, or write `~/.claude/coralline.conf` by hand
-(see any file under `themes/` for the shape); both work with `statusline.ps1` unchanged.
+(see any file under `themes/` for the shape); both work with `statusline.ps1` unchanged. The
+per-process `ExecutionPolicy Bypass` lets the unsigned local renderer start when the normal
+session default would otherwise be `Restricted`; it does not change any persisted policy, and
+an enforced Group Policy still takes precedence.
 
 ### Updating
 
@@ -511,12 +521,11 @@ The wizard discovers themes automatically from `themes/*.conf` and nested collec
 | macOS | ✅ supported (works on the stock bash 3.2) |
 | Linux | ✅ supported |
 | Windows + Git Bash | ✅ supported — Claude Code runs the status line through Git Bash when it's installed |
-| Windows without Git Bash | ❌ not yet — Claude Code falls back to PowerShell, which can't run the bash script ([roadmap](https://github.com/Nanako0129/coralline/issues)) |
+| Windows without Git Bash | ✅ supported for the main bar through native Windows PowerShell 5.1 |
 
-> **Windows note:** install [Git for Windows](https://git-scm.com/download/win) (which bundles
-> Git Bash) and `jq`, and coralline runs natively. A native PowerShell port for the no-Git-Bash
-> case is on the roadmap. The render path is built to stay cheap under Git Bash's emulated
-> `fork()` — one `jq`, one `git`, and no per-field subprocess spawning.
+> **Windows note:** the native PowerShell renderer needs neither Git Bash nor `jq`. `git.exe`
+> is optional and only enables the `git`, `stash`, and `project` segments. The interactive
+> wizard and themed `--subagent` rows remain bash-only.
 
 ## Why it's fast
 

--- a/README.md
+++ b/README.md
@@ -115,12 +115,15 @@ bar, point the registration at its own config file:
 
 ## Install
 
-Three ways to install, all driven by the same `install.sh`. Each one copies the renderer **and
-the setup wizard** into `~/.claude/coralline` and registers the status line in Claude Code, so
-you can re-run the wizard later no matter which way you installed.
+On macOS, Linux, and Windows environments with Bash, three install routes use the same
+`install.sh`. Each one copies the Bash renderer **and the setup wizard** into
+`~/.claude/coralline` and registers the status line in Claude Code, so you can re-run the
+wizard later no matter which Bash route you used. A PowerShell-only Windows machine uses the
+separate native archive flow under [Windows without Git Bash](#windows-without-git-bash).
 
-> **Requirements:** `jq` and a [Nerd Font](https://www.nerdfonts.com/) terminal. No Nerd Font?
-> Set `VL_ASCII=1` in your config for a glyph-free rendering.
+> **Bash requirements:** `jq` and a [Nerd Font](https://www.nerdfonts.com/) terminal. No Nerd
+> Font? Set `VL_ASCII=1` in your config for a glyph-free rendering. The native PowerShell
+> renderer below does not require `jq`.
 
 ### Ask Claude (recommended)
 
@@ -132,16 +135,18 @@ fetch https://raw.githubusercontent.com/Nanako0129/coralline/main/INSTALL.md
 and follow the playbook in it.
 ```
 
-Claude will read the playbook, use the same installer to bootstrap the runtime, interview you
-about the look, write the config, verify it, and remind you that you can rerun the visual
-wizard if the first result doesn't match your taste.
+In a Bash environment, Claude will read the playbook, use `install.sh` to bootstrap the
+runtime, interview you about the look, write the config, verify it, and remind you that you can
+rerun the visual wizard if the first result doesn't match your taste. On PowerShell-only
+Windows, use the native archive flow below instead; the Bash playbook does not install
+`statusline.ps1`.
 
 If your Claude flags the playbook and wants to inspect things first, that is the right
 instinct, not an obstacle: see [Trust and security](#trust-and-security).
 
 ### Install it yourself
 
-Run the installer in your terminal:
+Run the Bash installer in your terminal:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
@@ -307,8 +312,10 @@ Then delete the `statusLine` block from `~/.claude/settings.json` (or restore th
 
 ## Setup
 
-Both paths use the same installer. Humans run it with no mode and get the visual setup. Claude
-uses it with `--install-only`, then follows `INSTALL.md` to interview you and write config.
+Both Bash setup paths use the same installer. Humans run it with no mode and get the visual
+setup. Claude uses it with `--install-only`, then follows `INSTALL.md` to interview you and
+write config. The native PowerShell archive path does not install a PowerShell wizard; it reads
+the same `coralline.conf`, which can come from an existing Bash setup or be written manually.
 
 ### Setup modes
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,42 @@ Then add to `~/.claude/settings.json`:
 > installers bundle every theme; after a manual install, copy the rest of
 > `~/.claude/coralline-src/themes/*.conf` into `~/.claude/coralline/themes/` to switch themes.
 
+### Windows without Git Bash
+
+`statusline.sh` needs a bash to run it, so a PowerShell-only Windows machine (no Git for
+Windows, no WSL) cannot use it at all — `install.sh` is itself a bash script. `statusline.ps1` is
+a native Windows PowerShell 5.1 port that needs neither: no bash, no `jq`, only `git.exe` on
+`PATH` for the `git`/`stash`/`project` segments (already required for those segments in the bash
+version too).
+
+It reads the exact same `~/.claude/coralline.conf` (and theme file) a bash install already
+wrote, so nothing about the config format changes; only the renderer is new. See
+[coralline-8-scope.md](../../handoff/coralline-8-scope.md) in the factory notes for the segment
+parity matrix and what is not ported yet (`lean`/`classic` styles, the `auto` responsive-wrap
+layout, the `burn` segment, and the `--subagent` panel-row protocol; unsupported style/layout
+values fall back to `pill`/`fixed` instead of erroring).
+
+```powershell
+git clone https://github.com/Nanako0129/coralline C:\Users\you\.claude\coralline-src
+New-Item -ItemType Directory -Force C:\Users\you\.claude\coralline\themes
+Copy-Item C:\Users\you\.claude\coralline-src\statusline.ps1 C:\Users\you\.claude\coralline\
+Copy-Item C:\Users\you\.claude\coralline-src\themes\*.conf C:\Users\you\.claude\coralline\themes\
+```
+
+Then add to `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "powershell -NoProfile -File C:/Users/you/.claude/coralline/statusline.ps1"
+  }
+}
+```
+
+Run the wizard-written config from a bash install, or write `~/.claude/coralline.conf` by hand
+(see any file under `themes/` for the shape); both work with `statusline.ps1` unchanged.
+
 ### Updating
 
 Two ways to update, both driven by the same installer. Either way your

--- a/README.md
+++ b/README.md
@@ -202,7 +202,11 @@ Expand-Archive $archive -DestinationPath $download
 $source = Join-Path $download "coralline-main"
 $target = Join-Path $HOME ".claude\coralline"
 New-Item -ItemType Directory -Force (Join-Path $target "themes") | Out-Null
-Copy-Item (Join-Path $source "statusline.ps1") $target
+$runtime = Join-Path $target "statusline.ps1"
+if (Test-Path -LiteralPath $runtime) {
+  Copy-Item -LiteralPath $runtime -Destination ($runtime + ".bak." + (Get-Date -Format "yyyyMMdd-HHmmss"))
+}
+Copy-Item (Join-Path $source "statusline.ps1") $runtime
 Copy-Item (Join-Path $source "themes\*.conf") (Join-Path $target "themes")
 Remove-Item $download -Recurse -Force
 ```
@@ -213,7 +217,7 @@ Then add to `~/.claude/settings.json`:
 {
   "statusLine": {
     "type": "command",
-    "command": "powershell -NoProfile -ExecutionPolicy Bypass -File C:/Users/you/.claude/coralline/statusline.ps1"
+    "command": "powershell -NoProfile -ExecutionPolicy Bypass -File \"C:/Users/you/.claude/coralline/statusline.ps1\""
   }
 }
 ```
@@ -226,9 +230,17 @@ an enforced Group Policy still takes precedence.
 
 ### Updating
 
-Two ways to update, both driven by the same installer. Either way your
+The two installer-driven routes below update Bash-based installs. Either way your
 `~/.claude/coralline.conf` is preserved and the previous `statusline.sh` is backed up
 under `~/.claude/coralline/` (the 3 newest are kept).
+
+#### PowerShell-only update
+
+On a machine without Bash, re-run the PowerShell archive block under
+[Windows without Git Bash](#windows-without-git-bash). The same block is also the native
+update path: it downloads the current `main` archive, backs up an existing
+`statusline.ps1` as `statusline.ps1.bak.<timestamp>`, refreshes the renderer and all themes,
+and leaves `~/.claude/coralline.conf` plus `settings.json` unchanged.
 
 #### Ask Claude (recommended)
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -191,7 +191,11 @@ Expand-Archive $archive -DestinationPath $download
 $source = Join-Path $download "coralline-main"
 $target = Join-Path $HOME ".claude\coralline"
 New-Item -ItemType Directory -Force (Join-Path $target "themes") | Out-Null
-Copy-Item (Join-Path $source "statusline.ps1") $target
+$runtime = Join-Path $target "statusline.ps1"
+if (Test-Path -LiteralPath $runtime) {
+  Copy-Item -LiteralPath $runtime -Destination ($runtime + ".bak." + (Get-Date -Format "yyyyMMdd-HHmmss"))
+}
+Copy-Item (Join-Path $source "statusline.ps1") $runtime
 Copy-Item (Join-Path $source "themes\*.conf") (Join-Path $target "themes")
 Remove-Item $download -Recurse -Force
 ```
@@ -202,7 +206,7 @@ Remove-Item $download -Recurse -Force
 {
   "statusLine": {
     "type": "command",
-    "command": "powershell -NoProfile -ExecutionPolicy Bypass -File C:/Users/you/.claude/coralline/statusline.ps1"
+    "command": "powershell -NoProfile -ExecutionPolicy Bypass -File \"C:/Users/you/.claude/coralline/statusline.ps1\""
   }
 }
 ```
@@ -214,8 +218,15 @@ renderer 在一般 session 預設為 `Restricted` 時仍能啟動；它不會修
 
 ### 更新
 
-兩種更新方式，都由同一支 installer 驅動。無論哪種，你的 `~/.claude/coralline.conf`
+下方兩種 installer 流程用於更新 Bash 安裝。無論哪種，你的 `~/.claude/coralline.conf`
 都會被保留，舊的 `statusline.sh` 會備份在 `~/.claude/coralline/` 下（保留最近 3 份）。
+
+#### 僅 PowerShell 的更新方式
+
+沒有 Bash 的電腦請重新執行 [Windows 無 Git Bash](#windows-無-git-bash)
+小節中的 PowerShell archive 指令。該區塊同時就是原生更新流程：下載目前的 `main`
+archive、把既有 `statusline.ps1` 備份為 `statusline.ps1.bak.<timestamp>`、更新
+renderer 與全部 themes，並保留 `~/.claude/coralline.conf` 與 `settings.json`。
 
 #### 請 Claude 更新（推薦）
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -169,6 +169,49 @@ cp ~/.claude/coralline-src/themes/claude-coral.conf ~/.claude/coralline/themes/
 > **注意：** 上面的指令只複製 `claude-coral` 一個主題。「請 Claude 安裝」與一行安裝會帶上全部主題；
 > 手動安裝後若要換主題，把 `~/.claude/coralline-src/themes/*.conf` 其餘的也複製進 `~/.claude/coralline/themes/`。
 
+### Windows 無 Git Bash
+
+`statusline.sh` 本身需要 bash，因此只有 Windows PowerShell 5.1、沒有 Git for Windows
+或 WSL 的電腦無法執行它。`statusline.ps1` 是原生 Windows PowerShell 5.1 renderer，
+不需要 bash 或 `jq`；只有啟用 `git`／`stash`／`project` segments 時才需要 `PATH`
+中有 `git.exe`。
+
+它會讀取 bash 版本相同的 `~/.claude/coralline.conf` 與 theme 檔。原生主列與 bash
+renderer 支援相同的 segments、`pill`／`lean`／`classic` styles、
+`fixed`／`auto` layouts、burn history、limit sync 與 float publication。
+只有 `--subagent` 面板列協定仍限定使用 bash；`statusline.ps1 --subagent` 不會輸出內容。
+
+```powershell
+$download = Join-Path $env:TEMP ("coralline-" + [guid]::NewGuid())
+$archive = Join-Path $download "coralline-main.zip"
+New-Item -ItemType Directory -Force $download | Out-Null
+Invoke-WebRequest https://github.com/Nanako0129/coralline/archive/refs/heads/main.zip -UseBasicParsing -OutFile $archive
+Expand-Archive $archive -DestinationPath $download
+
+$source = Join-Path $download "coralline-main"
+$target = Join-Path $HOME ".claude\coralline"
+New-Item -ItemType Directory -Force (Join-Path $target "themes") | Out-Null
+Copy-Item (Join-Path $source "statusline.ps1") $target
+Copy-Item (Join-Path $source "themes\*.conf") (Join-Path $target "themes")
+Remove-Item $download -Recurse -Force
+```
+
+接著在 `~/.claude/settings.json` 加入：
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "powershell -NoProfile -ExecutionPolicy Bypass -File C:/Users/you/.claude/coralline/statusline.ps1"
+  }
+}
+```
+
+可以沿用 bash wizard 已寫好的設定，或參考 `themes/` 內任一檔案手動建立
+`~/.claude/coralline.conf`。per-process `ExecutionPolicy Bypass` 讓未簽章的本機
+renderer 在一般 session 預設為 `Restricted` 時仍能啟動；它不會修改任何持久化 policy，
+且強制套用的 Group Policy 仍具有最高優先權。
+
 ### 更新
 
 兩種更新方式，都由同一支 installer 驅動。無論哪種，你的 `~/.claude/coralline.conf`
@@ -421,11 +464,11 @@ wizard 會自動掃描 `themes/*.conf` 與 `themes/best-themes/*.conf` 這類巢
 | macOS | ✅ 支援（內建 bash 3.2 即可） |
 | Linux | ✅ 支援 |
 | Windows + Git Bash | ✅ 支援——有裝 Git Bash 時，Claude Code 會用它執行 statusline |
-| Windows 無 Git Bash | ❌ 暫不支援——Claude Code 會退回 PowerShell，跑不了 bash 腳本（[roadmap](https://github.com/Nanako0129/coralline/issues)） |
+| Windows 無 Git Bash | ✅ 原生 Windows PowerShell 5.1 支援主列 |
 
-> **Windows 提醒：** 裝 [Git for Windows](https://git-scm.com/download/win)（內含 Git Bash）和 `jq`，
-> coralline 即可原生運作。給「無 Git Bash」情境的原生 PowerShell 版本列在 roadmap 上。渲染流程
-> 特意設計成在 Git Bash 模擬的 `fork()` 下仍便宜——一個 `jq`、一個 `git`，沒有逐欄位的子程序開銷。
+> **Windows 提醒：** 原生 PowerShell renderer 不需要 Git Bash 或 `jq`。`git.exe`
+> 是選用項目，只用來啟用 `git`、`stash`、`project` segments。互動式 wizard 與套用
+> theme 的 `--subagent` 列仍限定使用 bash。
 
 ## 為什麼很快
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -110,11 +110,15 @@ burn、git 與 runtime segments——都只作用於主列，在 subagent 模式
 
 ## 安裝
 
-三種安裝方式都由同一支 `install.sh` 驅動，每一種都會把 renderer **與設定 wizard** 複製到
-`~/.claude/coralline`、並把 statusline 註冊進 Claude Code，所以不管你用哪種方式裝，之後都能重跑 wizard。
+在 macOS、Linux，以及具有 Bash 的 Windows 環境中，三種安裝方式都由同一支
+`install.sh` 驅動。每一種都會把 Bash renderer **與設定 wizard** 複製到
+`~/.claude/coralline`、並把 statusline 註冊進 Claude Code，所以之後都能重跑
+wizard。僅有 PowerShell 的 Windows 電腦則使用下方
+[Windows 無 Git Bash](#windows-無-git-bash)的獨立原生 archive 流程。
 
-> **需求：** `jq` 以及 [Nerd Font](https://www.nerdfonts.com/) 終端機字型。
-> 沒有 Nerd Font 的話，在設定檔加上 `VL_ASCII=1` 改用無特殊字符的渲染。
+> **Bash 需求：** `jq` 以及 [Nerd Font](https://www.nerdfonts.com/) 終端機字型。
+> 沒有 Nerd Font 的話，在設定檔加上 `VL_ASCII=1` 改用無特殊字符的渲染。下方原生
+> PowerShell renderer 不需要 `jq`。
 
 ### 請 Claude 安裝（推薦）
 
@@ -126,15 +130,17 @@ fetch https://raw.githubusercontent.com/Nanako0129/coralline/main/INSTALL.md
 and follow the playbook in it.
 ```
 
-Claude 會先讀 playbook，再用同一支 installer bootstrap runtime、訪談你的外觀偏好、
-寫入設定並驗證，最後提醒你如果不滿意可以自己重新開啟視覺化 wizard。
+在 Bash 環境中，Claude 會先讀 playbook，再用 `install.sh` bootstrap runtime、訪談你的
+外觀偏好、寫入設定並驗證，最後提醒你如果不滿意可以自己重新開啟視覺化 wizard。僅有
+PowerShell 的 Windows 請改用下方原生 archive 流程；這份 Bash playbook 不會安裝
+`statusline.ps1`。
 
 如果你的 Claude 對這份 playbook 亮紅旗、想先檢查內容，那是正確的直覺而不是阻礙：
 見[信任與安全](#信任與安全)。
 
 ### 自己安裝
 
-在終端機執行：
+在 Bash 終端機執行：
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
@@ -287,8 +293,10 @@ rm -rf ~/.claude/coralline ~/.claude/coralline.conf
 
 ## 設定
 
-兩種方式都使用同一支 installer。人類不帶模式參數執行時會進入視覺化設定；
-Claude 則使用 `--install-only` bootstrap，接著依照 `INSTALL.md` 訪談並寫入設定。
+兩種 Bash 設定方式都使用同一支 installer。人類不帶模式參數執行時會進入視覺化設定；
+Claude 則使用 `--install-only` bootstrap，接著依照 `INSTALL.md` 訪談並寫入設定。原生
+PowerShell archive 流程目前不會安裝 PowerShell wizard；它讀取同一份
+`coralline.conf`，可沿用既有 Bash 設定或手動建立。
 
 ### 設定模式
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -311,11 +311,15 @@ Claude 不需要操作這個人類 TUI。
 
 ### 重新設定
 
-每一種安裝方式都會把 wizard 複製到 `~/.claude/coralline`，所以你隨時可以重跑來重新調整外觀：
+兩種 Bash 安裝方式都會把 wizard 複製到 `~/.claude/coralline`，所以有 Bash 的環境可隨時
+重跑來重新調整外觀：
 
 ```bash
 bash ~/.claude/coralline/configure.sh
 ```
+
+PowerShell-only 安裝不含原生 wizard。請先備份再手動編輯
+`$HOME\.claude\coralline.conf`，或沿用在有 Bash 的環境產生的設定。
 
 ### 測試 fork
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -281,7 +281,7 @@ curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.s
 
 ### 移除
 
-若曾啟用 subagent 列主題，請先移除對應設定，再刪除工具：
+若環境可使用 Bash，請先移除 subagent 列主題，再刪除工具：
 
 ```bash
 bash ~/.claude/coralline/configure.sh --subagent-rows=off
@@ -290,6 +290,23 @@ rm -rf ~/.claude/coralline ~/.claude/coralline.conf
 
 然後把 `~/.claude/settings.json` 裡的 `statusLine` 區塊刪掉（或還原最新的
 `settings.json.bak.*`）。若略過第一個指令，也要一併刪除 `subagentStatusLine`。
+
+若是僅有 PowerShell 的原生 archive 安裝，先關閉 Claude Code 並備份設定檔：
+
+```powershell
+$settings = Join-Path $HOME '.claude\settings.json'
+Copy-Item -LiteralPath $settings -Destination "$settings.bak.$(Get-Date -Format yyyyMMddHHmmss)"
+notepad.exe $settings
+```
+
+在記事本中刪除 command 指向 `~/.claude/coralline/statusline.ps1` 的 `statusLine`
+物件。若 `subagentStatusLine` 的 command 也指向 coralline，請一併刪除，並確認存檔後
+仍是有效 JSON。最後移除已安裝的 runtime 與選用設定檔：
+
+```powershell
+Remove-Item -LiteralPath (Join-Path $HOME '.claude\coralline') -Recurse -Force
+Remove-Item -LiteralPath (Join-Path $HOME '.claude\coralline.conf') -Force -ErrorAction SilentlyContinue
+```
 
 ## 設定
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,11 @@
 > backs up the old `statusline.sh` and never touches `~/.claude/coralline.conf`. It
 > only *reports* what is new; you enable the new opt-in features additively, with the
 > user's consent.
+>
+> This playbook updates Bash-based installs. On PowerShell-only Windows, do not run
+> `install.sh`; re-run the native archive procedure under
+> [Windows without Git Bash](README.md#windows-without-git-bash), which preserves
+> `coralline.conf` and `settings.json`.
 
 ## Overview
 
@@ -77,6 +82,11 @@ append the approved segments:
     VL_SEGMENTS="dir git model ctx limit5h limit7d cost clock <approved segments>"
 
 followed by one line per approved option.
+
+Before writing an existing `coralline.conf`, show the bounded additive diff and obtain
+explicit approval. Leave the file byte-for-byte unchanged when no change was approved.
+When a write is approved, create a timestamped byte-exact backup and replace through a
+sibling temporary file; never reorder, drop, or rewrite unrelated content.
 
 ## Verification
 

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -1,0 +1,645 @@
+﻿#Requires -Version 5.1
+<#
+  coralline ??native PowerShell port of statusline.sh for Claude Code on
+  Windows without Git Bash (see issue #8).
+
+  Design goals for this port:
+    * No jq, no bash, no WSL. Only `git.exe` on PATH is used, and only when a
+      git-dependent segment (git/stash/project) is actually enabled.
+    * Reads the SAME ~/.claude/coralline.conf (and its `. theme.conf` include)
+      that statusline.sh reads. The config file is plain `KEY=value` /
+      `KEY="value"` assignments with a single `. "path"` include line, so this
+      script parses that shape directly with a small regex-based reader
+      instead of requiring a new config format or an installer change (see
+      Import-CorallineConfLines below). Existing coralline.conf files and
+      every shipped theme work unmodified with this script.
+    * Targets Windows PowerShell 5.1 (the interpreter that ships on every
+      Windows 10/11 box; no PowerShell 7 dependency), since that is what a
+      "no Git Bash" user already has available.
+
+  Scope (first native slice ??see handoff/coralline-8-scope.md for the parity
+  matrix): the "pill" style (VL_STYLE default) in "fixed" layout (VL_LAYOUT
+  default) with every main-bar JSON-driven segment statusline.sh ships except
+  `burn` (cross-session sampling with an awk slope fit) and the `--subagent`
+  panel-row protocol. `lean`/`classic` styles and the `auto` responsive-wrap
+  layout are not yet ported; VL_STYLE/VL_LAYOUT values other than the defaults
+  fall back to pill/fixed so an imported bash config still renders instead of
+  erroring.
+
+  Usage (settings.json), matching the shape proposed in issue #8:
+    "statusLine": {
+      "type": "command",
+      "command": "powershell -NoProfile -File C:/Users/you/.claude/coralline/statusline.ps1"
+    }
+#>
+
+param(
+    # statusline.sh's --subagent panel-row protocol is not ported yet. Accept
+    # the flag and exit clean (no output) so Claude Code keeps its own default
+    # panel rows instead of erroring on an unregistered command.
+    [switch]$Subagent
+)
+
+if ($Subagent) { exit 0 }
+
+# Left at the default ('Continue'): a native helper (git) writing to stderr
+# must not become a terminating error here even when its stream is
+# redirected away below, and every render must still print something rather
+# than aborting on one bad segment.
+$ErrorActionPreference = 'Continue'
+
+# Windows PowerShell 5.1 defaults stdout to the console/OEM codepage, which
+# mangles every non-ASCII glyph below (the p10k caps, the segment icons) once
+# Claude Code captures this process's raw stdout bytes. Force UTF-8 (no BOM)
+# on both the read and write sides so the bytes Claude Code reads back match
+# what statusline.sh's Nerd-Font/Unicode segments look like on bash.
+$Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+try { [Console]::OutputEncoding = $Utf8NoBom } catch { }
+try { [Console]::InputEncoding = $Utf8NoBom } catch { }
+$OutputEncoding = $Utf8NoBom
+
+# ---- stdin --------------------------------------------------------------
+$rawInput = [Console]::In.ReadToEnd()
+
+$Now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+
+# ---- glyphs (codepoint literals, not source-embedded UTF-8, so this file
+# renders correctly under Windows PowerShell 5.1's default ANSI-codepage
+# script parsing regardless of the file's on-disk BOM) ---------------------
+function Glyph([int]$Codepoint) { [System.Char]::ConvertFromUtf32($Codepoint) }
+
+$G = @{
+    CapL      = Glyph 0xE0B6
+    CapR      = Glyph 0xE0B4
+    Sep       = Glyph 0xE0B0
+    Node      = Glyph 0xE718
+    Python    = Glyph 0xE73C
+    Project   = Glyph 0x2B22
+    Branch    = Glyph 0x2387
+    Diamond   = Glyph 0x25C6
+    Hex       = Glyph 0x2B21
+    Flag      = Glyph 0x2691
+    Dot       = Glyph 0x2299
+    Pencil    = Glyph 0x270E
+    Hourglass = Glyph 0x29D6
+    Psi       = Glyph 0x03C8
+    Ahead     = Glyph 0x21E1
+    Behind    = Glyph 0x21E3
+    Ellipsis  = Glyph 0x2026
+    BarFill   = Glyph 0x25B0
+    BarEmpty  = Glyph 0x25B1
+    Up        = Glyph 0x2191
+    Down      = Glyph 0x2193
+    Reset     = Glyph 0x21BA
+}
+
+$Esc  = [char]27
+$Rst  = "$Esc[0m"
+$Bold = "$Esc[1m"
+$Norm = "$Esc[22m"
+
+# ---- config: defaults (mirrors statusline.sh's hardcoded defaults for the
+# segments this port renders) ----------------------------------------------
+$Cfg = [ordered]@{
+    VL_STYLE          = 'pill'
+    VL_LAYOUT         = 'fixed'
+    VL_SEGMENTS       = 'dir git model ctx limit5h limit7d cost clock'
+    VL_SEGMENTS2      = ''
+    VL_SEGMENTS3      = ''
+    VL_BAR_WIDTH      = '5'
+    VL_CLOCK          = '12h'
+    VL_CLOCK_SECONDS  = '1'
+    VL_PATH_DEPTH     = '4'
+    VL_NAME_MAX       = '0'
+    VL_COST_DECIMALS  = '2'
+    VL_WARN_PCT       = '50'
+    VL_HOT_PCT        = '75'
+    VL_ASCII          = '0'
+    VL_RUNTIME_PROBE  = '0'
+    VL_NOCOLOR        = '0'
+
+    VL_BG_DIR      = '81,166,199'
+    VL_BG_PROJECT  = ''
+    VL_BG_GIT_OK   = '65'
+    VL_BG_STASH    = ''
+    VL_BG_GIT_DIRTY = '130'
+    VL_BG_MODEL    = '173'
+    VL_BG_CTX      = '238'
+    VL_BG_5H       = '237'
+    VL_BG_7D       = '236'
+    VL_BG_COST     = '212,125,145'
+    VL_BG_CLOCK    = '70,80,110'
+    VL_BG_LINES    = '240'
+    VL_BG_STYLE    = '96'
+    VL_BG_DURATION = '60'
+    VL_BG_EFFORT   = '141'
+    VL_BG_NODE     = ''
+    VL_BG_PYTHON   = ''
+
+    VL_FG_TEXT = '231'
+    VL_FG_DIM  = '245'
+    VL_FG_OK   = '114'
+    VL_FG_WARN = '179'
+    VL_FG_HOT  = '167'
+}
+
+# ---- config: parser -------------------------------------------------------
+# Reads the same bash-syntax coralline.conf / theme.conf files statusline.sh
+# sources. Handles the two shapes those files actually contain: the leading
+# `. "path"` theme include, and `KEY=value` / `KEY="value"` assignments with
+# an optional trailing `# comment`. Anything else (bash logic, conditionals)
+# is silently ignored, which is fine here since every shipped config and
+# theme is exactly this shape (write_candidate_config in configure.sh never
+# emits anything else). This means the SAME coralline.conf a bash install
+# wrote works for this script unmodified ??no new config format needed.
+function Strip-ConfValue([string]$Raw) {
+    $v = $Raw.Trim()
+    if ($v.Length -ge 1 -and $v[0] -eq '"') {
+        $endIdx = $v.IndexOf('"', 1)
+        if ($endIdx -ge 0) { return $v.Substring(1, $endIdx - 1) }
+        return $v.Substring(1)
+    }
+    if ($v.Length -ge 1 -and $v[0] -eq "'") {
+        $endIdx = $v.IndexOf("'", 1)
+        if ($endIdx -ge 0) { return $v.Substring(1, $endIdx - 1) }
+        return $v.Substring(1)
+    }
+    $hashIdx = $v.IndexOf('#')
+    if ($hashIdx -ge 0) { $v = $v.Substring(0, $hashIdx) }
+    return $v.Trim()
+}
+
+function Import-CorallineConfLines([string]$Path, [System.Collections.Specialized.OrderedDictionary]$Target, [int]$Depth = 0) {
+    if ($Depth -gt 4) { return }              # guard against an include cycle
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return }
+    foreach ($line in Get-Content -LiteralPath $Path -ErrorAction SilentlyContinue) {
+        $t = $line.Trim()
+        if ($t -eq '' -or $t.StartsWith('#')) { continue }
+        if ($t -match '^\.\s+"?([^"]+?)"?\s*$') {
+            Import-CorallineConfLines -Path $matches[1] -Target $Target -Depth ($Depth + 1)
+            continue
+        }
+        if ($t -match '^([A-Za-z_][A-Za-z0-9_]*)=(.*)$') {
+            $Target[$matches[1]] = Strip-ConfValue $matches[2]
+        }
+    }
+}
+
+$ConfigPath = $env:CORALLINE_CONFIG
+if ([string]::IsNullOrEmpty($ConfigPath)) { $ConfigPath = Join-Path $HOME '.claude\coralline.conf' }
+Import-CorallineConfLines -Path $ConfigPath -Target $Cfg
+
+# Unsupported style/layout values fall back to this port's supported pair
+# rather than erroring, so an existing bash config (lean/classic, auto) still
+# renders ??just without that style/layout's extra behavior yet.
+if ($Cfg.VL_STYLE -ne 'pill') { $Cfg.VL_STYLE = 'pill' }
+if ($Cfg.VL_LAYOUT -ne 'fixed') { $Cfg.VL_LAYOUT = 'fixed' }
+
+$AsciiMode = ($Cfg.VL_ASCII -eq '1')
+if ($AsciiMode) {
+    $G.CapL = ''; $G.CapR = ''; $G.Sep = ''
+    $G.BarFill = '#'; $G.BarEmpty = '-'
+    $G.Node = 'node'; $G.Python = 'py'
+}
+
+$NoColor = ($Cfg.VL_NOCOLOR -eq '1')
+
+# ---- ANSI primitives --------------------------------------------------------
+function Get-Fg([string]$Spec) {
+    if ($NoColor -or [string]::IsNullOrEmpty($Spec)) { return '' }
+    if ($Spec.Contains(',')) {
+        $p = $Spec.Split(',')
+        return "$Esc[38;2;$($p[0]);$($p[1]);$($p[2])m"
+    }
+    return "$Esc[38;5;${Spec}m"
+}
+function Get-Bg([string]$Spec) {
+    if ($NoColor -or [string]::IsNullOrEmpty($Spec)) { return '' }
+    if ($Spec.Contains(',')) {
+        $p = $Spec.Split(',')
+        return "$Esc[48;2;$($p[0]);$($p[1]);$($p[2])m"
+    }
+    return "$Esc[48;5;${Spec}m"
+}
+
+# ---- formatting helpers (mirrors statusline.sh's make_bar/fmt_tok/etc.) ----
+function New-Bar([double]$Pct, [int]$Width) {
+    if ($Pct -lt 0) { $Pct = 0 }
+    $filled = [math]::Floor(($Pct * $Width + 50) / 100)
+    if ($filled -lt 0) { $filled = 0 }
+    if ($filled -gt $Width) { $filled = $Width }
+    $empty = $Width - $filled
+    $sb = New-Object System.Text.StringBuilder
+    for ($i = 0; $i -lt $filled; $i++) { [void]$sb.Append($G.BarFill) }
+    for ($i = 0; $i -lt $empty; $i++) { [void]$sb.Append($G.BarEmpty) }
+    return $sb.ToString()
+}
+
+function Format-Tok([string]$Raw) {
+    $n = 0L
+    if (-not [long]::TryParse($Raw, [ref]$n)) { return $Raw }
+    if ($n -ge 1000000) { return ('{0}.{1}M' -f [math]::Floor($n / 1000000), ([math]::Floor(($n % 1000000) / 100000))) }
+    if ($n -ge 1000) { return ('{0}.{1}k' -f [math]::Floor($n / 1000), ([math]::Floor(($n % 1000) / 100))) }
+    return "$n"
+}
+
+function Get-PctFg([double]$Pct) {
+    if ($Pct -ge [double]$Cfg.VL_HOT_PCT) { return $Cfg.VL_FG_HOT }
+    if ($Pct -ge [double]$Cfg.VL_WARN_PCT) { return $Cfg.VL_FG_WARN }
+    return $Cfg.VL_FG_OK
+}
+
+function Get-Trunc([string]$S, [int]$Max) {
+    if ($Max -le 0 -or $S.Length -le $Max) { return $S }
+    if ($Max -lt 3) { return $S.Substring(0, $Max) }
+    $head = [math]::Floor(($Max - 1) / 2)
+    $tail = $Max - 1 - $head
+    return $S.Substring(0, $head) + $G.Ellipsis + $S.Substring($S.Length - $tail)
+}
+
+# Accepts epoch seconds (int/float string) or an ISO 8601 timestamp -> epoch
+# seconds, or $null when unparseable. .NET's DateTimeOffset parser replaces
+# statusline.sh's hand-rolled iso_epoch/to_epoch civil-calendar math.
+function ConvertTo-Epoch([string]$Raw) {
+    if ([string]::IsNullOrEmpty($Raw)) { return $null }
+    if ($Raw -match '^[0-9]+(\.[0-9]+)?$') { return [long][double]$Raw }
+    try {
+        $styles = [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal
+        $dto = [DateTimeOffset]::Parse($Raw, [System.Globalization.CultureInfo]::InvariantCulture, $styles)
+        return $dto.ToUnixTimeSeconds()
+    } catch { return $null }
+}
+
+function Format-Countdown([string]$ResetsAt) {
+    $ep = ConvertTo-Epoch $ResetsAt
+    if ($null -eq $ep) { return '' }
+    $diff = $ep - $Now
+    if ($diff -le 0) { return 'now' }
+    $d = [math]::Floor($diff / 86400)
+    $h = [math]::Floor(($diff % 86400) / 3600)
+    $m = [math]::Floor(($diff % 3600) / 60)
+    if ($d -gt 0) { return ('{0}d{1:00}h' -f $d, $h) }
+    if ($h -gt 0) { return ('{0}h{1:00}m' -f $h, $m) }
+    return "${m}m"
+}
+
+function Format-Duration([double]$Ms, [bool]$IncludeSeconds) {
+    $s = [math]::Floor($Ms / 1000)
+    $h = [math]::Floor($s / 3600)
+    $m = [math]::Floor(($s % 3600) / 60)
+    $sec = $s % 60
+    if ($IncludeSeconds) {
+        if ($h -gt 0) { return ('{0}h{1:00}m{2:00}s' -f $h, $m, $sec) }
+        if ($m -gt 0) { return ('{0}m{1:00}s' -f $m, $sec) }
+        return "${s}s"
+    }
+    if ($h -gt 0) { return ('{0}h{1:00}m' -f $h, $m) }
+    if ($m -gt 0) { return "${m}m" }
+    return "${s}s"
+}
+
+function Get-ClockText {
+    $now = Get-Date
+    $inv = [System.Globalization.CultureInfo]::InvariantCulture
+    if ($Cfg.VL_CLOCK -eq '24h') {
+        if ($Cfg.VL_CLOCK_SECONDS -eq '1') { return $now.ToString('HH:mm:ss', $inv) }
+        return $now.ToString('HH:mm', $inv)
+    }
+    $fmt = if ($Cfg.VL_CLOCK_SECONDS -eq '1') { 'hh:mm:ss tt' } else { 'hh:mm tt' }
+    $t = $now.ToString($fmt, $inv)
+    if ($t.EndsWith('AM')) { return ($t.Substring(0, $t.Length - 2) + 'am') }
+    if ($t.EndsWith('PM')) { return ($t.Substring(0, $t.Length - 2) + 'pm') }
+    return $t
+}
+
+# ---- git state (single `git status` call, parsed once; mirrors read_git) --
+$env:GIT_OPTIONAL_LOCKS = '0'
+
+function Get-GitState([string]$Cwd) {
+    $state = @{ Branch = ''; Marks = ''; Ab = ''; Dirty = $false }
+    if ([string]::IsNullOrEmpty($Cwd)) { return $state }
+    $lines = & git -C $Cwd status --porcelain=v2 --branch 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $lines) { return $state }
+    $oid = ''; $head = ''; $a = 0; $b = 0
+    $staged = $false; $unstaged = $false; $untracked = $false
+    foreach ($line in $lines) {
+        if ($line.StartsWith('# branch.oid ')) { $oid = $line.Substring(13) }
+        elseif ($line.StartsWith('# branch.head ')) { $head = $line.Substring(14) }
+        elseif ($line.StartsWith('# branch.ab ')) {
+            if ($line -match '\+(\d+)\s+-(\d+)') { $a = [int]$matches[1]; $b = [int]$matches[2] }
+        }
+        elseif ($line.StartsWith('? ')) { $untracked = $true }
+        elseif ($line -match '^[12] ') {
+            $rest = $line.Substring(2)
+            if ($rest.Length -ge 1 -and $rest[0] -ne '.') { $staged = $true }
+            if ($rest.Length -ge 2 -and $rest[1] -ne '.') { $unstaged = $true }
+        }
+        elseif ($line.StartsWith('u ')) { $unstaged = $true }
+    }
+    if ([string]::IsNullOrEmpty($oid)) { return $state }
+    if ($head -eq '(detached)' -or [string]::IsNullOrEmpty($head)) {
+        $state.Branch = $oid.Substring(0, [Math]::Min(7, $oid.Length))
+    } else {
+        $state.Branch = $head
+    }
+    if ($staged) { $state.Marks += '+' }
+    if ($unstaged) { $state.Marks += '!' }
+    if ($untracked) { $state.Marks += '?' }
+    if ($a -gt 0) { $state.Ab += "$($G.Ahead)$a" }
+    if ($b -gt 0) { $state.Ab += "$($G.Behind)$b" }
+    if ($state.Marks) { $state.Dirty = $true }
+    return $state
+}
+
+function Get-GitRoot([string]$Cwd) {
+    if ([string]::IsNullOrEmpty($Cwd)) { return '' }
+    $root = & git -C $Cwd rev-parse --path-format=absolute --git-common-dir 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $root) {
+        $root = & git -C $Cwd rev-parse --show-toplevel 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $root) { return '' }
+    }
+    $root = ($root -replace '\\', '/').TrimEnd('/')
+    if ($root.EndsWith('/.git')) { $root = $root.Substring(0, $root.Length - 5) }
+    $parts = $root.Split('/', [StringSplitOptions]::RemoveEmptyEntries)
+    if ($parts.Length -eq 0) { return '' }
+    return $parts[$parts.Length - 1]
+}
+
+function Get-StashCount([string]$Cwd) {
+    $n = & git -C $Cwd rev-list --walk-reflogs --count refs/stash 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $n) { return 0 }
+    $count = 0
+    if ([int]::TryParse(($n | Select-Object -First 1), [ref]$count)) { return $count }
+    return 0
+}
+
+# ---- node/python runtime detection (pin-file walk; mirrors runtime_node /
+# runtime_python) -------------------------------------------------------------
+function Get-NodeVersion([string]$Dir) {
+    $d = $Dir
+    while ($d -and (Test-Path -LiteralPath $d -PathType Container)) {
+        foreach ($f in '.nvmrc', '.node-version') {
+            $p = Join-Path $d $f
+            if (Test-Path -LiteralPath $p -PathType Leaf) {
+                $v = (Get-Content -LiteralPath $p -TotalCount 1 -ErrorAction SilentlyContinue)
+                if ($v) { $v = $v.Trim(); if ($v) { return $v.TrimStart('v') } }
+            }
+        }
+        $parent = Split-Path -Path $d -Parent
+        if (-not $parent -or $parent -eq $d) { break }
+        $d = $parent
+    }
+    if ($Cfg.VL_RUNTIME_PROBE -eq '1') {
+        $v = (& node --version 2>$null | Select-Object -First 1)
+        if ($v) { return $v.TrimStart('v') }
+    }
+    return ''
+}
+
+function Get-PythonVersion([string]$Dir) {
+    if ($env:VIRTUAL_ENV) { return (Split-Path -Leaf $env:VIRTUAL_ENV) }
+    if ($env:CONDA_DEFAULT_ENV -and $env:CONDA_DEFAULT_ENV -ne 'base') { return $env:CONDA_DEFAULT_ENV }
+    $d = $Dir
+    while ($d -and (Test-Path -LiteralPath $d -PathType Container)) {
+        $p = Join-Path $d '.python-version'
+        if (Test-Path -LiteralPath $p -PathType Leaf) {
+            $v = (Get-Content -LiteralPath $p -TotalCount 1 -ErrorAction SilentlyContinue)
+            if ($v) { $v = $v.Trim(); if ($v) { return $v } }
+        }
+        $parent = Split-Path -Path $d -Parent
+        if (-not $parent -or $parent -eq $d) { break }
+        $d = $parent
+    }
+    if ($Cfg.VL_RUNTIME_PROBE -eq '1') {
+        $v = (& python3 --version 2>&1 | Select-Object -First 1)
+        if ($v) { return ($v -replace '^Python ', '').Trim() }
+    }
+    return ''
+}
+
+# ---- JSON input -------------------------------------------------------------
+try { $J = $rawInput | ConvertFrom-Json } catch { $J = $null }
+
+function Str($Value) { if ($null -eq $Value) { '' } else { [string]$Value } }
+
+$cwd = Str $J.workspace.current_dir
+if (-not $cwd) { $cwd = Str $J.cwd }
+$model     = Str $J.model.display_name
+$ctxPct    = Str $J.context_window.used_percentage
+$tokIn     = Str $J.context_window.total_input_tokens
+$tokOut    = Str $J.context_window.total_output_tokens
+$tokCr     = Str $J.context_window.current_usage.cache_read_input_tokens
+$tokCw     = Str $J.context_window.current_usage.cache_creation_input_tokens
+$fhPct     = Str $J.rate_limits.five_hour.used_percentage
+$fhRst     = Str $J.rate_limits.five_hour.resets_at
+$wdPct     = Str $J.rate_limits.seven_day.used_percentage
+$wdRst     = Str $J.rate_limits.seven_day.resets_at
+$cost      = Str $J.cost.total_cost_usd
+$linesAdd  = Str $J.cost.total_lines_added
+$linesDel  = Str $J.cost.total_lines_removed
+$outStyle  = Str $J.output_style.name
+$durMs     = Str $J.cost.total_duration_ms
+$effort    = Str $J.effort.level
+
+$segScan = " $($Cfg.VL_SEGMENTS) $($Cfg.VL_SEGMENTS2) $($Cfg.VL_SEGMENTS3) "
+$GitState = @{ Branch = ''; Marks = ''; Ab = ''; Dirty = $false }
+$GitRoot = ''
+if ($segScan -match ' (git|stash|project) ') { $GitState = Get-GitState $cwd }
+if ($segScan -match ' project ') { $GitRoot = Get-GitRoot $cwd }
+
+# ---- segments (each Add-*Segment mirrors one seg_* function) --------------
+$SegBgs = New-Object System.Collections.Generic.List[string]
+$SegTxt = New-Object System.Collections.Generic.List[string]
+function Push-Segment([string]$Bg, [string]$Text) {
+    [void]$SegBgs.Add($Bg)
+    [void]$SegTxt.Add($Text)
+}
+
+function Add-DirSegment {
+    if (-not $cwd) { return }
+    $short = $cwd -replace '\\', '/'
+    if ($HOME) {
+        $homeFwd = $HOME -replace '\\', '/'
+        if ($short.StartsWith($homeFwd)) { $short = '~' + $short.Substring($homeFwd.Length) }
+    }
+    $parts = $short.Split('/', [StringSplitOptions]::RemoveEmptyEntries)
+    $depth = [int]$Cfg.VL_PATH_DEPTH
+    if ($parts.Length -gt $depth -and $parts.Length -ge 1) {
+        $last = $parts[$parts.Length - 1]
+        $p1 = if ($parts.Length -ge 1) { $parts[0] } else { '' }
+        $p2 = if ($parts.Length -ge 2) { $parts[1] } else { '' }
+        $short = "$p1/$p2/$($G.Ellipsis)/$last"
+    }
+    $fg = Get-Fg $Cfg.VL_FG_TEXT
+    Push-Segment $Cfg.VL_BG_DIR "${Bold}${fg} $short ${Norm}"
+}
+
+function Add-ProjectSegment {
+    if (-not $GitRoot) {
+        if ($segScan -notmatch ' dir ') { Add-DirSegment }
+        return
+    }
+    $tr = Get-Trunc $GitRoot ([int]$Cfg.VL_NAME_MAX)
+    $fg = Get-Fg $Cfg.VL_FG_TEXT
+    $bg = if ($Cfg.VL_BG_PROJECT) { $Cfg.VL_BG_PROJECT } else { $Cfg.VL_BG_DIR }
+    Push-Segment $bg "${Bold}${fg} $($G.Project) $tr ${Norm}"
+}
+
+function Add-GitSegment {
+    if (-not $GitState.Branch) { return }
+    $bgc = if ($GitState.Dirty) { $Cfg.VL_BG_GIT_DIRTY } else { $Cfg.VL_BG_GIT_OK }
+    $fg = Get-Fg $Cfg.VL_FG_TEXT
+    $tr = Get-Trunc $GitState.Branch ([int]$Cfg.VL_NAME_MAX)
+    Push-Segment $bgc "${Bold}${fg} $($G.Branch) ${tr}$($GitState.Marks)$($GitState.Ab) ${Norm}"
+}
+
+function Add-StashSegment {
+    if (-not $GitState.Branch) { return }
+    $n = Get-StashCount $cwd
+    if ($n -le 0) { return }
+    $fg = Get-Fg $Cfg.VL_FG_TEXT
+    $bg = if ($Cfg.VL_BG_STASH) { $Cfg.VL_BG_STASH } else { $Cfg.VL_BG_GIT_OK }
+    Push-Segment $bg "${fg} $($G.Flag) $n "
+}
+
+function Add-ModelSegment {
+    if (-not $model) { return }
+    $fg = Get-Fg $Cfg.VL_FG_TEXT
+    $shown = $model -replace '^Claude ', ''
+    Push-Segment $Cfg.VL_BG_MODEL "${Bold}${fg} $($G.Diamond) $shown ${Norm}"
+}
+
+function Add-EffortSegment {
+    if (-not $effort) { return }
+    $label = $effort
+    if ($effort -eq 'medium') { $label = 'med' }
+    $fg = Get-Fg $Cfg.VL_FG_TEXT
+    Push-Segment $Cfg.VL_BG_EFFORT "${fg} $($G.Psi) $label "
+}
+
+function Add-CtxSegment {
+    if (-not $ctxPct) { return }
+    $ci = [math]::Round([double]$ctxPct)
+    $bar = New-Bar $ci ([int]$Cfg.VL_BAR_WIDTH)
+    $pfg = Get-Fg (Get-PctFg $ci)
+    $dfg = Get-Fg $Cfg.VL_FG_DIM
+    $ti = Format-Tok $tokIn
+    $to = Format-Tok $tokOut
+    $tcr = Format-Tok $tokCr
+    $tcw = Format-Tok $tokCw
+    Push-Segment $Cfg.VL_BG_CTX "${pfg} $($G.Hex) ${bar} ${ci}% ${dfg}$($G.Up)${ti} $($G.Down)${to} cr:${tcr} cw:${tcw} "
+}
+
+function Add-LimitSegment([string]$Label, [string]$Pct, [string]$ResetsAt, [string]$Bg) {
+    if (-not $Pct) { return }
+    $v = [math]::Round([double]$Pct)
+    $bar = New-Bar $v ([int]$Cfg.VL_BAR_WIDTH)
+    $pfg = Get-Fg (Get-PctFg $v)
+    $cd = Format-Countdown $ResetsAt
+    $rst = ''
+    if ($cd) { $dfg = Get-Fg $Cfg.VL_FG_DIM; $rst = "${dfg}$($G.Reset)${cd}" }
+    Push-Segment $Bg "${pfg} $Label ${bar} ${v}% ${rst} "
+}
+
+function Add-Cost {
+    if (-not $cost -or $cost -eq '0') { return }
+    $decimals = [int]$Cfg.VL_COST_DECIMALS
+    $fmt = ''
+    try { $fmt = [string]::Format([System.Globalization.CultureInfo]::InvariantCulture, "`$" + '{0:F' + $decimals + '}', [double]$cost) } catch { $fmt = "`$$cost" }
+    $fg = Get-Fg $Cfg.VL_FG_TEXT
+    Push-Segment $Cfg.VL_BG_COST "${fg} $fmt "
+}
+
+function Add-Clock {
+    if ($Cfg.VL_CLOCK -eq 'off') { return }
+    $fg = Get-Fg $Cfg.VL_FG_TEXT
+    Push-Segment $Cfg.VL_BG_CLOCK "${fg} $($G.Dot) $(Get-ClockText) "
+}
+
+function Add-Lines {
+    $add = 0; $del = 0
+    [int]::TryParse($linesAdd, [ref]$add) | Out-Null
+    [int]::TryParse($linesDel, [ref]$del) | Out-Null
+    if ($add -le 0 -and $del -le 0) { return }
+    $fgo = Get-Fg $Cfg.VL_FG_OK
+    $fgh = Get-Fg $Cfg.VL_FG_HOT
+    Push-Segment $Cfg.VL_BG_LINES " ${fgo}+${add} ${fgh}-${del} "
+}
+
+function Add-Style {
+    if (-not $outStyle -or $outStyle -eq 'default') { return }
+    $fg = Get-Fg $Cfg.VL_FG_TEXT
+    Push-Segment $Cfg.VL_BG_STYLE "${fg} $($G.Pencil) $outStyle "
+}
+
+function Add-Duration {
+    $ms = 0.0
+    if (-not [double]::TryParse($durMs, [ref]$ms) -or $ms -le 0) { return }
+    $fg = Get-Fg $Cfg.VL_FG_TEXT
+    Push-Segment $Cfg.VL_BG_DURATION "${fg} $($G.Hourglass) $(Format-Duration $ms $true) "
+}
+
+function Add-Node {
+    if (-not $cwd) { return }
+    $v = Get-NodeVersion $cwd
+    if (-not $v) { return }
+    $fg = Get-Fg $Cfg.VL_FG_TEXT
+    $bg = if ($Cfg.VL_BG_NODE) { $Cfg.VL_BG_NODE } else { $Cfg.VL_BG_MODEL }
+    Push-Segment $bg "${fg} $($G.Node) $v "
+}
+
+function Add-Python {
+    if (-not $cwd) { return }
+    $v = Get-PythonVersion $cwd
+    if (-not $v) { return }
+    $fg = Get-Fg $Cfg.VL_FG_TEXT
+    $bg = if ($Cfg.VL_BG_PYTHON) { $Cfg.VL_BG_PYTHON } else { $Cfg.VL_BG_MODEL }
+    Push-Segment $bg "${fg} $($G.Python) $v "
+}
+
+$SegmentBuilders = @{
+    dir      = { Add-DirSegment }
+    project  = { Add-ProjectSegment }
+    git      = { Add-GitSegment }
+    stash    = { Add-StashSegment }
+    model    = { Add-ModelSegment }
+    effort   = { Add-EffortSegment }
+    ctx      = { Add-CtxSegment }
+    limit5h  = { Add-LimitSegment '5h' $fhPct $fhRst $Cfg.VL_BG_5H }
+    limit7d  = { Add-LimitSegment '7d' $wdPct $wdRst $Cfg.VL_BG_7D }
+    cost     = { Add-Cost }
+    clock    = { Add-Clock }
+    lines    = { Add-Lines }
+    style    = { Add-Style }
+    duration = { Add-Duration }
+    node     = { Add-Node }
+    python   = { Add-Python }
+    # burn (cross-session rate sampling) and the subagent panel row segments
+    # are not ported in this slice; see handoff/coralline-8-scope.md.
+}
+
+function Build-Segments([string]$List) {
+    $SegBgs.Clear(); $SegTxt.Clear()
+    foreach ($name in ($List -split '\s+' | Where-Object { $_ })) {
+        if ($SegmentBuilders.ContainsKey($name)) { & $SegmentBuilders[$name] }
+    }
+}
+
+function Render-Row {
+    if ($SegBgs.Count -eq 0) { return '' }
+    $out = $Rst + (Get-Fg $SegBgs[0]) + $G.CapL
+    for ($i = 0; $i -lt $SegBgs.Count; $i++) {
+        $out += (Get-Bg $SegBgs[$i]) + $SegTxt[$i]
+        if ($i -lt ($SegBgs.Count - 1)) {
+            $out += (Get-Bg $SegBgs[$i + 1]) + (Get-Fg $SegBgs[$i]) + $G.Sep
+        }
+    }
+    $out += $Rst + (Get-Fg $SegBgs[$SegBgs.Count - 1]) + $G.CapR + $Rst
+    return $out
+}
+
+foreach ($list in @($Cfg.VL_SEGMENTS, $Cfg.VL_SEGMENTS2, $Cfg.VL_SEGMENTS3)) {
+    if ([string]::IsNullOrWhiteSpace($list)) { continue }
+    Build-Segments $list
+    if ($SegBgs.Count -gt 0) { Write-Output (Render-Row) }
+}

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -148,6 +148,8 @@ $Defaults = [ordered]@{
 
 $PathConfigKeys = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
 foreach ($key in @('VL_FLOAT_FILE', 'BURN_FILE', 'RL5H_FILE', 'RL7D_FILE')) { [void]$PathConfigKeys.Add($key) }
+$ConfigKeys = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
+foreach ($key in $Defaults.Keys) { [void]$ConfigKeys.Add([string]$key) }
 
 function Add-Utf8Text([System.Collections.Generic.List[byte]]$Bytes, [string]$Text) {
     try {
@@ -551,7 +553,10 @@ function Import-ConfigFile(
                 }
                 continue
             }
-            $candidate[$name] = $decoded.Value
+            # Bash variable names are case-sensitive. OrderedDictionary is not,
+            # so ignore unknown and case-variant keys instead of letting them
+            # overwrite a supported setting.
+            if ($ConfigKeys.Contains($name)) { $candidate[$name] = $decoded.Value }
             continue
         }
 
@@ -758,11 +763,24 @@ function Get-PctFg([int]$Pct) {
 
 function Get-Trunc([string]$S, [int]$Max) {
     if ($null -eq $S) { return '' }
-    if ($Max -le 0 -or $S.Length -le $Max) { return $S }
-    if ($Max -lt 3) { return $S.Substring(0, $Max) }
+    if ($Max -le 0) { return $S }
+    $offsets = New-Object 'System.Collections.Generic.List[int]'
+    for ($i = 0; $i -lt $S.Length) {
+        [void]$offsets.Add($i)
+        if ([char]::IsHighSurrogate($S[$i]) -and ($i + 1) -lt $S.Length -and [char]::IsLowSurrogate($S[$i + 1])) { $i += 2 }
+        else { $i++ }
+    }
+    $count = $offsets.Count
+    if ($count -le $Max) { return $S }
+    if ($Max -lt 3) {
+        $end = if ($Max -lt $count) { $offsets[$Max] } else { $S.Length }
+        return $S.Substring(0, $end)
+    }
     $head = [int][math]::Floor(($Max - 1) / 2)
     $tail = $Max - 1 - $head
-    return $S.Substring(0, $head) + $G.Ellipsis + $S.Substring($S.Length - $tail)
+    $headEnd = if ($head -lt $count) { $offsets[$head] } else { $S.Length }
+    $tailStart = $offsets[$count - $tail]
+    return $S.Substring(0, $headEnd) + $G.Ellipsis + $S.Substring($tailStart)
 }
 
 function ConvertTo-Epoch([string]$Raw) {
@@ -1414,8 +1432,30 @@ $effort = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('effort', '
 
 function ConvertTo-ProbePath([string]$Path) {
     if ([string]::IsNullOrEmpty($Path)) { return '' }
-    $full = ConvertTo-LocalFullPath $Path ([Environment]::CurrentDirectory)
-    if ($null -eq $full) { return '' }
+    if ($Path.Length -gt 4096 -or $Path -match '[\u0000-\u001f\u007f-\u009f]') { return '' }
+    $p = $Path.Replace('/', '\')
+    if ($p.StartsWith('\\?\', [System.StringComparison]::Ordinal) -or $p.StartsWith('\\.\', [System.StringComparison]::Ordinal)) { return '' }
+    if (-not $p.StartsWith('\\', [System.StringComparison]::Ordinal)) {
+        $local = ConvertTo-LocalFullPath $Path ([Environment]::CurrentDirectory)
+        if ($null -eq $local) { return '' }
+        return $local
+    }
+
+    # Workspace probes are read-only and may follow a normal UNC path. Config,
+    # include, float, burn, and rate-limit paths keep using the stricter local
+    # validator above and therefore still reject every UNC form.
+    $parts = $p.Substring(2).Split(@('\'), [System.StringSplitOptions]::None)
+    if ($parts.Length -lt 2 -or [string]::IsNullOrEmpty($parts[0]) -or [string]::IsNullOrEmpty($parts[1])) { return '' }
+    for ($i = 0; $i -lt $parts.Length; $i++) {
+        $component = $parts[$i]
+        if ([string]::IsNullOrEmpty($component)) { continue }
+        if (($i -lt 2) -and ($component -eq '.' -or $component -eq '..')) { return '' }
+        if ($component -eq '.' -or $component -eq '..') { continue }
+        if ($component.EndsWith('.') -or $component.EndsWith(' ')) { return '' }
+        if ($component -match '[<>"\|\?\*:]' -or (Test-DosDeviceComponent $component)) { return '' }
+    }
+    try { $full = [System.IO.Path]::GetFullPath($p) } catch { return '' }
+    if ([string]::IsNullOrEmpty($full) -or $full.Length -gt 4096 -or -not $full.StartsWith('\\', [System.StringComparison]::Ordinal)) { return '' }
     return $full
 }
 

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -2,11 +2,10 @@
 <#
   coralline - native Windows PowerShell statusline for Claude Code.
 
-  This slice implements the fixed pill main bar without Bash, jq, WSL, or
-  PowerShell 7. Config is read from the same coralline.conf through a narrow,
-  non-executing Bash-word parser. Burn and synced limit state share the same
-  immutable store as Bash; alternate styles/layouts, float output, and subagent
-  rows are implemented by later slices.
+  This runtime implements the main bar and optional float producer without Bash,
+  jq, WSL, or PowerShell 7. Config is read from the same coralline.conf through a
+  narrow, non-executing Bash-word parser. Burn and synced limit state share the
+  same immutable store as Bash; subagent rows remain a later protocol slice.
 #>
 
 # Claude Code registers this exact literal. It must leave before stdin, config,
@@ -50,6 +49,7 @@ function Copy-Config([System.Collections.IDictionary]$Source) {
 $HomeDir = [string]$HOME
 if ([string]::IsNullOrEmpty($HomeDir)) { $HomeDir = [Environment]::GetFolderPath('UserProfile') }
 $ScriptDir = [System.IO.Path]::GetDirectoryName($MyInvocation.MyCommand.Path)
+$ScriptPath = [string]$MyInvocation.MyCommand.Path
 $DefaultFloatFile = [System.IO.Path]::Combine($HomeDir, '.claude\coralline\float.txt')
 $DefaultBurnFile = [string]$env:CORALLINE_BURN_FILE
 if ([string]::IsNullOrEmpty($DefaultBurnFile)) {
@@ -68,6 +68,7 @@ $Defaults = [ordered]@{
     VL_STYLE = 'pill'
     VL_LEAN_SEP = ''
     VL_LEAN_BG = ''
+    VL_LEAN_FG = ''
     VL_LEAN_CAP_R = ''
     VL_LEAN_CAP_L = ''
     VL_LAYOUT = 'fixed'
@@ -360,11 +361,19 @@ function Decode-ShellWord([string]$Text, [bool]$PathContext) {
     return [pscustomobject]@{ Success = $true; Value = $value }
 }
 
-function ConvertTo-LocalFullPath([string]$Path, [string]$BaseDir) {
-    if ([string]::IsNullOrEmpty($Path)) { return $null }
-    if ($Path -match '[\u0000-\u001f\u007f-\u009f]') { return $null }
-    if ($Path.StartsWith('\\', [System.StringComparison]::Ordinal) -or $Path.StartsWith('//', [System.StringComparison]::Ordinal)) { return $null }
-    if ($Path.StartsWith('\\?\', [System.StringComparison]::Ordinal) -or $Path.StartsWith('\\.\', [System.StringComparison]::Ordinal) -or $Path -match '^\\\x3f\x3f\\') { return $null }
+function Test-DosDeviceComponent([string]$Component) {
+    if ([string]::IsNullOrEmpty($Component)) { return $false }
+    $name = $Component.TrimEnd('.', ' ')
+    $dot = $name.IndexOf('.')
+    if ($dot -ge 0) { $name = $name.Substring(0, $dot) }
+    return $name -match '^(?i:CON|PRN|AUX|NUL|CLOCK\$|COM[1-9]|LPT[1-9])$'
+}
+
+function Test-LocalPathSyntax([string]$Path, [ref]$Normalized) {
+    if ([string]::IsNullOrEmpty($Path) -or $Path.Length -gt 4096) { return $false }
+    if ($Path -match '[\u0000-\u001f\u007f-\u009f]') { return $false }
+    if ($Path.StartsWith('\\', [System.StringComparison]::Ordinal) -or $Path.StartsWith('//', [System.StringComparison]::Ordinal)) { return $false }
+    if ($Path.StartsWith('\\?\', [System.StringComparison]::Ordinal) -or $Path.StartsWith('\\.\', [System.StringComparison]::Ordinal) -or $Path.StartsWith('//?/', [System.StringComparison]::Ordinal) -or $Path.StartsWith('//./', [System.StringComparison]::Ordinal)) { return $false }
 
     $p = $Path
     if ($p -match '^/([A-Za-z])(?:/|$)') {
@@ -372,17 +381,34 @@ function ConvertTo-LocalFullPath([string]$Path, [string]$BaseDir) {
         $p = $drive + ':\' + $p.Substring(2).TrimStart('/')
     }
     $p = $p.Replace('/', '\')
+    if ($p.StartsWith('\', [System.StringComparison]::Ordinal)) { return $false }
 
     $colon = $p.IndexOf(':')
-    if ($colon -ge 0) {
-        if ($colon -ne 1 -or $p.Length -lt 3 -or -not [char]::IsLetter($p[0]) -or $p[2] -ne '\' -or $p.IndexOf(':', 2) -ge 0) { return $null }
-    } elseif ($p.StartsWith('\', [System.StringComparison]::Ordinal)) { return $null }
+    if ($colon -ge 0 -and ($colon -ne 1 -or $p.Length -lt 3 -or -not [char]::IsLetter($p[0]) -or $p[2] -ne '\' -or $p.IndexOf(':', 2) -ge 0)) { return $false }
+    try { $root = [System.IO.Path]::GetPathRoot($p) } catch { return $false }
+    $rest = $p
+    if (-not [string]::IsNullOrEmpty($root)) { $rest = $p.Substring($root.Length) }
+    foreach ($component in $rest.Split(@('\'), [System.StringSplitOptions]::RemoveEmptyEntries)) {
+        if ($component -eq '.' -or $component -eq '..') { continue }
+        if ($component.EndsWith('.') -or $component.EndsWith(' ')) { return $false }
+        if ($component -match '[<>"\|\?\*:]') { return $false }
+        if (Test-DosDeviceComponent $component) { return $false }
+    }
+    $Normalized.Value = $p
+    return $true
+}
 
+function ConvertTo-LocalFullPath([string]$Path, [string]$BaseDir) {
+    if ([string]::IsNullOrEmpty($Path) -or $Path.Length -gt 4096) { return $null }
+    $p = ''
+    $normalized = $null
+    if (-not (Test-LocalPathSyntax $Path ([ref]$normalized))) { return $null }
+    $p = $normalized
     try {
         if (-not [System.IO.Path]::IsPathRooted($p)) { $p = [System.IO.Path]::Combine($BaseDir, $p) }
         $full = [System.IO.Path]::GetFullPath($p)
     } catch { return $null }
-    if ($full.StartsWith('\\', [System.StringComparison]::Ordinal)) { return $null }
+    if ([string]::IsNullOrEmpty($full) -or $full.Length -gt 4096 -or $full.StartsWith('\\', [System.StringComparison]::Ordinal)) { return $null }
     return $full
 }
 
@@ -450,6 +476,7 @@ function Import-ConfigFile(
     if ($null -eq $text) { return $failed }
 
     $candidate = Copy-Config $BaseConfig
+    $rootFloatAuthorized = $false
     $stack = New-Object System.Collections.ArrayList
     $active = $true
     $valid = $true
@@ -513,10 +540,17 @@ function Import-ConfigFile(
         if ($statement -match '^([A-Za-z_][A-Za-z0-9_]*)=(.*)$') {
             $name = $Matches[1]
             $raw = $Matches[2]
-            $pathContext = $PathConfigKeys.Contains($name)
+            $pathContext = $PathConfigKeys.Contains($name) -or $name -ieq 'VL_FLOAT_FILE'
             $decoded = Decode-ShellWord $raw $pathContext
             if (-not $decoded.Success) { $valid = $false; break }
             if ($pathContext -and $decoded.Value -match '[ -\u007f-\u009f]') { $valid = $false; break }
+            if ($name -ieq 'VL_FLOAT_FILE') {
+                if ($Depth -eq 0 -and $name -ceq 'VL_FLOAT_FILE') {
+                    $candidate['VL_FLOAT_FILE'] = $decoded.Value
+                    $rootFloatAuthorized = $true
+                }
+                continue
+            }
             $candidate[$name] = $decoded.Value
             continue
         }
@@ -527,10 +561,11 @@ function Import-ConfigFile(
 
     if ($stack.Count -ne 0) { $valid = $false }
     if (-not $valid) { return $failed }
-    return [pscustomobject]@{ Success = $true; Config = $candidate }
+    return [pscustomobject]@{ Success = $true; Config = $candidate; FloatFileAuthorized = ($Depth -eq 0 -and $rootFloatAuthorized) }
 }
 
 $Cfg = Copy-Config $Defaults
+$FloatFileRootAuthorized = $false
 $ConfigInput = [string]$env:CORALLINE_CONFIG
 if ([string]::IsNullOrEmpty($ConfigInput)) { $ConfigInput = [System.IO.Path]::Combine($HomeDir, '.claude\coralline.conf') }
 $ConfigPath = ConvertTo-LocalFullPath $ConfigInput ([Environment]::CurrentDirectory)
@@ -542,7 +577,14 @@ if (-not [string]::IsNullOrEmpty($ConfigPath)) {
     $visited = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
     $state = @{ IncludeCount = 0; Visited = $visited }
     $parsed = Import-ConfigFile $ConfigPath $Cfg $state 0 $approved
-    if ($parsed.Success) { $Cfg = $parsed.Config }
+    if ($parsed.Success) {
+        $Cfg = $parsed.Config
+        $FloatFileRootAuthorized = [bool]$parsed.FloatFileAuthorized
+    }
+}
+$ConfigVisitedPaths = @()
+if ($null -ne $visited) {
+    foreach ($visitedPath in $visited) { $ConfigVisitedPaths += [string]$visitedPath }
 }
 
 # Config never supplies terminal controls. The renderer is the sole ANSI source.
@@ -590,6 +632,8 @@ $Cfg.VL_NAME_MAX = [string](Get-BoundedInt $Cfg.VL_NAME_MAX ([int]$Defaults.VL_N
 $Cfg.VL_COST_DECIMALS = [string](Get-BoundedInt $Cfg.VL_COST_DECIMALS ([int]$Defaults.VL_COST_DECIMALS) 0 9)
 $Cfg.VL_WARN_PCT = [string](Get-BoundedInt $Cfg.VL_WARN_PCT ([int]$Defaults.VL_WARN_PCT) 0 100)
 $Cfg.VL_HOT_PCT = [string](Get-BoundedInt $Cfg.VL_HOT_PCT ([int]$Defaults.VL_HOT_PCT) 0 100)
+$Cfg.VL_MAX_LINES = [string](Get-BoundedInt $Cfg.VL_MAX_LINES ([int]$Defaults.VL_MAX_LINES) 1 64)
+$Cfg.VL_WRAP_MARGIN = [string](Get-BoundedInt $Cfg.VL_WRAP_MARGIN ([int]$Defaults.VL_WRAP_MARGIN) 0 32767)
 if ([int]$Cfg.VL_HOT_PCT -lt [int]$Cfg.VL_WARN_PCT) {
     $Cfg.VL_WARN_PCT = $Defaults.VL_WARN_PCT
     $Cfg.VL_HOT_PCT = $Defaults.VL_HOT_PCT
@@ -597,11 +641,22 @@ if ([int]$Cfg.VL_HOT_PCT -lt [int]$Cfg.VL_WARN_PCT) {
 foreach ($key in @($Cfg.Keys | Where-Object { $_ -like 'VL_BG_*' -or $_ -like 'VL_FG_*' })) {
     if (-not (Test-Color $Cfg[$key])) { $Cfg[$key] = $Defaults[$key] }
 }
+if (-not (Test-Color $Cfg.VL_LEAN_BG)) { $Cfg.VL_LEAN_BG = '' }
+if (-not (Test-Color $Cfg.VL_LEAN_FG)) { $Cfg.VL_LEAN_FG = '' }
 
-# Later slices add the other styles/layout. Existing configs degrade predictably.
-if ($Cfg.VL_STYLE -ne 'pill') { $Cfg.VL_STYLE = 'pill' }
-if ($Cfg.VL_LAYOUT -ne 'fixed') { $Cfg.VL_LAYOUT = 'fixed' }
+$Cfg.VL_STYLE = switch ([string]$Cfg.VL_STYLE) {
+    'pill' { 'pill'; break }
+    'lean' { 'lean'; break }
+    'classic' { 'classic'; break }
+    default { 'pill' }
+}
+$Cfg.VL_LAYOUT = switch ([string]$Cfg.VL_LAYOUT) {
+    'fixed' { 'fixed'; break }
+    'auto' { 'auto'; break }
+    default { 'fixed' }
+}
 
+# Bash applies ASCII first, then classic's lean defaults, then lean overrides.
 if ($Cfg.VL_ASCII -eq '1') {
     $Cfg.VL_CAP_L = ''
     $Cfg.VL_CAP_R = ''
@@ -610,6 +665,16 @@ if ($Cfg.VL_ASCII -eq '1') {
     $Cfg.VL_BAR_EMPTY = '-'
     $Cfg.VL_NODE_GLYPH = 'node'
     $Cfg.VL_PY_GLYPH = 'py'
+}
+if ($Cfg.VL_STYLE -eq 'classic') {
+    $Cfg.VL_STYLE = 'lean'
+    if ([string]::IsNullOrEmpty($Cfg.VL_LEAN_BG)) { $Cfg.VL_LEAN_BG = if ([string]::IsNullOrEmpty($Cfg.VL_BG_BAR)) { '238' } else { $Cfg.VL_BG_BAR } }
+    if ([string]::IsNullOrEmpty($Cfg.VL_LEAN_CAP_R)) { $Cfg.VL_LEAN_CAP_R = $Cfg.VL_SEP }
+}
+if ($Cfg.VL_STYLE -eq 'lean') {
+    $Cfg.VL_CAP_L = ''
+    $Cfg.VL_CAP_R = ''
+    $Cfg.VL_FG_TEXT = $Cfg.VL_LEAN_FG
 }
 
 $NoColor = $Cfg.VL_NOCOLOR -eq '1'
@@ -1522,7 +1587,7 @@ function Read-PinFile([string]$Path) {
     } catch { return '' }
 }
 
-function Get-NodeVersion([string]$Dir) {
+function Get-NodeVersion-Uncached([string]$Dir) {
     if ([string]::IsNullOrEmpty($Dir)) { return '' }
     try { $d = New-Object System.IO.DirectoryInfo($Dir) } catch { $d = $null }
     while ($null -ne $d) {
@@ -1545,7 +1610,7 @@ function Get-NodeVersion([string]$Dir) {
     return ''
 }
 
-function Get-PythonVersion([string]$Dir) {
+function Get-PythonVersion-Uncached([string]$Dir) {
     $venv = Remove-ControlChars ([string]$env:VIRTUAL_ENV)
     if (-not [string]::IsNullOrEmpty($venv)) {
         try { return [System.IO.Path]::GetFileName($venv.TrimEnd('\', '/')) } catch { }
@@ -1573,19 +1638,65 @@ function Get-PythonVersion([string]$Dir) {
     return ''
 }
 
+$script:StashCacheSet = $false
+$script:StashCache = 0
+$script:NodeCacheSet = $false
+$script:NodeCache = ''
+$script:PythonCacheSet = $false
+$script:PythonCache = ''
+
+function Get-StashCount-Cached([string]$Cwd) {
+    if (-not $script:StashCacheSet) {
+        $script:StashCache = Get-StashCount $Cwd
+        $script:StashCacheSet = $true
+    }
+    return [int]$script:StashCache
+}
+
+function Get-NodeVersion([string]$Dir) {
+    if (-not $script:NodeCacheSet) {
+        $script:NodeCache = [string](Get-NodeVersion-Uncached $Dir)
+        $script:NodeCacheSet = $true
+    }
+    return [string]$script:NodeCache
+}
+
+function Get-PythonVersion([string]$Dir) {
+    if (-not $script:PythonCacheSet) {
+        $script:PythonCache = [string](Get-PythonVersion-Uncached $Dir)
+        $script:PythonCacheSet = $true
+    }
+    return [string]$script:PythonCache
+}
+
 function Get-SegmentTokens([string]$List) {
     if ([string]::IsNullOrWhiteSpace($List)) { return @() }
     return @([regex]::Split($List.Trim(), '\s+') | Where-Object { -not [string]::IsNullOrEmpty($_) })
 }
 
-$AllSegmentNames = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
-foreach ($list in @($Cfg.VL_SEGMENTS, $Cfg.VL_SEGMENTS2, $Cfg.VL_SEGMENTS3)) {
-    foreach ($name in (Get-SegmentTokens $list)) { [void]$AllSegmentNames.Add($name) }
+$MainSegmentNames = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
+$MainSegmentLists = @([string]$Cfg.VL_SEGMENTS, [string]$Cfg.VL_SEGMENTS2, [string]$Cfg.VL_SEGMENTS3)
+foreach ($list in $MainSegmentLists) {
+    foreach ($name in (Get-SegmentTokens $list)) { [void]$MainSegmentNames.Add($name) }
+}
+$FloatSegmentNames = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
+$FloatTokens = @(Get-SegmentTokens ([string]$Cfg.VL_FLOAT_SEGMENTS))
+$FloatEnabled = $Cfg.VL_FLOAT -eq '1' -and ([string]$Cfg.VL_FLOAT_SEGMENTS).Length -le 4096 -and $FloatTokens.Count -le 64 -and ([string]$Cfg.VL_FLOAT_SEP).Length -le 256
+if ($FloatEnabled) { foreach ($name in $FloatTokens) { [void]$FloatSegmentNames.Add($name) } }
+$ProbeSegmentNames = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
+foreach ($name in $MainSegmentNames) { [void]$ProbeSegmentNames.Add($name) }
+foreach ($name in $FloatSegmentNames) { [void]$ProbeSegmentNames.Add($name) }
+
+# Collision derivation is lexical only and runs even when all state gates are off.
+$AllStatePaths = New-Object 'System.Collections.Generic.List[object]'
+foreach ($base in @($Cfg.BURN_FILE, $Cfg.RL5H_FILE, $Cfg.RL7D_FILE)) {
+    $statePath = Get-StatePaths $base
+    if ($null -ne $statePath) { [void]$AllStatePaths.Add($statePath) }
 }
 
-$BurnStateGate = $AllSegmentNames.Contains('burn')
-$Limit5StateGate = $Cfg.VL_LIMIT_SYNC -eq '1' -and $AllSegmentNames.Contains('limit5h')
-$Limit7StateGate = $Cfg.VL_LIMIT_SYNC -eq '1' -and ($AllSegmentNames.Contains('limit7d') -or $BurnStateGate)
+$BurnStateGate = $ProbeSegmentNames.Contains('burn')
+$Limit5StateGate = $Cfg.VL_LIMIT_SYNC -eq '1' -and $ProbeSegmentNames.Contains('limit5h')
+$Limit7StateGate = $Cfg.VL_LIMIT_SYNC -eq '1' -and ($ProbeSegmentNames.Contains('limit7d') -or $BurnStateGate)
 $State = $null
 if ($BurnStateGate -or $Limit5StateGate -or $Limit7StateGate) {
     $State = Get-CorallineState $BurnStateGate $Limit5StateGate $Limit7StateGate
@@ -1593,16 +1704,51 @@ if ($BurnStateGate -or $Limit5StateGate -or $Limit7StateGate) {
 
 $GitState = @{ Branch = ''; Marks = ''; Ab = ''; Dirty = $false }
 $GitRoot = ''
-if ($AllSegmentNames.Contains('git') -or $AllSegmentNames.Contains('stash') -or $AllSegmentNames.Contains('project')) {
+if ($ProbeSegmentNames.Contains('git') -or $ProbeSegmentNames.Contains('stash') -or $ProbeSegmentNames.Contains('project')) {
     $GitState = Get-GitState $ProbeCwd
 }
-if ($AllSegmentNames.Contains('project') -and -not [string]::IsNullOrEmpty($GitState.Branch)) { $GitRoot = Get-GitRoot $ProbeCwd }
+if ($ProbeSegmentNames.Contains('project') -and -not [string]::IsNullOrEmpty($GitState.Branch)) { $GitRoot = Get-GitRoot $ProbeCwd }
 
 $SegBgs = New-Object System.Collections.Generic.List[string]
 $SegTxt = New-Object System.Collections.Generic.List[string]
+$SegLen = New-Object 'System.Collections.Generic.List[int]'
+
+function Remove-Sgr([string]$Value) {
+    if ([string]::IsNullOrEmpty($Value)) { return '' }
+    return [regex]::Replace($Value, ([string][char]27 + '\[[0-9;]*m'), '')
+}
+
+function Get-DisplayWidth([string]$Value) {
+    $plain = Remove-Sgr $Value
+    $width = 0
+    $i = 0
+    while ($i -lt $plain.Length) {
+        $advance = 1
+        try {
+            $cp = [char]::ConvertToUtf32($plain, $i)
+            if ([char]::IsHighSurrogate($plain[$i])) { $advance = 2 }
+        } catch {
+            $cp = 0xFFFD
+        }
+        if ($cp -ge 0x300 -and $cp -le 0x36F -or $cp -ge 0x200B -and $cp -le 0x200F -or $cp -ge 0xFE00 -and $cp -le 0xFE0F) {
+            $i += $advance
+            continue
+        }
+        if ($cp -ge 0x1100 -and $cp -le 0x115F -or $cp -ge 0x2E80 -and $cp -le 0xA4CF -or $cp -ge 0xAC00 -and $cp -le 0xD7A3 -or $cp -ge 0xF900 -and $cp -le 0xFAFF -or $cp -ge 0xFE10 -and $cp -le 0xFE19 -or $cp -ge 0xFE30 -and $cp -le 0xFE6F -or $cp -ge 0xFF00 -and $cp -le 0xFF60 -or $cp -ge 0xFFE0 -and $cp -le 0xFFE6 -or $cp -ge 0x1F300 -and $cp -le 0x1FAFF -or $cp -ge 0x20000 -and $cp -le 0x3FFFF) {
+            $width += 2
+        } else {
+            $width++
+        }
+        $i += $advance
+    }
+    return $width
+}
+
 function Push-Segment([string]$Bg, [string]$Text) {
     [void]$SegBgs.Add($Bg)
     [void]$SegTxt.Add($Text)
+    if ($Cfg.VL_LAYOUT -eq 'auto') { [void]$SegLen.Add((Get-DisplayWidth $Text)) }
+    else { [void]$SegLen.Add(0) }
 }
 
 function Add-DirSegment {
@@ -1615,7 +1761,7 @@ function Add-DirSegment {
 
 function Add-ProjectSegment {
     if ([string]::IsNullOrEmpty($GitRoot)) {
-        if (-not $AllSegmentNames.Contains('dir')) { Add-DirSegment }
+        if (-not $MainSegmentNames.Contains('dir')) { Add-DirSegment }
         return
     }
     $tr = Get-Trunc $GitRoot ([int]$Cfg.VL_NAME_MAX)
@@ -1636,7 +1782,7 @@ function Add-GitSegment {
 
 function Add-StashSegment {
     if ([string]::IsNullOrEmpty($GitState.Branch)) { return }
-    $count = Get-StashCount $ProbeCwd
+    $count = Get-StashCount-Cached $ProbeCwd
     if ($count -le 0) { return }
     $fg = Get-Fg $Cfg.VL_FG_TEXT
     $bg = $Cfg.VL_BG_STASH
@@ -1827,29 +1973,249 @@ $SegmentBuilders = [ordered]@{
 function Build-Segments([string]$List) {
     $SegBgs.Clear()
     $SegTxt.Clear()
+    $SegLen.Clear()
     foreach ($name in (Get-SegmentTokens $List)) {
         if ($SegmentBuilders.Contains($name)) { & $SegmentBuilders[$name] }
     }
 }
 
-function Render-Row {
-    if ($SegBgs.Count -eq 0) { return '' }
-    $out = $Rst + (Get-Fg $SegBgs[0]) + $Cfg.VL_CAP_L
-    for ($i = 0; $i -lt $SegBgs.Count; $i++) {
+function Render-Range([int]$Start, [int]$End) {
+    if ($SegBgs.Count -eq 0 -or $Start -lt 0 -or $End -lt $Start -or $End -ge $SegBgs.Count) { return '' }
+    if ($Cfg.VL_STYLE -eq 'lean') {
+        $lbg = ''
+        if (-not [string]::IsNullOrEmpty($Cfg.VL_LEAN_BG)) { $lbg = Get-Bg $Cfg.VL_LEAN_BG }
+        $out = ''
+        if (-not [string]::IsNullOrEmpty($lbg) -and -not [string]::IsNullOrEmpty($Cfg.VL_LEAN_CAP_L)) {
+            $out = $Rst + (Get-Fg $Cfg.VL_LEAN_BG) + $Cfg.VL_LEAN_CAP_L
+        }
+        for ($i = $Start; $i -le $End; $i++) {
+            $out += $Rst + $lbg + (Get-Fg $SegBgs[$i]) + $SegTxt[$i]
+            if ($i -lt $End) { $out += $Rst + $lbg + $Cfg.VL_LEAN_SEP }
+        }
+        if (-not [string]::IsNullOrEmpty($lbg) -and -not [string]::IsNullOrEmpty($Cfg.VL_LEAN_CAP_R)) {
+            $out += $Rst + (Get-Fg $Cfg.VL_LEAN_BG) + $Cfg.VL_LEAN_CAP_R
+        }
+        return $out + $Rst
+    }
+    $out = $Rst + (Get-Fg $SegBgs[$Start]) + $Cfg.VL_CAP_L
+    for ($i = $Start; $i -le $End; $i++) {
         $out += (Get-Bg $SegBgs[$i]) + $SegTxt[$i]
-        if ($i -lt ($SegBgs.Count - 1)) {
+        if ($i -lt $End) {
             $out += (Get-Bg $SegBgs[$i + 1]) + (Get-Fg $SegBgs[$i]) + $Cfg.VL_SEP
         }
     }
-    $out += $Rst + (Get-Fg $SegBgs[$SegBgs.Count - 1]) + $Cfg.VL_CAP_R + $Rst
+    $out += $Rst + (Get-Fg $SegBgs[$End]) + $Cfg.VL_CAP_R + $Rst
     return $out
 }
 
+function Get-ScalarCount([string]$Value) {
+    if ([string]::IsNullOrEmpty($Value)) { return 0 }
+    $count = 0
+    $i = 0
+    while ($i -lt $Value.Length) {
+        if ([char]::IsHighSurrogate($Value[$i]) -and $i + 1 -lt $Value.Length -and [char]::IsLowSurrogate($Value[$i + 1])) { $i++ }
+        $count++
+        $i++
+    }
+    return $count
+}
+
+function Test-FloatCollision([string]$Target) {
+    $runtime = ''
+    try { $runtime = [IO.Path]::GetFullPath($ScriptPath) } catch { }
+    $collisionPaths = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($path in @($ConfigPath, $runtime)) { if (-not [string]::IsNullOrEmpty($path)) { [void]$collisionPaths.Add($path) } }
+    foreach ($path in $ConfigVisitedPaths) { if (-not [string]::IsNullOrEmpty([string]$path)) { [void]$collisionPaths.Add([string]$path) } }
+    foreach ($statePath in $AllStatePaths) {
+        if ($null -eq $statePath) { continue }
+        foreach ($path in @($statePath.Base, $statePath.Root)) { if (-not [string]::IsNullOrEmpty($path)) { [void]$collisionPaths.Add($path) } }
+    }
+    foreach ($path in $collisionPaths) {
+        if ($Target.Equals([string]$path, [StringComparison]::OrdinalIgnoreCase)) { return $true }
+    }
+    return $false
+}
+
+function Get-FloatTarget {
+    if (-not $FloatEnabled) { return $null }
+    if ($FloatFileRootAuthorized -and [string]::IsNullOrEmpty([string]$Cfg.VL_FLOAT_FILE)) { return $null }
+    if (([string]$Cfg.VL_FLOAT_FILE).Length -gt 4096) { return $null }
+    $target = ConvertTo-LocalFullPath ([string]$Cfg.VL_FLOAT_FILE) ([Environment]::CurrentDirectory)
+    if ([string]::IsNullOrEmpty($target) -or (Test-FloatCollision $target)) { return $null }
+    return $target
+}
+
+function Write-FloatAtomic([string]$Target, [byte[]]$Bytes) {
+    $parent = $null
+    try { $parent = [IO.Path]::GetDirectoryName($Target) } catch { return $false }
+    if ([string]::IsNullOrEmpty($parent) -or -not (Test-NoReparseComponents $parent)) { return $false }
+    try {
+        # WIN03_TEST_BEFORE_PARENT_CREATE
+        if (-not [IO.Directory]::Exists($parent)) { [void][IO.Directory]::CreateDirectory($parent) }
+    } catch { return $false }
+    # WIN03_TEST_AFTER_PARENT_CREATE
+    if (-not (Test-NoReparseComponents $parent) -or -not [IO.Directory]::Exists($parent)) { return $false }
+    if ((Test-StateObjectExists $Target) -and -not (Test-SafeRegularFile $Target)) { return $false }
+
+    $temp = ''
+    $backup = ''
+    try {
+        for ($attempt = 0; $attempt -lt 8; $attempt++) {
+            $candidate = [IO.Path]::Combine($parent, '.float.tmp.' + [string]$PID + '.' + [guid]::NewGuid().ToString('N'))
+            if ($candidate.Length -gt 4096) { return $false }
+            $stream = $null
+            try {
+                $stream = New-Object IO.FileStream($candidate, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None, 4096, [IO.FileOptions]::WriteThrough)
+                if ($Bytes.Length -gt 0) { $stream.Write($Bytes, 0, $Bytes.Length) }
+                $stream.Flush($true)
+                $stream.Dispose()
+                $stream = $null
+                # WIN03_TEST_AFTER_TEMP_CLOSE
+                $temp = $candidate
+                break
+            } catch [IO.IOException] {
+                if ($null -ne $stream) { $stream.Dispose() }
+            } catch {
+                if ($null -ne $stream) { $stream.Dispose() }
+                return $false
+            }
+        }
+        if ([string]::IsNullOrEmpty($temp)) { return $false }
+        if (-not (Test-NoReparseComponents $parent)) { return $false }
+        if (Test-StateObjectExists $Target) {
+            if (-not (Test-SafeRegularFile $Target)) { return $false }
+            for ($attempt = 0; $attempt -lt 8; $attempt++) {
+                $backup = [IO.Path]::Combine($parent, '.float.bak.' + [string]$PID + '.' + [guid]::NewGuid().ToString('N'))
+                if ($backup.Length -gt 4096) { $backup = ''; return $false }
+                if (-not (Test-StateObjectExists $backup)) { break }
+                $backup = ''
+            }
+            if ([string]::IsNullOrEmpty($backup)) { return $false }
+            [IO.File]::Replace($temp, $Target, $backup)
+            if (Test-SafeRegularFile $backup) { [IO.File]::Delete($backup); $backup = '' }
+            elseif (-not (Test-StateObjectExists $backup)) { $backup = '' }
+        } else {
+            [IO.File]::Move($temp, $Target)
+        }
+        $temp = ''
+        return $true
+    } catch { return $false }
+    finally {
+        foreach ($path in @($temp, $backup)) {
+            if (-not [string]::IsNullOrEmpty($path)) {
+                try {
+                    if (Test-SafeRegularFile $path) { [IO.File]::Delete($path) }
+                } catch { }
+            }
+        }
+    }
+}
+
+function Test-FloatText([string]$Value) {
+    if ($null -eq $Value) { return $false }
+    foreach ($ch in $Value.ToCharArray()) {
+        $code = [int][char]$ch
+        if ($code -lt 0x20 -or $code -eq 0x7F -or $code -ge 0x80 -and $code -le 0x9F -or $code -eq 0x1B) { return $true }
+    }
+    return $false
+}
+
+function Invoke-Float {
+    if (-not $FloatEnabled) { return }
+    $target = Get-FloatTarget
+    if ([string]::IsNullOrEmpty($target)) { return }
+    $oldNoColor = $NoColor
+    $oldBold = $Bold
+    $oldNorm = $Norm
+    $oldRst = $Rst
+    $oldLayout = $Cfg.VL_LAYOUT
+    try {
+        $NoColor = $true
+        $Bold = ''
+        $Norm = ''
+        $Rst = ''
+        $Cfg.VL_LAYOUT = 'fixed'
+        Build-Segments ([string]$Cfg.VL_FLOAT_SEGMENTS)
+        $parts = New-Object 'System.Collections.Generic.List[string]'
+        for ($i = 0; $i -lt $SegTxt.Count; $i++) {
+            $plain = (Remove-Sgr ([string]$SegTxt[$i])).Trim()
+            if ([string]::IsNullOrEmpty($plain)) { continue }
+            if (Test-FloatText $plain) { return }
+            [void]$parts.Add($plain)
+        }
+        $line = [string]::Join([string]$Cfg.VL_FLOAT_SEP, $parts.ToArray())
+        if (Test-FloatText $line) { return }
+        $payload = $line + "`n"
+        $bytes = $StrictUtf8.GetBytes($payload)
+        if ($bytes.Length -gt 65536) { return }
+        [void](Write-FloatAtomic $target $bytes)
+    } catch { }
+    finally {
+        $NoColor = $oldNoColor
+        $Bold = $oldBold
+        $Norm = $oldNorm
+        $Rst = $oldRst
+        $Cfg.VL_LAYOUT = $oldLayout
+    }
+}
+
+function Get-TerminalColumns {
+    $raw = [string]$env:COLUMNS
+    if (-not [string]::IsNullOrEmpty($raw)) {
+        if ($raw -notmatch '^([0-9]+)$') { return 0 }
+        $value = 0
+        if (-not [int]::TryParse($raw, $IntegerStyle, $Invariant, [ref]$value) -or $value -lt 1 -or $value -gt 32767) { return 0 }
+        return $value
+    }
+    if ($Host.Name -ne 'ConsoleHost') { return 0 }
+    try {
+        $value = [int]$Host.UI.RawUI.WindowSize.Width
+        if ($value -ge 1 -and $value -le 32767) { return $value }
+    } catch { }
+    return 0
+}
+
 try {
-    foreach ($list in @($Cfg.VL_SEGMENTS, $Cfg.VL_SEGMENTS2, $Cfg.VL_SEGMENTS3)) {
-        if ([string]::IsNullOrWhiteSpace($list)) { continue }
-        Build-Segments $list
-        if ($SegBgs.Count -gt 0) { $OutputWriter.WriteLine((Render-Row)) }
+    Invoke-Float
+    if ($Cfg.VL_LAYOUT -eq 'auto') {
+        Build-Segments ([string]$Cfg.VL_SEGMENTS)
+        $total = $SegBgs.Count
+        if ($total -gt 0) {
+            $width = Get-TerminalColumns
+            $maxLines = [int]$Cfg.VL_MAX_LINES
+            if ($width -le 0 -or $maxLines -le 1) {
+                $OutputWriter.WriteLine((Render-Range 0 ($total - 1)))
+            } else {
+                $width -= [int]$Cfg.VL_WRAP_MARGIN
+                if ($width -lt 1) { $width = 1 }
+                if ($Cfg.VL_STYLE -eq 'lean') {
+                    $capWidth = (Get-ScalarCount $Cfg.VL_LEAN_CAP_L) + (Get-ScalarCount $Cfg.VL_LEAN_CAP_R)
+                    $sepWidth = Get-ScalarCount $Cfg.VL_LEAN_SEP
+                } else {
+                    $capWidth = 2
+                    $sepWidth = 1
+                }
+                $start = 0
+                $line = 1
+                $current = $capWidth + [int]$SegLen[0]
+                for ($i = 1; $i -lt $total; $i++) {
+                    $need = $current + $sepWidth + [int]$SegLen[$i]
+                    if ($need -gt $width -and $line -lt $maxLines) {
+                        $OutputWriter.WriteLine((Render-Range $start ($i - 1)))
+                        $start = $i
+                        $line++
+                        $current = $capWidth + [int]$SegLen[$i]
+                    } else { $current = $need }
+                }
+                $OutputWriter.WriteLine((Render-Range $start ($total - 1)))
+            }
+        }
+    } else {
+        foreach ($list in $MainSegmentLists) {
+            if ([string]::IsNullOrWhiteSpace($list)) { continue }
+            Build-Segments $list
+            if ($SegBgs.Count -gt 0) { $OutputWriter.WriteLine((Render-Range 0 ($SegBgs.Count - 1))) }
+        }
     }
 } finally {
     $OutputWriter.Flush()

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -1381,7 +1381,7 @@ function Format-Duration([double]$Ms, [bool]$IncludeSeconds) {
 
 function Get-ClockText {
     $now = Get-Date
-    if ($Cfg.VL_CLOCK -eq '24h') {
+    if ($Cfg.VL_CLOCK -ceq '24h') {
         if ($Cfg.VL_CLOCK_SECONDS -eq '1') { return $now.ToString('HH:mm:ss', $Invariant) }
         return $now.ToString('HH:mm', $Invariant)
     }
@@ -1953,7 +1953,7 @@ function Add-CostSegment {
 }
 
 function Add-ClockSegment {
-    if ($Cfg.VL_CLOCK -eq 'off') { return }
+    if ($Cfg.VL_CLOCK -ceq 'off') { return }
     $fg = Get-Fg $Cfg.VL_FG_TEXT
     Push-Segment $Cfg.VL_BG_CLOCK "${fg} $($G.Dot) $(Get-ClockText) "
 }

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -217,11 +217,20 @@ function Decode-ShellWord([string]$Text, [bool]$PathContext) {
                     $i++
                     if ($i -ge $Text.Length) { return [pscustomobject]@{ Success = $false; Value = '' } }
                     $next = $Text[$i]
-                    if ($next -ne '"' -and $next -ne '\' -and $next -ne '$' -and $next -ne '`') {
+                    if ($next -eq '"' -or $next -eq '\' -or $next -eq '$' -or $next -eq '`') {
+                        if (-not (Add-Utf8Text $bytes ([string]$next))) { return [pscustomobject]@{ Success = $false; Value = '' } }
+                        $i++
+                        continue
+                    }
+                    # In Bash double quotes, a backslash before an ordinary
+                    # character remains literal together with that character.
+                    if (-not (Add-Utf8Text $bytes '\')) { return [pscustomobject]@{ Success = $false; Value = '' } }
+                    $ri = [ref]$i
+                    $piece = Read-WordChar $Text $ri
+                    if ($null -eq $piece -or -not (Add-Utf8Text $bytes $piece)) {
                         return [pscustomobject]@{ Success = $false; Value = '' }
                     }
-                    if (-not (Add-Utf8Text $bytes ([string]$next))) { return [pscustomobject]@{ Success = $false; Value = '' } }
-                    $i++
+                    $i = $ri.Value
                     continue
                 }
                 if ($ch -eq '$') {

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -1,210 +1,636 @@
-﻿#Requires -Version 5.1
+#Requires -Version 5.1
 <#
-  coralline ??native PowerShell port of statusline.sh for Claude Code on
-  Windows without Git Bash (see issue #8).
+  coralline - native Windows PowerShell statusline for Claude Code.
 
-  Design goals for this port:
-    * No jq, no bash, no WSL. Only `git.exe` on PATH is used, and only when a
-      git-dependent segment (git/stash/project) is actually enabled.
-    * Reads the SAME ~/.claude/coralline.conf (and its `. theme.conf` include)
-      that statusline.sh reads. The config file is plain `KEY=value` /
-      `KEY="value"` assignments with a single `. "path"` include line, so this
-      script parses that shape directly with a small regex-based reader
-      instead of requiring a new config format or an installer change (see
-      Import-CorallineConfLines below). Existing coralline.conf files and
-      every shipped theme work unmodified with this script.
-    * Targets Windows PowerShell 5.1 (the interpreter that ships on every
-      Windows 10/11 box; no PowerShell 7 dependency), since that is what a
-      "no Git Bash" user already has available.
-
-  Scope (first native slice ??see handoff/coralline-8-scope.md for the parity
-  matrix): the "pill" style (VL_STYLE default) in "fixed" layout (VL_LAYOUT
-  default) with every main-bar JSON-driven segment statusline.sh ships except
-  `burn` (cross-session sampling with an awk slope fit) and the `--subagent`
-  panel-row protocol. `lean`/`classic` styles and the `auto` responsive-wrap
-  layout are not yet ported; VL_STYLE/VL_LAYOUT values other than the defaults
-  fall back to pill/fixed so an imported bash config still renders instead of
-  erroring.
-
-  Usage (settings.json), matching the shape proposed in issue #8:
-    "statusLine": {
-      "type": "command",
-      "command": "powershell -NoProfile -File C:/Users/you/.claude/coralline/statusline.ps1"
-    }
+  This slice implements the fixed pill main bar without Bash, jq, WSL, or
+  PowerShell 7. Config is read from the same coralline.conf through a narrow,
+  non-executing Bash-word parser. Burn state, alternate styles/layouts, float
+  output, and subagent rows are implemented by later slices.
 #>
 
-param(
-    # statusline.sh's --subagent panel-row protocol is not ported yet. Accept
-    # the flag and exit clean (no output) so Claude Code keeps its own default
-    # panel rows instead of erroring on an unregistered command.
-    [switch]$Subagent
-)
-
-if ($Subagent) { exit 0 }
-
-# Left at the default ('Continue'): a native helper (git) writing to stderr
-# must not become a terminating error here even when its stream is
-# redirected away below, and every render must still print something rather
-# than aborting on one bad segment.
-$ErrorActionPreference = 'Continue'
-
-# Windows PowerShell 5.1 defaults stdout to the console/OEM codepage, which
-# mangles every non-ASCII glyph below (the p10k caps, the segment icons) once
-# Claude Code captures this process's raw stdout bytes. Force UTF-8 (no BOM)
-# on both the read and write sides so the bytes Claude Code reads back match
-# what statusline.sh's Nerd-Font/Unicode segments look like on bash.
-$Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
-try { [Console]::OutputEncoding = $Utf8NoBom } catch { }
-try { [Console]::InputEncoding = $Utf8NoBom } catch { }
-$OutputEncoding = $Utf8NoBom
-
-# ---- stdin --------------------------------------------------------------
-$rawInput = [Console]::In.ReadToEnd()
-
-$Now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
-
-# ---- glyphs (codepoint literals, not source-embedded UTF-8, so this file
-# renders correctly under Windows PowerShell 5.1's default ANSI-codepage
-# script parsing regardless of the file's on-disk BOM) ---------------------
-function Glyph([int]$Codepoint) { [System.Char]::ConvertFromUtf32($Codepoint) }
-
-$G = @{
-    CapL      = Glyph 0xE0B6
-    CapR      = Glyph 0xE0B4
-    Sep       = Glyph 0xE0B0
-    Node      = Glyph 0xE718
-    Python    = Glyph 0xE73C
-    Project   = Glyph 0x2B22
-    Branch    = Glyph 0x2387
-    Diamond   = Glyph 0x25C6
-    Hex       = Glyph 0x2B21
-    Flag      = Glyph 0x2691
-    Dot       = Glyph 0x2299
-    Pencil    = Glyph 0x270E
-    Hourglass = Glyph 0x29D6
-    Psi       = Glyph 0x03C8
-    Ahead     = Glyph 0x21E1
-    Behind    = Glyph 0x21E3
-    Ellipsis  = Glyph 0x2026
-    BarFill   = Glyph 0x25B0
-    BarEmpty  = Glyph 0x25B1
-    Up        = Glyph 0x2191
-    Down      = Glyph 0x2193
-    Reset     = Glyph 0x21BA
+# Claude Code registers this exact literal. It must leave before stdin, config,
+# executable discovery, or any other main-bar work.
+if ($args.Count -gt 0 -and [string]$args[0] -ceq '--subagent') {
+    [Environment]::Exit(0)
 }
 
-$Esc  = [char]27
-$Rst  = "$Esc[0m"
-$Bold = "$Esc[1m"
-$Norm = "$Esc[22m"
+$ErrorActionPreference = 'SilentlyContinue'
+$ProgressPreference = 'SilentlyContinue'
 
-# ---- config: defaults (mirrors statusline.sh's hardcoded defaults for the
-# segments this port renders) ----------------------------------------------
-$Cfg = [ordered]@{
-    VL_STYLE          = 'pill'
-    VL_LAYOUT         = 'fixed'
-    VL_SEGMENTS       = 'dir git model ctx limit5h limit7d cost clock'
-    VL_SEGMENTS2      = ''
-    VL_SEGMENTS3      = ''
-    VL_BAR_WIDTH      = '5'
-    VL_CLOCK          = '12h'
-    VL_CLOCK_SECONDS  = '1'
-    VL_PATH_DEPTH     = '4'
-    VL_NAME_MAX       = '0'
-    VL_COST_DECIMALS  = '2'
-    VL_WARN_PCT       = '50'
-    VL_HOT_PCT        = '75'
-    VL_ASCII          = '0'
-    VL_RUNTIME_PROBE  = '0'
-    VL_NOCOLOR        = '0'
+$StrictUtf8 = New-Object System.Text.UTF8Encoding($false, $true)
+$Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+$InputStream = [Console]::OpenStandardInput()
+$InputReader = New-Object System.IO.StreamReader($InputStream, $StrictUtf8, $false, 4096, $false)
+try { $rawInput = $InputReader.ReadToEnd() } catch { $rawInput = '' }
+$InputReader.Dispose()
 
-    VL_BG_DIR      = '81,166,199'
-    VL_BG_PROJECT  = ''
-    VL_BG_GIT_OK   = '65'
-    VL_BG_STASH    = ''
+$OutputStream = [Console]::OpenStandardOutput()
+$OutputWriter = New-Object System.IO.StreamWriter($OutputStream, $Utf8NoBom, 4096, $false)
+$OutputWriter.NewLine = "`n"
+$OutputWriter.AutoFlush = $true
+$OutputEncoding = $Utf8NoBom
+[Console]::OutputEncoding = $Utf8NoBom
+
+function Glyph([int]$Codepoint) {
+    return [System.Char]::ConvertFromUtf32($Codepoint)
+}
+
+function Remove-ControlChars([string]$Value) {
+    if ([string]::IsNullOrEmpty($Value)) { return '' }
+    return [regex]::Replace($Value, '[\u0000-\u001f\u007f-\u009f]', '')
+}
+
+function Copy-Config([System.Collections.IDictionary]$Source) {
+    $copy = [ordered]@{}
+    foreach ($key in $Source.Keys) { $copy[$key] = [string]$Source[$key] }
+    return ,$copy
+}
+
+$HomeDir = [string]$HOME
+if ([string]::IsNullOrEmpty($HomeDir)) { $HomeDir = [Environment]::GetFolderPath('UserProfile') }
+$ScriptDir = [System.IO.Path]::GetDirectoryName($MyInvocation.MyCommand.Path)
+$DefaultFloatFile = [System.IO.Path]::Combine($HomeDir, '.claude\coralline\float.txt')
+$DefaultBurnFile = [string]$env:CORALLINE_BURN_FILE
+if ([string]::IsNullOrEmpty($DefaultBurnFile)) {
+    $DefaultBurnFile = [System.IO.Path]::Combine($HomeDir, '.claude\coralline\burn-5h.tsv')
+}
+$DefaultRl5File = [string]$env:CORALLINE_RL5H_FILE
+if ([string]::IsNullOrEmpty($DefaultRl5File)) {
+    $DefaultRl5File = [System.IO.Path]::Combine($HomeDir, '.claude\coralline\limit-5h.tsv')
+}
+$DefaultRl7File = [string]$env:CORALLINE_RL7D_FILE
+if ([string]::IsNullOrEmpty($DefaultRl7File)) {
+    $DefaultRl7File = [System.IO.Path]::Combine($HomeDir, '.claude\coralline\limit-7d.tsv')
+}
+
+$Defaults = [ordered]@{
+    VL_STYLE = 'pill'
+    VL_LEAN_SEP = ''
+    VL_LEAN_BG = ''
+    VL_LEAN_CAP_R = ''
+    VL_LEAN_CAP_L = ''
+    VL_LAYOUT = 'fixed'
+    VL_MAX_LINES = '3'
+    VL_WRAP_MARGIN = '4'
+    VL_SEGMENTS = 'dir git model ctx limit5h limit7d cost clock'
+    VL_SEGMENTS2 = ''
+    VL_SEGMENTS3 = ''
+    VL_BAR_WIDTH = '5'
+    VL_BAR_FILL = (Glyph 0x25B0)
+    VL_BAR_EMPTY = (Glyph 0x25B1)
+    VL_CTX_GLYPH = (Glyph 0x2B21)
+    VL_PROJECT_GLYPH = (Glyph 0x2B22)
+    VL_CLOCK = '12h'
+    VL_CLOCK_SECONDS = '1'
+    VL_PATH_DEPTH = '4'
+    VL_NAME_MAX = '0'
+    VL_COST_DECIMALS = '2'
+    VL_WARN_PCT = '50'
+    VL_HOT_PCT = '75'
+    VL_ASCII = '0'
+    VL_FLOAT = '0'
+    VL_FLOAT_SEGMENTS = 'model ctx cost'
+    VL_FLOAT_SEP = ('  ' + (Glyph 0x00B7) + '  ')
+    VL_FLOAT_FILE = $DefaultFloatFile
+    VL_NOCOLOR = '0'
+
+    VL_SUB_SEGMENTS = 'name model ctx elapsed'
+    VL_BG_SUB_NAME = ''
+    VL_BG_SUB_MODEL = ''
+    VL_BG_SUB_CTX = ''
+    VL_BG_SUB_ELAPSED = ''
+
+    CORALLINE_BURN_WINDOW = '600'
+    VL_BURN_GLYPH = (Glyph 0x2197)
+    VL_BG_BURN = ''
+    BURN_FILE = $DefaultBurnFile
+    BURN_TRIM = '1500'
+    VL_LIMIT_SYNC = '0'
+    RL5H_FILE = $DefaultRl5File
+    RL7D_FILE = $DefaultRl7File
+    RL_MAX_5H = '21600'
+    RL_MAX_7D = '691200'
+
+    VL_CAP_L = (Glyph 0xE0B6)
+    VL_CAP_R = (Glyph 0xE0B4)
+    VL_SEP = (Glyph 0xE0B0)
+
+    VL_BG_DIR = '81,166,199'
+    VL_BG_PROJECT = ''
+    VL_BG_GIT_OK = '65'
+    VL_BG_STASH = ''
     VL_BG_GIT_DIRTY = '130'
-    VL_BG_MODEL    = '173'
-    VL_BG_CTX      = '238'
-    VL_BG_5H       = '237'
-    VL_BG_7D       = '236'
-    VL_BG_COST     = '212,125,145'
-    VL_BG_CLOCK    = '70,80,110'
-    VL_BG_LINES    = '240'
-    VL_BG_STYLE    = '96'
+    VL_BG_MODEL = '173'
+    VL_BG_CTX = '238'
+    VL_BG_5H = '237'
+    VL_BG_7D = '236'
+    VL_BG_COST = '212,125,145'
+    VL_BG_CLOCK = '70,80,110'
+    VL_BG_LINES = '240'
+    VL_BG_STYLE = '96'
     VL_BG_DURATION = '60'
-    VL_BG_EFFORT   = '141'
-    VL_BG_NODE     = ''
-    VL_BG_PYTHON   = ''
+    VL_BG_EFFORT = '141'
+    VL_BG_NODE = ''
+    VL_BG_PYTHON = ''
+    VL_BG_BAR = ''
+    VL_NODE_GLYPH = (Glyph 0xE718)
+    VL_PY_GLYPH = (Glyph 0xE73C)
+    VL_RUNTIME_PROBE = '0'
 
     VL_FG_TEXT = '231'
-    VL_FG_DIM  = '245'
-    VL_FG_OK   = '114'
+    VL_FG_DIM = '245'
+    VL_FG_OK = '114'
     VL_FG_WARN = '179'
-    VL_FG_HOT  = '167'
+    VL_FG_HOT = '167'
 }
 
-# ---- config: parser -------------------------------------------------------
-# Reads the same bash-syntax coralline.conf / theme.conf files statusline.sh
-# sources. Handles the two shapes those files actually contain: the leading
-# `. "path"` theme include, and `KEY=value` / `KEY="value"` assignments with
-# an optional trailing `# comment`. Anything else (bash logic, conditionals)
-# is silently ignored, which is fine here since every shipped config and
-# theme is exactly this shape (write_candidate_config in configure.sh never
-# emits anything else). This means the SAME coralline.conf a bash install
-# wrote works for this script unmodified ??no new config format needed.
-function Strip-ConfValue([string]$Raw) {
-    $v = $Raw.Trim()
-    if ($v.Length -ge 1 -and $v[0] -eq '"') {
-        $endIdx = $v.IndexOf('"', 1)
-        if ($endIdx -ge 0) { return $v.Substring(1, $endIdx - 1) }
-        return $v.Substring(1)
-    }
-    if ($v.Length -ge 1 -and $v[0] -eq "'") {
-        $endIdx = $v.IndexOf("'", 1)
-        if ($endIdx -ge 0) { return $v.Substring(1, $endIdx - 1) }
-        return $v.Substring(1)
-    }
-    $hashIdx = $v.IndexOf('#')
-    if ($hashIdx -ge 0) { $v = $v.Substring(0, $hashIdx) }
-    return $v.Trim()
+$PathConfigKeys = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
+foreach ($key in @('VL_FLOAT_FILE', 'BURN_FILE', 'RL5H_FILE', 'RL7D_FILE')) { [void]$PathConfigKeys.Add($key) }
+
+function Add-Utf8Text([System.Collections.Generic.List[byte]]$Bytes, [string]$Text) {
+    try {
+        $encoded = $StrictUtf8.GetBytes($Text)
+        $Bytes.AddRange($encoded)
+        return $true
+    } catch { return $false }
 }
 
-function Import-CorallineConfLines([string]$Path, [System.Collections.Specialized.OrderedDictionary]$Target, [int]$Depth = 0) {
-    if ($Depth -gt 4) { return }              # guard against an include cycle
-    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return }
-    foreach ($line in Get-Content -LiteralPath $Path -ErrorAction SilentlyContinue) {
-        $t = $line.Trim()
-        if ($t -eq '' -or $t.StartsWith('#')) { continue }
-        if ($t -match '^\.\s+"?([^"]+?)"?\s*$') {
-            Import-CorallineConfLines -Path $matches[1] -Target $Target -Depth ($Depth + 1)
+function Read-WordChar([string]$Text, [ref]$Index) {
+    $i = [int]$Index.Value
+    if ($i -ge $Text.Length) { return $null }
+    $count = 1
+    if ([char]::IsHighSurrogate($Text[$i])) {
+        if (($i + 1) -ge $Text.Length -or -not [char]::IsLowSurrogate($Text[$i + 1])) { return $null }
+        $count = 2
+    } elseif ([char]::IsLowSurrogate($Text[$i])) { return $null }
+    $piece = $Text.Substring($i, $count)
+    $Index.Value = $i + $count
+    return $piece
+}
+
+function Decode-ShellWord([string]$Text, [bool]$PathContext) {
+    if ($null -eq $Text) { return [pscustomobject]@{ Success = $false; Value = '' } }
+    $bytes = New-Object 'System.Collections.Generic.List[byte]'
+    $i = 0
+    $started = $false
+
+    if ($Text.Length -eq 0) { return [pscustomobject]@{ Success = $true; Value = '' } }
+    if ($Text[0] -eq ' ' -or $Text[0] -eq "`t") {
+        $rest = $Text.TrimStart(' ', "`t")
+        if ($rest.Length -eq 0 -or $rest[0] -eq '#') {
+            return [pscustomobject]@{ Success = $true; Value = '' }
+        }
+        return [pscustomobject]@{ Success = $false; Value = '' }
+    }
+
+    while ($i -lt $Text.Length) {
+        $ch = $Text[$i]
+        if ($ch -eq ' ' -or $ch -eq "`t") { break }
+        $started = $true
+
+        if ($ch -eq "'") {
+            $i++
+            $closed = $false
+            while ($i -lt $Text.Length) {
+                if ($Text[$i] -eq "'") { $i++; $closed = $true; break }
+                $ri = [ref]$i
+                $piece = Read-WordChar $Text $ri
+                if ($null -eq $piece) { return [pscustomobject]@{ Success = $false; Value = '' } }
+                $i = $ri.Value
+                if (-not (Add-Utf8Text $bytes $piece)) { return [pscustomobject]@{ Success = $false; Value = '' } }
+            }
+            if (-not $closed) { return [pscustomobject]@{ Success = $false; Value = '' } }
             continue
         }
-        if ($t -match '^([A-Za-z_][A-Za-z0-9_]*)=(.*)$') {
-            $Target[$matches[1]] = Strip-ConfValue $matches[2]
+
+        if ($ch -eq '"') {
+            $i++
+            $closed = $false
+            while ($i -lt $Text.Length) {
+                $ch = $Text[$i]
+                if ($ch -eq '"') { $i++; $closed = $true; break }
+                if ($ch -eq '\') {
+                    $i++
+                    if ($i -ge $Text.Length) { return [pscustomobject]@{ Success = $false; Value = '' } }
+                    $next = $Text[$i]
+                    if ($next -ne '"' -and $next -ne '\' -and $next -ne '$' -and $next -ne '`') {
+                        return [pscustomobject]@{ Success = $false; Value = '' }
+                    }
+                    if (-not (Add-Utf8Text $bytes ([string]$next))) { return [pscustomobject]@{ Success = $false; Value = '' } }
+                    $i++
+                    continue
+                }
+                if ($ch -eq '$') {
+                    if (-not $PathContext) { return [pscustomobject]@{ Success = $false; Value = '' } }
+                    if ($Text.Substring($i).StartsWith('${HOME}', [System.StringComparison]::Ordinal)) { $i += 7 }
+                    elseif ($Text.Substring($i).StartsWith('$HOME', [System.StringComparison]::Ordinal)) { $i += 5 }
+                    else { return [pscustomobject]@{ Success = $false; Value = '' } }
+                    if (-not (Add-Utf8Text $bytes $HomeDir)) { return [pscustomobject]@{ Success = $false; Value = '' } }
+                    continue
+                }
+                if ($ch -eq '`') { return [pscustomobject]@{ Success = $false; Value = '' } }
+                $ri = [ref]$i
+                $piece = Read-WordChar $Text $ri
+                if ($null -eq $piece) { return [pscustomobject]@{ Success = $false; Value = '' } }
+                $i = $ri.Value
+                if (-not (Add-Utf8Text $bytes $piece)) { return [pscustomobject]@{ Success = $false; Value = '' } }
+            }
+            if (-not $closed) { return [pscustomobject]@{ Success = $false; Value = '' } }
+            continue
         }
+
+        if ($ch -eq '$' -and ($i + 1) -lt $Text.Length -and $Text[$i + 1] -eq "'") {
+            $i += 2
+            $closed = $false
+            while ($i -lt $Text.Length) {
+                $ch = $Text[$i]
+                if ($ch -eq "'") { $i++; $closed = $true; break }
+                if ($ch -ne '\') {
+                    $ri = [ref]$i
+                    $piece = Read-WordChar $Text $ri
+                    if ($null -eq $piece) { return [pscustomobject]@{ Success = $false; Value = '' } }
+                    $i = $ri.Value
+                    if (-not (Add-Utf8Text $bytes $piece)) { return [pscustomobject]@{ Success = $false; Value = '' } }
+                    continue
+                }
+
+                $i++
+                if ($i -ge $Text.Length) { return [pscustomobject]@{ Success = $false; Value = '' } }
+                $esc = $Text[$i]
+                $i++
+                $byteValue = -1
+                switch ($esc) {
+                    'a' { $byteValue = 7 }
+                    'b' { $byteValue = 8 }
+                    'e' { $byteValue = 27 }
+                    'E' { $byteValue = 27 }
+                    'f' { $byteValue = 12 }
+                    'n' { $byteValue = 10 }
+                    'r' { $byteValue = 13 }
+                    't' { $byteValue = 9 }
+                    'v' { $byteValue = 11 }
+                    '\' { $byteValue = 92 }
+                    "'" { $byteValue = 39 }
+                    '"' { $byteValue = 34 }
+                    default {
+                        if ($esc -ge '0' -and $esc -le '7') {
+                            $digits = [string]$esc
+                            while ($digits.Length -lt 3 -and $i -lt $Text.Length -and $Text[$i] -ge '0' -and $Text[$i] -le '7') {
+                                $digits += $Text[$i]
+                                $i++
+                            }
+                            try { $byteValue = [Convert]::ToInt32($digits, 8) } catch { $byteValue = -1 }
+                            if ($byteValue -gt 255) { $byteValue = -1 }
+                        } elseif ($esc -eq 'x') {
+                            $digits = ''
+                            while ($digits.Length -lt 2 -and $i -lt $Text.Length -and $Text[$i] -match '[0-9A-Fa-f]') {
+                                $digits += $Text[$i]
+                                $i++
+                            }
+                            if ($digits.Length -eq 0) { return [pscustomobject]@{ Success = $false; Value = '' } }
+                            try { $byteValue = [Convert]::ToInt32($digits, 16) } catch { $byteValue = -1 }
+                        } elseif ($esc -eq 'u' -or $esc -eq 'U') {
+                            $need = 4
+                            if ($esc -eq 'U') { $need = 8 }
+                            if (($i + $need) -gt $Text.Length) { return [pscustomobject]@{ Success = $false; Value = '' } }
+                            $digits = $Text.Substring($i, $need)
+                            if ($digits -notmatch ('^[0-9A-Fa-f]{' + $need + '}$')) { return [pscustomobject]@{ Success = $false; Value = '' } }
+                            $i += $need
+                            try { $cp = [Convert]::ToInt32($digits, 16) } catch { return [pscustomobject]@{ Success = $false; Value = '' } }
+                            if ($cp -gt 0x10FFFF -or ($cp -ge 0xD800 -and $cp -le 0xDFFF)) {
+                                return [pscustomobject]@{ Success = $false; Value = '' }
+                            }
+                            if (-not (Add-Utf8Text $bytes ([char]::ConvertFromUtf32($cp)))) {
+                                return [pscustomobject]@{ Success = $false; Value = '' }
+                            }
+                            continue
+                        } else { return [pscustomobject]@{ Success = $false; Value = '' } }
+                    }
+                }
+                if ($byteValue -lt 0 -or $byteValue -gt 255) { return [pscustomobject]@{ Success = $false; Value = '' } }
+                [void]$bytes.Add([byte]$byteValue)
+            }
+            if (-not $closed) { return [pscustomobject]@{ Success = $false; Value = '' } }
+            continue
+        }
+
+        if ($ch -eq '\') {
+            $i++
+            if ($i -ge $Text.Length) { return [pscustomobject]@{ Success = $false; Value = '' } }
+            $ri = [ref]$i
+            $piece = Read-WordChar $Text $ri
+            if ($null -eq $piece) { return [pscustomobject]@{ Success = $false; Value = '' } }
+            $i = $ri.Value
+            if (-not (Add-Utf8Text $bytes $piece)) { return [pscustomobject]@{ Success = $false; Value = '' } }
+            continue
+        }
+
+        if ($ch -eq '$') {
+            if (-not $PathContext) { return [pscustomobject]@{ Success = $false; Value = '' } }
+            if ($Text.Substring($i).StartsWith('${HOME}', [System.StringComparison]::Ordinal)) { $i += 7 }
+            elseif ($Text.Substring($i).StartsWith('$HOME', [System.StringComparison]::Ordinal)) { $i += 5 }
+            else { return [pscustomobject]@{ Success = $false; Value = '' } }
+            if (-not (Add-Utf8Text $bytes $HomeDir)) { return [pscustomobject]@{ Success = $false; Value = '' } }
+            continue
+        }
+
+        if ($ch -eq '`' -or $ch -eq ';' -or $ch -eq '|' -or $ch -eq '&' -or $ch -eq '<' -or $ch -eq '>' -or $ch -eq '(' -or $ch -eq ')') {
+            return [pscustomobject]@{ Success = $false; Value = '' }
+        }
+
+        $ri = [ref]$i
+        $piece = Read-WordChar $Text $ri
+        if ($null -eq $piece) { return [pscustomobject]@{ Success = $false; Value = '' } }
+        $i = $ri.Value
+        if (-not (Add-Utf8Text $bytes $piece)) { return [pscustomobject]@{ Success = $false; Value = '' } }
     }
+
+    if (-not $started) { return [pscustomobject]@{ Success = $false; Value = '' } }
+    while ($i -lt $Text.Length -and ($Text[$i] -eq ' ' -or $Text[$i] -eq "`t")) { $i++ }
+    if ($i -lt $Text.Length -and $Text[$i] -ne '#') { return [pscustomobject]@{ Success = $false; Value = '' } }
+
+    try { $value = $StrictUtf8.GetString($bytes.ToArray()) } catch { return [pscustomobject]@{ Success = $false; Value = '' } }
+    if ($PathContext -and $value.StartsWith('~', [System.StringComparison]::Ordinal)) {
+        if ($value -eq '~') { $value = $HomeDir }
+        elseif ($value.StartsWith('~/', [System.StringComparison]::Ordinal) -or $value.StartsWith('~\', [System.StringComparison]::Ordinal)) {
+            $value = $HomeDir.TrimEnd('\', '/') + $value.Substring(1)
+        } else { return [pscustomobject]@{ Success = $false; Value = '' } }
+    }
+    return [pscustomobject]@{ Success = $true; Value = $value }
 }
 
-$ConfigPath = $env:CORALLINE_CONFIG
-if ([string]::IsNullOrEmpty($ConfigPath)) { $ConfigPath = Join-Path $HOME '.claude\coralline.conf' }
-Import-CorallineConfLines -Path $ConfigPath -Target $Cfg
+function ConvertTo-LocalFullPath([string]$Path, [string]$BaseDir) {
+    if ([string]::IsNullOrEmpty($Path)) { return $null }
+    if ($Path -match '[\u0000-\u001f\u007f-\u009f]') { return $null }
+    if ($Path.StartsWith('\\', [System.StringComparison]::Ordinal) -or $Path.StartsWith('//', [System.StringComparison]::Ordinal)) { return $null }
+    if ($Path.StartsWith('\\?\', [System.StringComparison]::Ordinal) -or $Path.StartsWith('\\.\', [System.StringComparison]::Ordinal) -or $Path -match '^\\\x3f\x3f\\') { return $null }
 
-# Unsupported style/layout values fall back to this port's supported pair
-# rather than erroring, so an existing bash config (lean/classic, auto) still
-# renders ??just without that style/layout's extra behavior yet.
+    $p = $Path
+    if ($p -match '^/([A-Za-z])(?:/|$)') {
+        $drive = $Matches[1].ToUpperInvariant()
+        $p = $drive + ':\' + $p.Substring(2).TrimStart('/')
+    }
+    $p = $p.Replace('/', '\')
+
+    $colon = $p.IndexOf(':')
+    if ($colon -ge 0) {
+        if ($colon -ne 1 -or $p.Length -lt 3 -or -not [char]::IsLetter($p[0]) -or $p[2] -ne '\' -or $p.IndexOf(':', 2) -ge 0) { return $null }
+    } elseif ($p.StartsWith('\', [System.StringComparison]::Ordinal)) { return $null }
+
+    try {
+        if (-not [System.IO.Path]::IsPathRooted($p)) { $p = [System.IO.Path]::Combine($BaseDir, $p) }
+        $full = [System.IO.Path]::GetFullPath($p)
+    } catch { return $null }
+    if ($full.StartsWith('\\', [System.StringComparison]::Ordinal)) { return $null }
+    return $full
+}
+
+function Test-PathInside([string]$Path, [string]$Root) {
+    if ([string]::IsNullOrEmpty($Path) -or [string]::IsNullOrEmpty($Root)) { return $false }
+    $trimmed = $Root.TrimEnd('\')
+    if ($trimmed.Length -eq 2 -and $trimmed[1] -eq ':') { $trimmed += '\' }
+    if ($Path.Equals($trimmed, [System.StringComparison]::OrdinalIgnoreCase)) { return $true }
+    $prefix = $trimmed
+    if (-not $prefix.EndsWith('\', [System.StringComparison]::Ordinal)) { $prefix += '\' }
+    return $Path.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Test-NoReparseComponents([string]$Path) {
+    try { $root = [System.IO.Path]::GetPathRoot($Path) } catch { return $false }
+    if ([string]::IsNullOrEmpty($root)) { return $false }
+    $relative = $Path.Substring($root.Length)
+    $current = $root
+    foreach ($part in $relative.Split(@('\'), [System.StringSplitOptions]::RemoveEmptyEntries)) {
+        $current = [System.IO.Path]::Combine($current, $part)
+        try { $attrs = [System.IO.File]::GetAttributes($current) }
+        catch [System.IO.FileNotFoundException] { return $true }
+        catch [System.IO.DirectoryNotFoundException] { return $true }
+        catch { return $false }
+        if (($attrs -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) { return $false }
+    }
+    return $true
+}
+
+function Test-SafeRegularFile([string]$Path) {
+    if (-not (Test-NoReparseComponents $Path)) { return $false }
+    try { $attrs = [System.IO.File]::GetAttributes($Path) } catch { return $false }
+    if (($attrs -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) { return $false }
+    if (($attrs -band [System.IO.FileAttributes]::Directory) -ne 0) { return $false }
+    return $true
+}
+
+function Read-StrictUtf8File([string]$Path) {
+    try {
+        $attrs = [System.IO.File]::GetAttributes($Path)
+        if (($attrs -band [System.IO.FileAttributes]::ReparsePoint) -ne 0 -or ($attrs -band [System.IO.FileAttributes]::Directory) -ne 0) { return $null }
+        $info = New-Object System.IO.FileInfo($Path)
+        if ($info.Length -gt 1048576) { return $null }
+        $bytes = [System.IO.File]::ReadAllBytes($Path)
+        $text = $StrictUtf8.GetString($bytes)
+        if ($text.Length -gt 0 -and [int]$text[0] -eq 0xFEFF) { $text = $text.Substring(1) }
+        return $text
+    } catch { return $null }
+}
+
+function Import-ConfigFile(
+    [string]$Path,
+    [System.Collections.IDictionary]$BaseConfig,
+    [hashtable]$State,
+    [int]$Depth,
+    [string[]]$ApprovedRoots
+) {
+    $failed = [pscustomobject]@{ Success = $false; Config = $BaseConfig }
+    if ($Depth -gt 8) { return $failed }
+    if ($State.Visited.Contains($Path)) { return $failed }
+    [void]$State.Visited.Add($Path)
+    if (-not (Test-SafeRegularFile $Path)) { return $failed }
+    $text = Read-StrictUtf8File $Path
+    if ($null -eq $text) { return $failed }
+
+    $candidate = Copy-Config $BaseConfig
+    $stack = New-Object System.Collections.ArrayList
+    $active = $true
+    $valid = $true
+    $lines = [regex]::Split($text, "`r`n|`n|`r")
+
+    foreach ($line in $lines) {
+        $t = $line.Trim()
+        if ($t.Length -eq 0 -or $t.StartsWith('#', [System.StringComparison]::Ordinal)) { continue }
+        $statement = $line.TrimStart(' ', "`t")
+
+        if ($t -match '^if[ \t]+\[[ \t]+"\$\{REMORA_ACTIVE:-0\}"[ \t]+(=|!=)[ \t]+"([^"\r\n]*)"[ \t]+\];[ \t]+then$') {
+            $op = $Matches[1]
+            $literal = $Matches[2]
+            $envValue = [string]$env:REMORA_ACTIVE
+            if ([string]::IsNullOrEmpty($envValue)) { $envValue = '0' }
+            $condition = $envValue -ceq $literal
+            if ($op -eq '!=') { $condition = -not $condition }
+            $frame = [pscustomobject]@{ ParentActive = $active; Condition = $condition; ElseSeen = $false }
+            [void]$stack.Add($frame)
+            $active = $active -and $condition
+            continue
+        }
+        if ($t -match '^if(?:[ \t]|$)') { $valid = $false; break }
+        if ($t -eq 'else') {
+            if ($stack.Count -eq 0) { $valid = $false; break }
+            $frame = $stack[$stack.Count - 1]
+            if ($frame.ElseSeen) { $valid = $false; break }
+            $frame.ElseSeen = $true
+            $active = $frame.ParentActive -and (-not $frame.Condition)
+            continue
+        }
+        if ($t -eq 'fi') {
+            if ($stack.Count -eq 0) { $valid = $false; break }
+            $frame = $stack[$stack.Count - 1]
+            $active = $frame.ParentActive
+            $stack.RemoveAt($stack.Count - 1)
+            continue
+        }
+        if (-not $active) { continue }
+
+        if ($statement -eq '.' -or $statement -match '^\.[ \t]+') {
+            if ([int]$State.IncludeCount -ge 16) { continue }
+            $State.IncludeCount = [int]$State.IncludeCount + 1
+            $wordText = ''
+            if ($statement.Length -gt 1) { $wordText = $statement.Substring(1).TrimStart(' ', "`t") }
+            $decoded = Decode-ShellWord $wordText $true
+            if (-not $decoded.Success) { continue }
+            $includePath = ConvertTo-LocalFullPath $decoded.Value ([System.IO.Path]::GetDirectoryName($Path))
+            if ([string]::IsNullOrEmpty($includePath)) { continue }
+            if (-not [System.IO.Path]::GetExtension($includePath).Equals('.conf', [System.StringComparison]::OrdinalIgnoreCase)) { continue }
+            $inside = $false
+            foreach ($root in $ApprovedRoots) {
+                if (Test-PathInside $includePath $root) { $inside = $true; break }
+            }
+            if (-not $inside) { continue }
+            $child = Import-ConfigFile $includePath $candidate $State ($Depth + 1) $ApprovedRoots
+            if ($child.Success) { $candidate = $child.Config }
+            continue
+        }
+
+        if ($statement -match '^([A-Za-z_][A-Za-z0-9_]*)=(.*)$') {
+            $name = $Matches[1]
+            $raw = $Matches[2]
+            $pathContext = $PathConfigKeys.Contains($name)
+            $decoded = Decode-ShellWord $raw $pathContext
+            if (-not $decoded.Success) { $valid = $false; break }
+            if ($pathContext -and $decoded.Value -match '[ -\u007f-\u009f]') { $valid = $false; break }
+            $candidate[$name] = $decoded.Value
+            continue
+        }
+
+        $valid = $false
+        break
+    }
+
+    if ($stack.Count -ne 0) { $valid = $false }
+    if (-not $valid) { return $failed }
+    return [pscustomobject]@{ Success = $true; Config = $candidate }
+}
+
+$Cfg = Copy-Config $Defaults
+$ConfigInput = [string]$env:CORALLINE_CONFIG
+if ([string]::IsNullOrEmpty($ConfigInput)) { $ConfigInput = [System.IO.Path]::Combine($HomeDir, '.claude\coralline.conf') }
+$ConfigPath = ConvertTo-LocalFullPath $ConfigInput ([Environment]::CurrentDirectory)
+if (-not [string]::IsNullOrEmpty($ConfigPath)) {
+    $ConfigRoot = [System.IO.Path]::GetDirectoryName($ConfigPath)
+    $ThemesRoot = ConvertTo-LocalFullPath ([System.IO.Path]::Combine($ScriptDir, 'themes')) $ScriptDir
+    $approved = @($ConfigRoot)
+    if (-not [string]::IsNullOrEmpty($ThemesRoot)) { $approved += $ThemesRoot }
+    $visited = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+    $state = @{ IncludeCount = 0; Visited = $visited }
+    $parsed = Import-ConfigFile $ConfigPath $Cfg $state 0 $approved
+    if ($parsed.Success) { $Cfg = $parsed.Config }
+}
+
+# Config never supplies terminal controls. The renderer is the sole ANSI source.
+foreach ($key in @($Cfg.Keys)) { $Cfg[$key] = Remove-ControlChars ([string]$Cfg[$key]) }
+
+$Invariant = [System.Globalization.CultureInfo]::InvariantCulture
+$IntegerStyle = [System.Globalization.NumberStyles]::Integer
+$FloatStyle = [System.Globalization.NumberStyles]::Float
+
+function Get-BoundedInt([string]$Raw, [int]$Fallback, [int]$Min, [int]$Max) {
+    $value = 0
+    if (-not [int]::TryParse($Raw, $IntegerStyle, $Invariant, [ref]$value)) { return $Fallback }
+    if ($value -lt $Min -or $value -gt $Max) { return $Fallback }
+    return $value
+}
+
+function Try-BoundedDouble([string]$Raw, [double]$Min, [double]$Max, [ref]$Result) {
+    $value = 0.0
+    if ([string]::IsNullOrEmpty($Raw)) { return $false }
+    if (-not [double]::TryParse($Raw, $FloatStyle, $Invariant, [ref]$value)) { return $false }
+    if ([double]::IsNaN($value) -or [double]::IsInfinity($value) -or $value -lt $Min -or $value -gt $Max) { return $false }
+    $Result.Value = $value
+    return $true
+}
+
+function Test-Color([string]$Spec) {
+    if ([string]::IsNullOrEmpty($Spec)) { return $true }
+    if ($Spec -match '^([0-9]{1,3})$') {
+        $n = 0
+        return [int]::TryParse($Matches[1], $IntegerStyle, $Invariant, [ref]$n) -and $n -ge 0 -and $n -le 255
+    }
+    if ($Spec -match '^([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3})$') {
+        foreach ($part in @($Matches[1], $Matches[2], $Matches[3])) {
+            $n = 0
+            if (-not [int]::TryParse($part, $IntegerStyle, $Invariant, [ref]$n) -or $n -lt 0 -or $n -gt 255) { return $false }
+        }
+        return $true
+    }
+    return $false
+}
+
+$Cfg.VL_BAR_WIDTH = [string](Get-BoundedInt $Cfg.VL_BAR_WIDTH ([int]$Defaults.VL_BAR_WIDTH) 0 64)
+$Cfg.VL_PATH_DEPTH = [string](Get-BoundedInt $Cfg.VL_PATH_DEPTH ([int]$Defaults.VL_PATH_DEPTH) 1 256)
+$Cfg.VL_NAME_MAX = [string](Get-BoundedInt $Cfg.VL_NAME_MAX ([int]$Defaults.VL_NAME_MAX) 0 4096)
+$Cfg.VL_COST_DECIMALS = [string](Get-BoundedInt $Cfg.VL_COST_DECIMALS ([int]$Defaults.VL_COST_DECIMALS) 0 9)
+$Cfg.VL_WARN_PCT = [string](Get-BoundedInt $Cfg.VL_WARN_PCT ([int]$Defaults.VL_WARN_PCT) 0 100)
+$Cfg.VL_HOT_PCT = [string](Get-BoundedInt $Cfg.VL_HOT_PCT ([int]$Defaults.VL_HOT_PCT) 0 100)
+if ([int]$Cfg.VL_HOT_PCT -lt [int]$Cfg.VL_WARN_PCT) {
+    $Cfg.VL_WARN_PCT = $Defaults.VL_WARN_PCT
+    $Cfg.VL_HOT_PCT = $Defaults.VL_HOT_PCT
+}
+foreach ($key in @($Cfg.Keys | Where-Object { $_ -like 'VL_BG_*' -or $_ -like 'VL_FG_*' })) {
+    if (-not (Test-Color $Cfg[$key])) { $Cfg[$key] = $Defaults[$key] }
+}
+
+# Later slices add the other styles/layout. Existing configs degrade predictably.
 if ($Cfg.VL_STYLE -ne 'pill') { $Cfg.VL_STYLE = 'pill' }
 if ($Cfg.VL_LAYOUT -ne 'fixed') { $Cfg.VL_LAYOUT = 'fixed' }
 
-$AsciiMode = ($Cfg.VL_ASCII -eq '1')
-if ($AsciiMode) {
-    $G.CapL = ''; $G.CapR = ''; $G.Sep = ''
-    $G.BarFill = '#'; $G.BarEmpty = '-'
-    $G.Node = 'node'; $G.Python = 'py'
+if ($Cfg.VL_ASCII -eq '1') {
+    $Cfg.VL_CAP_L = ''
+    $Cfg.VL_CAP_R = ''
+    $Cfg.VL_SEP = ''
+    $Cfg.VL_BAR_FILL = '#'
+    $Cfg.VL_BAR_EMPTY = '-'
+    $Cfg.VL_NODE_GLYPH = 'node'
+    $Cfg.VL_PY_GLYPH = 'py'
 }
 
-$NoColor = ($Cfg.VL_NOCOLOR -eq '1')
+$NoColor = $Cfg.VL_NOCOLOR -eq '1'
+$Esc = [char]27
+$Rst = "$Esc[0m"
+$Bold = "$Esc[1m"
+$Norm = "$Esc[22m"
+$G = @{
+    Branch = Glyph 0x2387
+    Diamond = Glyph 0x25C6
+    Flag = Glyph 0x2691
+    Dot = Glyph 0x2299
+    Pencil = Glyph 0x270E
+    Hourglass = Glyph 0x29D6
+    Psi = Glyph 0x03C8
+    Ahead = Glyph 0x21E1
+    Behind = Glyph 0x21E3
+    Ellipsis = Glyph 0x2026
+    Up = Glyph 0x2191
+    Down = Glyph 0x2193
+    Reset = Glyph 0x21BA
+}
 
-# ---- ANSI primitives --------------------------------------------------------
 function Get-Fg([string]$Spec) {
     if ($NoColor -or [string]::IsNullOrEmpty($Spec)) { return '' }
     if ($Spec.Contains(',')) {
@@ -213,6 +639,7 @@ function Get-Fg([string]$Spec) {
     }
     return "$Esc[38;5;${Spec}m"
 }
+
 function Get-Bg([string]$Spec) {
     if ($NoColor -or [string]::IsNullOrEmpty($Spec)) { return '' }
     if ($Spec.Contains(',')) {
@@ -222,58 +649,69 @@ function Get-Bg([string]$Spec) {
     return "$Esc[48;5;${Spec}m"
 }
 
-# ---- formatting helpers (mirrors statusline.sh's make_bar/fmt_tok/etc.) ----
-function New-Bar([double]$Pct, [int]$Width) {
+function New-Bar([int]$Pct, [int]$Width) {
     if ($Pct -lt 0) { $Pct = 0 }
-    $filled = [math]::Floor(($Pct * $Width + 50) / 100)
+    if ($Pct -gt 100) { $Pct = 100 }
+    $filled = [int][math]::Floor(($Pct * $Width + 50) / 100)
     if ($filled -lt 0) { $filled = 0 }
     if ($filled -gt $Width) { $filled = $Width }
-    $empty = $Width - $filled
     $sb = New-Object System.Text.StringBuilder
-    for ($i = 0; $i -lt $filled; $i++) { [void]$sb.Append($G.BarFill) }
-    for ($i = 0; $i -lt $empty; $i++) { [void]$sb.Append($G.BarEmpty) }
+    for ($i = 0; $i -lt $filled; $i++) { [void]$sb.Append($Cfg.VL_BAR_FILL) }
+    for ($i = $filled; $i -lt $Width; $i++) { [void]$sb.Append($Cfg.VL_BAR_EMPTY) }
     return $sb.ToString()
 }
 
 function Format-Tok([string]$Raw) {
+    if ([string]::IsNullOrEmpty($Raw)) { return '0' }
+    if ($Raw -notmatch '^[0-9]+$') { return $Raw }
     $n = 0L
-    if (-not [long]::TryParse($Raw, [ref]$n)) { return $Raw }
-    if ($n -ge 1000000) { return ('{0}.{1}M' -f [math]::Floor($n / 1000000), ([math]::Floor(($n % 1000000) / 100000))) }
-    if ($n -ge 1000) { return ('{0}.{1}k' -f [math]::Floor($n / 1000), ([math]::Floor(($n % 1000) / 100))) }
-    return "$n"
+    if (-not [long]::TryParse($Raw, $IntegerStyle, $Invariant, [ref]$n)) { return '0' }
+    if ($n -ge 1000000) { return ('{0}.{1}M' -f [math]::Floor($n / 1000000), [math]::Floor(($n % 1000000) / 100000)) }
+    if ($n -ge 1000) { return ('{0}.{1}k' -f [math]::Floor($n / 1000), [math]::Floor(($n % 1000) / 100)) }
+    return [string]$n
 }
 
-function Get-PctFg([double]$Pct) {
-    if ($Pct -ge [double]$Cfg.VL_HOT_PCT) { return $Cfg.VL_FG_HOT }
-    if ($Pct -ge [double]$Cfg.VL_WARN_PCT) { return $Cfg.VL_FG_WARN }
+function Get-PctValue([string]$Raw, [ref]$Result) {
+    if ([string]::IsNullOrEmpty($Raw)) { return $false }
+    $value = 0.0
+    if (-not (Try-BoundedDouble $Raw -1000000 1000000 ([ref]$value))) { $value = 0 }
+    if ($value -lt 0) { $value = 0 }
+    if ($value -gt 100) { $value = 100 }
+    $Result.Value = [int][math]::Round($value, [System.MidpointRounding]::ToEven)
+    return $true
+}
+
+function Get-PctFg([int]$Pct) {
+    if ($Pct -ge [int]$Cfg.VL_HOT_PCT) { return $Cfg.VL_FG_HOT }
+    if ($Pct -ge [int]$Cfg.VL_WARN_PCT) { return $Cfg.VL_FG_WARN }
     return $Cfg.VL_FG_OK
 }
 
 function Get-Trunc([string]$S, [int]$Max) {
+    if ($null -eq $S) { return '' }
     if ($Max -le 0 -or $S.Length -le $Max) { return $S }
     if ($Max -lt 3) { return $S.Substring(0, $Max) }
-    $head = [math]::Floor(($Max - 1) / 2)
+    $head = [int][math]::Floor(($Max - 1) / 2)
     $tail = $Max - 1 - $head
     return $S.Substring(0, $head) + $G.Ellipsis + $S.Substring($S.Length - $tail)
 }
 
-# Accepts epoch seconds (int/float string) or an ISO 8601 timestamp -> epoch
-# seconds, or $null when unparseable. .NET's DateTimeOffset parser replaces
-# statusline.sh's hand-rolled iso_epoch/to_epoch civil-calendar math.
 function ConvertTo-Epoch([string]$Raw) {
     if ([string]::IsNullOrEmpty($Raw)) { return $null }
-    if ($Raw -match '^[0-9]+(\.[0-9]+)?$') { return [long][double]$Raw }
-    try {
-        $styles = [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal
-        $dto = [DateTimeOffset]::Parse($Raw, [System.Globalization.CultureInfo]::InvariantCulture, $styles)
-        return $dto.ToUnixTimeSeconds()
-    } catch { return $null }
+    $numeric = 0.0
+    if (Try-BoundedDouble $Raw 0 253402300799 ([ref]$numeric)) { return [long][math]::Floor($numeric) }
+    $dto = [DateTimeOffset]::MinValue
+    $styles = [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal
+    if ([DateTimeOffset]::TryParse($Raw, $Invariant, $styles, [ref]$dto)) { return $dto.ToUnixTimeSeconds() }
+    return $null
 }
+
+$Now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
 
 function Format-Countdown([string]$ResetsAt) {
     $ep = ConvertTo-Epoch $ResetsAt
     if ($null -eq $ep) { return '' }
-    $diff = $ep - $Now
+    $diff = [long]$ep - $Now
     if ($diff -le 0) { return 'now' }
     $d = [math]::Floor($diff / 86400)
     $h = [math]::Floor(($diff % 86400) / 3600)
@@ -284,7 +722,7 @@ function Format-Countdown([string]$ResetsAt) {
 }
 
 function Format-Duration([double]$Ms, [bool]$IncludeSeconds) {
-    $s = [math]::Floor($Ms / 1000)
+    $s = [long][math]::Floor($Ms / 1000)
     $h = [math]::Floor($s / 3600)
     $m = [math]::Floor(($s % 3600) / 60)
     $sec = $s % 60
@@ -300,154 +738,313 @@ function Format-Duration([double]$Ms, [bool]$IncludeSeconds) {
 
 function Get-ClockText {
     $now = Get-Date
-    $inv = [System.Globalization.CultureInfo]::InvariantCulture
     if ($Cfg.VL_CLOCK -eq '24h') {
-        if ($Cfg.VL_CLOCK_SECONDS -eq '1') { return $now.ToString('HH:mm:ss', $inv) }
-        return $now.ToString('HH:mm', $inv)
+        if ($Cfg.VL_CLOCK_SECONDS -eq '1') { return $now.ToString('HH:mm:ss', $Invariant) }
+        return $now.ToString('HH:mm', $Invariant)
     }
-    $fmt = if ($Cfg.VL_CLOCK_SECONDS -eq '1') { 'hh:mm:ss tt' } else { 'hh:mm tt' }
-    $t = $now.ToString($fmt, $inv)
-    if ($t.EndsWith('AM')) { return ($t.Substring(0, $t.Length - 2) + 'am') }
-    if ($t.EndsWith('PM')) { return ($t.Substring(0, $t.Length - 2) + 'pm') }
-    return $t
+    $format = 'hh:mm tt'
+    if ($Cfg.VL_CLOCK_SECONDS -eq '1') { $format = 'hh:mm:ss tt' }
+    $text = $now.ToString($format, $Invariant)
+    if ($text.EndsWith('AM', [System.StringComparison]::Ordinal)) { return $text.Substring(0, $text.Length - 2) + 'am' }
+    if ($text.EndsWith('PM', [System.StringComparison]::Ordinal)) { return $text.Substring(0, $text.Length - 2) + 'pm' }
+    return $text
 }
 
-# ---- git state (single `git status` call, parsed once; mirrors read_git) --
+function Get-JsonMember($Object, [string]$Name) {
+    if ($null -eq $Object) { return $null }
+    try {
+        $property = $Object.PSObject.Properties[$Name]
+        if ($null -eq $property) { return $null }
+        return $property.Value
+    } catch { return $null }
+}
+
+function Get-JsonPath($Object, [string[]]$Names) {
+    $value = $Object
+    foreach ($name in $Names) {
+        $value = Get-JsonMember $value $name
+        if ($null -eq $value) { return $null }
+    }
+    return $value
+}
+
+function To-InvariantString($Value) {
+    if ($null -eq $Value) { return '' }
+    if ($Value -is [string]) { return [string]$Value }
+    if ($Value -is [bool]) {
+        if ($Value) { return 'true' }
+        return 'false'
+    }
+    if ($Value -is [System.IFormattable] -and -not ($Value -is [System.Array])) {
+        return $Value.ToString($null, $Invariant)
+    }
+    return ''
+}
+
+try { $J = $rawInput | ConvertFrom-Json -ErrorAction Stop } catch { $J = $null }
+
+$cwd = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('workspace', 'current_dir')))
+if ([string]::IsNullOrEmpty($cwd)) { $cwd = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('cwd'))) }
+$model = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('model', 'display_name')))
+$ctxPct = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('context_window', 'used_percentage')))
+$tokIn = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('context_window', 'total_input_tokens')))
+$tokOut = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('context_window', 'total_output_tokens')))
+$tokCr = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('context_window', 'current_usage', 'cache_read_input_tokens')))
+$tokCw = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('context_window', 'current_usage', 'cache_creation_input_tokens')))
+$fhPct = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('rate_limits', 'five_hour', 'used_percentage')))
+$fhRst = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('rate_limits', 'five_hour', 'resets_at')))
+$wdPct = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('rate_limits', 'seven_day', 'used_percentage')))
+$wdRst = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('rate_limits', 'seven_day', 'resets_at')))
+$cost = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('cost', 'total_cost_usd')))
+$linesAdd = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('cost', 'total_lines_added')))
+$linesDel = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('cost', 'total_lines_removed')))
+$outStyle = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('output_style', 'name')))
+$durMs = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('cost', 'total_duration_ms')))
+$effort = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('effort', 'level')))
+
+function ConvertTo-ProbePath([string]$Path) {
+    if ([string]::IsNullOrEmpty($Path)) { return '' }
+    $full = ConvertTo-LocalFullPath $Path ([Environment]::CurrentDirectory)
+    if ($null -eq $full) { return '' }
+    return $full
+}
+
+$ProbeCwd = ConvertTo-ProbePath $cwd
+
+function Get-DisplayPath([string]$Path) {
+    if ([string]::IsNullOrEmpty($Path)) { return '' }
+    $short = $Path.Replace('\', '/')
+    $homeFwd = $HomeDir.Replace('\', '/').TrimEnd('/')
+    if (-not [string]::IsNullOrEmpty($homeFwd)) {
+        if ($short.Equals($homeFwd, [System.StringComparison]::OrdinalIgnoreCase)) { $short = '~' }
+        elseif ($short.StartsWith($homeFwd + '/', [System.StringComparison]::OrdinalIgnoreCase)) { $short = '~' + $short.Substring($homeFwd.Length) }
+    }
+    if ($short -eq '/') { return '/' }
+    if ($short -match '^[A-Za-z]:/?$') { return $short.Substring(0, 2) + '/' }
+
+    $parts = New-Object System.Collections.Generic.List[string]
+    $prefix = ''
+    if ($short.StartsWith('//', [System.StringComparison]::Ordinal)) {
+        $raw = $short.Substring(2).Split(@('/'), [System.StringSplitOptions]::RemoveEmptyEntries)
+        if ($raw.Length -eq 0) { return '//' }
+        if ($raw.Length -eq 1) { return '//' + $raw[0] }
+        $prefix = '//' + $raw[0] + '/' + $raw[1]
+        for ($i = 2; $i -lt $raw.Length; $i++) { [void]$parts.Add($raw[$i]) }
+        $logicalCount = 2 + $parts.Count
+    } elseif ($short -match '^([A-Za-z]:)(?:/(.*))?$') {
+        $prefix = $Matches[1]
+        $rest = $Matches[2]
+        if (-not [string]::IsNullOrEmpty($rest)) {
+            foreach ($part in $rest.Split(@('/'), [System.StringSplitOptions]::RemoveEmptyEntries)) { [void]$parts.Add($part) }
+        }
+        $logicalCount = 1 + $parts.Count
+    } elseif ($short.StartsWith('/', [System.StringComparison]::Ordinal)) {
+        $prefix = '/'
+        foreach ($part in $short.Substring(1).Split(@('/'), [System.StringSplitOptions]::RemoveEmptyEntries)) { [void]$parts.Add($part) }
+        $logicalCount = 1 + $parts.Count
+    } elseif ($short -eq '~' -or $short.StartsWith('~/', [System.StringComparison]::Ordinal)) {
+        $prefix = '~'
+        if ($short.Length -gt 2) {
+            foreach ($part in $short.Substring(2).Split(@('/'), [System.StringSplitOptions]::RemoveEmptyEntries)) { [void]$parts.Add($part) }
+        }
+        $logicalCount = 1 + $parts.Count
+    } else {
+        foreach ($part in $short.Split(@('/'), [System.StringSplitOptions]::RemoveEmptyEntries)) { [void]$parts.Add($part) }
+        $logicalCount = $parts.Count
+    }
+
+    if ($logicalCount -le [int]$Cfg.VL_PATH_DEPTH) { return $short.TrimEnd('/') }
+    $last = ''
+    if ($parts.Count -gt 0) { $last = $parts[$parts.Count - 1] }
+    if ($prefix.StartsWith('//', [System.StringComparison]::Ordinal)) { return $prefix + '/' + $G.Ellipsis + '/' + $last }
+    if ($prefix -eq '/') {
+        $first = ''
+        if ($parts.Count -gt 0) { $first = $parts[0] }
+        return '/' + $first + '/' + $G.Ellipsis + '/' + $last
+    }
+    if ($prefix -eq '~' -or $prefix -match '^[A-Za-z]:$') {
+        $first = ''
+        if ($parts.Count -gt 0) { $first = $parts[0] }
+        return $prefix + '/' + $first + '/' + $G.Ellipsis + '/' + $last
+    }
+    if ($parts.Count -ge 2) { return $parts[0] + '/' + $parts[1] + '/' + $G.Ellipsis + '/' + $last }
+    return $short
+}
+
+$AppCache = @{}
+function Get-ApplicationPath([string]$Name) {
+    if ($AppCache.ContainsKey($Name)) { return [string]$AppCache[$Name] }
+    $path = ''
+    try {
+        $cmd = Get-Command -Name $Name -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($null -ne $cmd) { $path = [string]$cmd.Source }
+    } catch { $path = '' }
+    $AppCache[$Name] = $path
+    return $path
+}
+
 $env:GIT_OPTIONAL_LOCKS = '0'
 
 function Get-GitState([string]$Cwd) {
     $state = @{ Branch = ''; Marks = ''; Ab = ''; Dirty = $false }
     if ([string]::IsNullOrEmpty($Cwd)) { return $state }
-    $lines = & git -C $Cwd status --porcelain=v2 --branch 2>$null
-    if ($LASTEXITCODE -ne 0 -or -not $lines) { return $state }
-    $oid = ''; $head = ''; $a = 0; $b = 0
-    $staged = $false; $unstaged = $false; $untracked = $false
-    foreach ($line in $lines) {
-        if ($line.StartsWith('# branch.oid ')) { $oid = $line.Substring(13) }
-        elseif ($line.StartsWith('# branch.head ')) { $head = $line.Substring(14) }
-        elseif ($line.StartsWith('# branch.ab ')) {
-            if ($line -match '\+(\d+)\s+-(\d+)') { $a = [int]$matches[1]; $b = [int]$matches[2] }
-        }
-        elseif ($line.StartsWith('? ')) { $untracked = $true }
+    $git = Get-ApplicationPath 'git'
+    if ([string]::IsNullOrEmpty($git)) { return $state }
+    try {
+        $LASTEXITCODE = 0
+        $lines = @(& $git -C $Cwd status --porcelain=v2 --branch 2>$null)
+        if ($LASTEXITCODE -ne 0 -or $lines.Count -eq 0) { return $state }
+    } catch { return $state }
+    $oid = ''
+    $head = ''
+    $ahead = 0
+    $behind = 0
+    $staged = $false
+    $unstaged = $false
+    $untracked = $false
+    foreach ($item in $lines) {
+        $line = [string]$item
+        if ($line.StartsWith('# branch.oid ', [System.StringComparison]::Ordinal)) { $oid = $line.Substring(13) }
+        elseif ($line.StartsWith('# branch.head ', [System.StringComparison]::Ordinal)) { $head = $line.Substring(14) }
+        elseif ($line.StartsWith('# branch.ab ', [System.StringComparison]::Ordinal)) {
+            if ($line -match '\+([0-9]+)[ \t]+-([0-9]+)') {
+                [void][int]::TryParse($Matches[1], $IntegerStyle, $Invariant, [ref]$ahead)
+                [void][int]::TryParse($Matches[2], $IntegerStyle, $Invariant, [ref]$behind)
+            }
+        } elseif ($line.StartsWith('? ', [System.StringComparison]::Ordinal)) { $untracked = $true }
         elseif ($line -match '^[12] ') {
-            $rest = $line.Substring(2)
-            if ($rest.Length -ge 1 -and $rest[0] -ne '.') { $staged = $true }
-            if ($rest.Length -ge 2 -and $rest[1] -ne '.') { $unstaged = $true }
-        }
-        elseif ($line.StartsWith('u ')) { $unstaged = $true }
+            $xy = $line.Substring(2)
+            if ($xy.Length -ge 1 -and $xy[0] -ne '.') { $staged = $true }
+            if ($xy.Length -ge 2 -and $xy[1] -ne '.') { $unstaged = $true }
+        } elseif ($line.StartsWith('u ', [System.StringComparison]::Ordinal)) { $unstaged = $true }
     }
     if ([string]::IsNullOrEmpty($oid)) { return $state }
-    if ($head -eq '(detached)' -or [string]::IsNullOrEmpty($head)) {
-        $state.Branch = $oid.Substring(0, [Math]::Min(7, $oid.Length))
-    } else {
-        $state.Branch = $head
-    }
+    if ($head -eq '(detached)' -or [string]::IsNullOrEmpty($head)) { $state.Branch = $oid.Substring(0, [Math]::Min(7, $oid.Length)) }
+    else { $state.Branch = Remove-ControlChars $head }
     if ($staged) { $state.Marks += '+' }
     if ($unstaged) { $state.Marks += '!' }
     if ($untracked) { $state.Marks += '?' }
-    if ($a -gt 0) { $state.Ab += "$($G.Ahead)$a" }
-    if ($b -gt 0) { $state.Ab += "$($G.Behind)$b" }
-    if ($state.Marks) { $state.Dirty = $true }
+    if ($ahead -gt 0) { $state.Ab += $G.Ahead + [string]$ahead }
+    if ($behind -gt 0) { $state.Ab += $G.Behind + [string]$behind }
+    if (-not [string]::IsNullOrEmpty($state.Marks)) { $state.Dirty = $true }
     return $state
 }
 
 function Get-GitRoot([string]$Cwd) {
     if ([string]::IsNullOrEmpty($Cwd)) { return '' }
-    $root = & git -C $Cwd rev-parse --path-format=absolute --git-common-dir 2>$null
-    if ($LASTEXITCODE -ne 0 -or -not $root) {
-        $root = & git -C $Cwd rev-parse --show-toplevel 2>$null
-        if ($LASTEXITCODE -ne 0 -or -not $root) { return '' }
-    }
-    $root = ($root -replace '\\', '/').TrimEnd('/')
-    if ($root.EndsWith('/.git')) { $root = $root.Substring(0, $root.Length - 5) }
-    $parts = $root.Split('/', [StringSplitOptions]::RemoveEmptyEntries)
+    $git = Get-ApplicationPath 'git'
+    if ([string]::IsNullOrEmpty($git)) { return '' }
+    $root = ''
+    try {
+        $LASTEXITCODE = 0
+        $result = @(& $git -C $Cwd rev-parse --path-format=absolute --git-common-dir 2>$null)
+        if ($LASTEXITCODE -eq 0 -and $result.Count -gt 0) { $root = [string]$result[0] }
+        if ([string]::IsNullOrEmpty($root)) {
+            $LASTEXITCODE = 0
+            $result = @(& $git -C $Cwd rev-parse --show-toplevel 2>$null)
+            if ($LASTEXITCODE -ne 0 -or $result.Count -eq 0) { return '' }
+            $root = [string]$result[0]
+        }
+    } catch { return '' }
+    $root = (Remove-ControlChars $root).Replace('\', '/').TrimEnd('/')
+    if ($root.EndsWith('/.git', [System.StringComparison]::OrdinalIgnoreCase)) { $root = $root.Substring(0, $root.Length - 5) }
+    $parts = $root.Split(@('/'), [System.StringSplitOptions]::RemoveEmptyEntries)
     if ($parts.Length -eq 0) { return '' }
     return $parts[$parts.Length - 1]
 }
 
 function Get-StashCount([string]$Cwd) {
-    $n = & git -C $Cwd rev-list --walk-reflogs --count refs/stash 2>$null
-    if ($LASTEXITCODE -ne 0 -or -not $n) { return 0 }
-    $count = 0
-    if ([int]::TryParse(($n | Select-Object -First 1), [ref]$count)) { return $count }
-    return 0
+    if ([string]::IsNullOrEmpty($Cwd)) { return 0 }
+    $git = Get-ApplicationPath 'git'
+    if ([string]::IsNullOrEmpty($git)) { return 0 }
+    try {
+        $LASTEXITCODE = 0
+        $result = @(& $git -C $Cwd rev-list --walk-reflogs --count refs/stash 2>$null)
+        if ($LASTEXITCODE -ne 0 -or $result.Count -eq 0) { return 0 }
+        return Get-BoundedInt ([string]$result[0]) 0 0 1000000
+    } catch { return 0 }
 }
 
-# ---- node/python runtime detection (pin-file walk; mirrors runtime_node /
-# runtime_python) -------------------------------------------------------------
+function Read-PinFile([string]$Path) {
+    try {
+        $attrs = [System.IO.File]::GetAttributes($Path)
+        if (($attrs -band [System.IO.FileAttributes]::Directory) -ne 0) { return '' }
+        $info = New-Object System.IO.FileInfo($Path)
+        if ($info.Length -gt 65536) { return '' }
+        $reader = New-Object System.IO.StreamReader($Path, $StrictUtf8, $true)
+        try { $line = $reader.ReadLine() } finally { $reader.Dispose() }
+        return (Remove-ControlChars ([string]$line)).Trim()
+    } catch { return '' }
+}
+
 function Get-NodeVersion([string]$Dir) {
-    $d = $Dir
-    while ($d -and (Test-Path -LiteralPath $d -PathType Container)) {
-        foreach ($f in '.nvmrc', '.node-version') {
-            $p = Join-Path $d $f
-            if (Test-Path -LiteralPath $p -PathType Leaf) {
-                $v = (Get-Content -LiteralPath $p -TotalCount 1 -ErrorAction SilentlyContinue)
-                if ($v) { $v = $v.Trim(); if ($v) { return $v.TrimStart('v') } }
-            }
+    if ([string]::IsNullOrEmpty($Dir)) { return '' }
+    try { $d = New-Object System.IO.DirectoryInfo($Dir) } catch { $d = $null }
+    while ($null -ne $d) {
+        foreach ($name in @('.nvmrc', '.node-version')) {
+            $value = Read-PinFile ([System.IO.Path]::Combine($d.FullName, $name))
+            if (-not [string]::IsNullOrEmpty($value)) { return $value.TrimStart('v') }
         }
-        $parent = Split-Path -Path $d -Parent
-        if (-not $parent -or $parent -eq $d) { break }
-        $d = $parent
+        $d = $d.Parent
     }
     if ($Cfg.VL_RUNTIME_PROBE -eq '1') {
-        $v = (& node --version 2>$null | Select-Object -First 1)
-        if ($v) { return $v.TrimStart('v') }
+        $node = Get-ApplicationPath 'node'
+        if (-not [string]::IsNullOrEmpty($node)) {
+            try {
+                $LASTEXITCODE = 0
+                $result = @(& $node --version 2>$null)
+                if ($LASTEXITCODE -eq 0 -and $result.Count -gt 0) { return (Remove-ControlChars ([string]$result[0])).Trim().TrimStart('v') }
+            } catch { }
+        }
     }
     return ''
 }
 
 function Get-PythonVersion([string]$Dir) {
-    if ($env:VIRTUAL_ENV) { return (Split-Path -Leaf $env:VIRTUAL_ENV) }
-    if ($env:CONDA_DEFAULT_ENV -and $env:CONDA_DEFAULT_ENV -ne 'base') { return $env:CONDA_DEFAULT_ENV }
-    $d = $Dir
-    while ($d -and (Test-Path -LiteralPath $d -PathType Container)) {
-        $p = Join-Path $d '.python-version'
-        if (Test-Path -LiteralPath $p -PathType Leaf) {
-            $v = (Get-Content -LiteralPath $p -TotalCount 1 -ErrorAction SilentlyContinue)
-            if ($v) { $v = $v.Trim(); if ($v) { return $v } }
+    $venv = Remove-ControlChars ([string]$env:VIRTUAL_ENV)
+    if (-not [string]::IsNullOrEmpty($venv)) {
+        try { return [System.IO.Path]::GetFileName($venv.TrimEnd('\', '/')) } catch { }
+    }
+    $conda = Remove-ControlChars ([string]$env:CONDA_DEFAULT_ENV)
+    if (-not [string]::IsNullOrEmpty($conda) -and $conda -ne 'base') { return $conda }
+    if (-not [string]::IsNullOrEmpty($Dir)) {
+        try { $d = New-Object System.IO.DirectoryInfo($Dir) } catch { $d = $null }
+        while ($null -ne $d) {
+            $value = Read-PinFile ([System.IO.Path]::Combine($d.FullName, '.python-version'))
+            if (-not [string]::IsNullOrEmpty($value)) { return $value }
+            $d = $d.Parent
         }
-        $parent = Split-Path -Path $d -Parent
-        if (-not $parent -or $parent -eq $d) { break }
-        $d = $parent
     }
     if ($Cfg.VL_RUNTIME_PROBE -eq '1') {
-        $v = (& python3 --version 2>&1 | Select-Object -First 1)
-        if ($v) { return ($v -replace '^Python ', '').Trim() }
+        $python = Get-ApplicationPath 'python3'
+        if (-not [string]::IsNullOrEmpty($python)) {
+            try {
+                $LASTEXITCODE = 0
+                $result = @(& $python --version 2>&1)
+                if ($LASTEXITCODE -eq 0 -and $result.Count -gt 0) { return ((Remove-ControlChars ([string]$result[0])) -replace '^Python ', '').Trim() }
+            } catch { }
+        }
     }
     return ''
 }
 
-# ---- JSON input -------------------------------------------------------------
-try { $J = $rawInput | ConvertFrom-Json } catch { $J = $null }
+function Get-SegmentTokens([string]$List) {
+    if ([string]::IsNullOrWhiteSpace($List)) { return @() }
+    return @([regex]::Split($List.Trim(), '\s+') | Where-Object { -not [string]::IsNullOrEmpty($_) })
+}
 
-function Str($Value) { if ($null -eq $Value) { '' } else { [string]$Value } }
+$AllSegmentNames = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
+foreach ($list in @($Cfg.VL_SEGMENTS, $Cfg.VL_SEGMENTS2, $Cfg.VL_SEGMENTS3)) {
+    foreach ($name in (Get-SegmentTokens $list)) { [void]$AllSegmentNames.Add($name) }
+}
 
-$cwd = Str $J.workspace.current_dir
-if (-not $cwd) { $cwd = Str $J.cwd }
-$model     = Str $J.model.display_name
-$ctxPct    = Str $J.context_window.used_percentage
-$tokIn     = Str $J.context_window.total_input_tokens
-$tokOut    = Str $J.context_window.total_output_tokens
-$tokCr     = Str $J.context_window.current_usage.cache_read_input_tokens
-$tokCw     = Str $J.context_window.current_usage.cache_creation_input_tokens
-$fhPct     = Str $J.rate_limits.five_hour.used_percentage
-$fhRst     = Str $J.rate_limits.five_hour.resets_at
-$wdPct     = Str $J.rate_limits.seven_day.used_percentage
-$wdRst     = Str $J.rate_limits.seven_day.resets_at
-$cost      = Str $J.cost.total_cost_usd
-$linesAdd  = Str $J.cost.total_lines_added
-$linesDel  = Str $J.cost.total_lines_removed
-$outStyle  = Str $J.output_style.name
-$durMs     = Str $J.cost.total_duration_ms
-$effort    = Str $J.effort.level
-
-$segScan = " $($Cfg.VL_SEGMENTS) $($Cfg.VL_SEGMENTS2) $($Cfg.VL_SEGMENTS3) "
 $GitState = @{ Branch = ''; Marks = ''; Ab = ''; Dirty = $false }
 $GitRoot = ''
-if ($segScan -match ' (git|stash|project) ') { $GitState = Get-GitState $cwd }
-if ($segScan -match ' project ') { $GitRoot = Get-GitRoot $cwd }
+if ($AllSegmentNames.Contains('git') -or $AllSegmentNames.Contains('stash') -or $AllSegmentNames.Contains('project')) {
+    $GitState = Get-GitState $ProbeCwd
+}
+if ($AllSegmentNames.Contains('project') -and -not [string]::IsNullOrEmpty($GitState.Branch)) { $GitRoot = Get-GitRoot $ProbeCwd }
 
-# ---- segments (each Add-*Segment mirrors one seg_* function) --------------
 $SegBgs = New-Object System.Collections.Generic.List[string]
 $SegTxt = New-Object System.Collections.Generic.List[string]
 function Push-Segment([string]$Bg, [string]$Text) {
@@ -456,61 +1053,53 @@ function Push-Segment([string]$Bg, [string]$Text) {
 }
 
 function Add-DirSegment {
-    if (-not $cwd) { return }
-    $short = $cwd -replace '\\', '/'
-    if ($HOME) {
-        $homeFwd = $HOME -replace '\\', '/'
-        if ($short.StartsWith($homeFwd)) { $short = '~' + $short.Substring($homeFwd.Length) }
-    }
-    $parts = $short.Split('/', [StringSplitOptions]::RemoveEmptyEntries)
-    $depth = [int]$Cfg.VL_PATH_DEPTH
-    if ($parts.Length -gt $depth -and $parts.Length -ge 1) {
-        $last = $parts[$parts.Length - 1]
-        $p1 = if ($parts.Length -ge 1) { $parts[0] } else { '' }
-        $p2 = if ($parts.Length -ge 2) { $parts[1] } else { '' }
-        $short = "$p1/$p2/$($G.Ellipsis)/$last"
-    }
+    if ([string]::IsNullOrEmpty($cwd)) { return }
+    $short = Get-DisplayPath $cwd
+    if ([string]::IsNullOrEmpty($short)) { return }
     $fg = Get-Fg $Cfg.VL_FG_TEXT
     Push-Segment $Cfg.VL_BG_DIR "${Bold}${fg} $short ${Norm}"
 }
 
 function Add-ProjectSegment {
-    if (-not $GitRoot) {
-        if ($segScan -notmatch ' dir ') { Add-DirSegment }
+    if ([string]::IsNullOrEmpty($GitRoot)) {
+        if (-not $AllSegmentNames.Contains('dir')) { Add-DirSegment }
         return
     }
     $tr = Get-Trunc $GitRoot ([int]$Cfg.VL_NAME_MAX)
     $fg = Get-Fg $Cfg.VL_FG_TEXT
-    $bg = if ($Cfg.VL_BG_PROJECT) { $Cfg.VL_BG_PROJECT } else { $Cfg.VL_BG_DIR }
-    Push-Segment $bg "${Bold}${fg} $($G.Project) $tr ${Norm}"
+    $bg = $Cfg.VL_BG_PROJECT
+    if ([string]::IsNullOrEmpty($bg)) { $bg = $Cfg.VL_BG_DIR }
+    Push-Segment $bg "${Bold}${fg} $($Cfg.VL_PROJECT_GLYPH) $tr ${Norm}"
 }
 
 function Add-GitSegment {
-    if (-not $GitState.Branch) { return }
-    $bgc = if ($GitState.Dirty) { $Cfg.VL_BG_GIT_DIRTY } else { $Cfg.VL_BG_GIT_OK }
+    if ([string]::IsNullOrEmpty($GitState.Branch)) { return }
+    $bg = $Cfg.VL_BG_GIT_OK
+    if ($GitState.Dirty) { $bg = $Cfg.VL_BG_GIT_DIRTY }
     $fg = Get-Fg $Cfg.VL_FG_TEXT
     $tr = Get-Trunc $GitState.Branch ([int]$Cfg.VL_NAME_MAX)
-    Push-Segment $bgc "${Bold}${fg} $($G.Branch) ${tr}$($GitState.Marks)$($GitState.Ab) ${Norm}"
+    Push-Segment $bg "${Bold}${fg} $($G.Branch) ${tr}$($GitState.Marks)$($GitState.Ab) ${Norm}"
 }
 
 function Add-StashSegment {
-    if (-not $GitState.Branch) { return }
-    $n = Get-StashCount $cwd
-    if ($n -le 0) { return }
+    if ([string]::IsNullOrEmpty($GitState.Branch)) { return }
+    $count = Get-StashCount $ProbeCwd
+    if ($count -le 0) { return }
     $fg = Get-Fg $Cfg.VL_FG_TEXT
-    $bg = if ($Cfg.VL_BG_STASH) { $Cfg.VL_BG_STASH } else { $Cfg.VL_BG_GIT_OK }
-    Push-Segment $bg "${fg} $($G.Flag) $n "
+    $bg = $Cfg.VL_BG_STASH
+    if ([string]::IsNullOrEmpty($bg)) { $bg = $Cfg.VL_BG_GIT_OK }
+    Push-Segment $bg "${fg} $($G.Flag) $count "
 }
 
 function Add-ModelSegment {
-    if (-not $model) { return }
-    $fg = Get-Fg $Cfg.VL_FG_TEXT
+    if ([string]::IsNullOrEmpty($model)) { return }
     $shown = $model -replace '^Claude ', ''
+    $fg = Get-Fg $Cfg.VL_FG_TEXT
     Push-Segment $Cfg.VL_BG_MODEL "${Bold}${fg} $($G.Diamond) $shown ${Norm}"
 }
 
 function Add-EffortSegment {
-    if (-not $effort) { return }
+    if ([string]::IsNullOrEmpty($effort)) { return }
     $label = $effort
     if ($effort -eq 'medium') { $label = 'med' }
     $fg = Get-Fg $Cfg.VL_FG_TEXT
@@ -518,128 +1107,142 @@ function Add-EffortSegment {
 }
 
 function Add-CtxSegment {
-    if (-not $ctxPct) { return }
-    $ci = [math]::Round([double]$ctxPct)
-    $bar = New-Bar $ci ([int]$Cfg.VL_BAR_WIDTH)
-    $pfg = Get-Fg (Get-PctFg $ci)
+    $pct = 0
+    if (-not (Get-PctValue $ctxPct ([ref]$pct))) { return }
+    $bar = New-Bar $pct ([int]$Cfg.VL_BAR_WIDTH)
+    $pfg = Get-Fg (Get-PctFg $pct)
     $dfg = Get-Fg $Cfg.VL_FG_DIM
     $ti = Format-Tok $tokIn
     $to = Format-Tok $tokOut
     $tcr = Format-Tok $tokCr
     $tcw = Format-Tok $tokCw
-    Push-Segment $Cfg.VL_BG_CTX "${pfg} $($G.Hex) ${bar} ${ci}% ${dfg}$($G.Up)${ti} $($G.Down)${to} cr:${tcr} cw:${tcw} "
+    Push-Segment $Cfg.VL_BG_CTX "${pfg} $($Cfg.VL_CTX_GLYPH) ${bar} ${pct}% ${dfg}$($G.Up)${ti} $($G.Down)${to} cr:${tcr} cw:${tcw} "
 }
 
-function Add-LimitSegment([string]$Label, [string]$Pct, [string]$ResetsAt, [string]$Bg) {
-    if (-not $Pct) { return }
-    $v = [math]::Round([double]$Pct)
-    $bar = New-Bar $v ([int]$Cfg.VL_BAR_WIDTH)
-    $pfg = Get-Fg (Get-PctFg $v)
-    $cd = Format-Countdown $ResetsAt
-    $rst = ''
-    if ($cd) { $dfg = Get-Fg $Cfg.VL_FG_DIM; $rst = "${dfg}$($G.Reset)${cd}" }
-    Push-Segment $Bg "${pfg} $Label ${bar} ${v}% ${rst} "
+function Add-LimitSegment([string]$Label, [string]$RawPct, [string]$ResetsAt, [string]$Bg) {
+    $pct = 0
+    if (-not (Get-PctValue $RawPct ([ref]$pct))) { return }
+    $bar = New-Bar $pct ([int]$Cfg.VL_BAR_WIDTH)
+    $pfg = Get-Fg (Get-PctFg $pct)
+    $countdown = Format-Countdown $ResetsAt
+    $reset = ''
+    if (-not [string]::IsNullOrEmpty($countdown)) {
+        $dfg = Get-Fg $Cfg.VL_FG_DIM
+        $reset = "${dfg}$($G.Reset)${countdown}"
+    }
+    Push-Segment $Bg "${pfg} $Label ${bar} ${pct}% ${reset} "
 }
 
-function Add-Cost {
-    if (-not $cost -or $cost -eq '0') { return }
-    $decimals = [int]$Cfg.VL_COST_DECIMALS
-    $fmt = ''
-    try { $fmt = [string]::Format([System.Globalization.CultureInfo]::InvariantCulture, "`$" + '{0:F' + $decimals + '}', [double]$cost) } catch { $fmt = "`$$cost" }
+function Add-CostSegment {
+    $value = 0.0
+    if (-not (Try-BoundedDouble $cost 0 1000000000 ([ref]$value)) -or $value -eq 0) { return }
+    $format = '$' + $value.ToString('F' + $Cfg.VL_COST_DECIMALS, $Invariant)
     $fg = Get-Fg $Cfg.VL_FG_TEXT
-    Push-Segment $Cfg.VL_BG_COST "${fg} $fmt "
+    Push-Segment $Cfg.VL_BG_COST "${fg} $format "
 }
 
-function Add-Clock {
+function Add-ClockSegment {
     if ($Cfg.VL_CLOCK -eq 'off') { return }
     $fg = Get-Fg $Cfg.VL_FG_TEXT
     Push-Segment $Cfg.VL_BG_CLOCK "${fg} $($G.Dot) $(Get-ClockText) "
 }
 
-function Add-Lines {
-    $add = 0; $del = 0
-    [int]::TryParse($linesAdd, [ref]$add) | Out-Null
-    [int]::TryParse($linesDel, [ref]$del) | Out-Null
-    if ($add -le 0 -and $del -le 0) { return }
-    $fgo = Get-Fg $Cfg.VL_FG_OK
-    $fgh = Get-Fg $Cfg.VL_FG_HOT
-    Push-Segment $Cfg.VL_BG_LINES " ${fgo}+${add} ${fgh}-${del} "
+function Get-NonNegativeLong([string]$Raw) {
+    $value = 0L
+    if (-not [long]::TryParse($Raw, $IntegerStyle, $Invariant, [ref]$value) -or $value -lt 0 -or $value -gt 1000000000000000) { return 0L }
+    return $value
 }
 
-function Add-Style {
-    if (-not $outStyle -or $outStyle -eq 'default') { return }
+function Add-LinesSegment {
+    $add = Get-NonNegativeLong $linesAdd
+    $del = Get-NonNegativeLong $linesDel
+    if ($add -le 0 -and $del -le 0) { return }
+    $ok = Get-Fg $Cfg.VL_FG_OK
+    $hot = Get-Fg $Cfg.VL_FG_HOT
+    Push-Segment $Cfg.VL_BG_LINES " ${ok}+${add} ${hot}-${del} "
+}
+
+function Add-StyleSegment {
+    if ([string]::IsNullOrEmpty($outStyle) -or $outStyle -eq 'default') { return }
     $fg = Get-Fg $Cfg.VL_FG_TEXT
     Push-Segment $Cfg.VL_BG_STYLE "${fg} $($G.Pencil) $outStyle "
 }
 
-function Add-Duration {
-    $ms = 0.0
-    if (-not [double]::TryParse($durMs, [ref]$ms) -or $ms -le 0) { return }
+function Add-DurationSegment {
+    $value = 0.0
+    if (-not (Try-BoundedDouble $durMs 0 1000000000000000 ([ref]$value)) -or $value -le 0) { return }
     $fg = Get-Fg $Cfg.VL_FG_TEXT
-    Push-Segment $Cfg.VL_BG_DURATION "${fg} $($G.Hourglass) $(Format-Duration $ms $true) "
+    Push-Segment $Cfg.VL_BG_DURATION "${fg} $($G.Hourglass) $(Format-Duration $value $false) "
 }
 
-function Add-Node {
-    if (-not $cwd) { return }
-    $v = Get-NodeVersion $cwd
-    if (-not $v) { return }
+function Add-NodeSegment {
+    $version = Get-NodeVersion $ProbeCwd
+    if ([string]::IsNullOrEmpty($version)) { return }
     $fg = Get-Fg $Cfg.VL_FG_TEXT
-    $bg = if ($Cfg.VL_BG_NODE) { $Cfg.VL_BG_NODE } else { $Cfg.VL_BG_MODEL }
-    Push-Segment $bg "${fg} $($G.Node) $v "
+    $bg = $Cfg.VL_BG_NODE
+    if ([string]::IsNullOrEmpty($bg)) { $bg = $Cfg.VL_BG_MODEL }
+    Push-Segment $bg "${fg} $($Cfg.VL_NODE_GLYPH) $version "
 }
 
-function Add-Python {
-    if (-not $cwd) { return }
-    $v = Get-PythonVersion $cwd
-    if (-not $v) { return }
+function Add-PythonSegment {
+    if ([string]::IsNullOrEmpty($ProbeCwd)) { return }
+    $version = Get-PythonVersion $ProbeCwd
+    if ([string]::IsNullOrEmpty($version)) { return }
     $fg = Get-Fg $Cfg.VL_FG_TEXT
-    $bg = if ($Cfg.VL_BG_PYTHON) { $Cfg.VL_BG_PYTHON } else { $Cfg.VL_BG_MODEL }
-    Push-Segment $bg "${fg} $($G.Python) $v "
+    $bg = $Cfg.VL_BG_PYTHON
+    if ([string]::IsNullOrEmpty($bg)) { $bg = $Cfg.VL_BG_MODEL }
+    Push-Segment $bg "${fg} $($Cfg.VL_PY_GLYPH) $version "
 }
 
-$SegmentBuilders = @{
-    dir      = { Add-DirSegment }
-    project  = { Add-ProjectSegment }
-    git      = { Add-GitSegment }
-    stash    = { Add-StashSegment }
-    model    = { Add-ModelSegment }
-    effort   = { Add-EffortSegment }
-    ctx      = { Add-CtxSegment }
-    limit5h  = { Add-LimitSegment '5h' $fhPct $fhRst $Cfg.VL_BG_5H }
-    limit7d  = { Add-LimitSegment '7d' $wdPct $wdRst $Cfg.VL_BG_7D }
-    cost     = { Add-Cost }
-    clock    = { Add-Clock }
-    lines    = { Add-Lines }
-    style    = { Add-Style }
-    duration = { Add-Duration }
-    node     = { Add-Node }
-    python   = { Add-Python }
-    # burn (cross-session rate sampling) and the subagent panel row segments
-    # are not ported in this slice; see handoff/coralline-8-scope.md.
+$SegmentBuilders = [ordered]@{
+    clock = { Add-ClockSegment }
+    cost = { Add-CostSegment }
+    ctx = { Add-CtxSegment }
+    dir = { Add-DirSegment }
+    duration = { Add-DurationSegment }
+    effort = { Add-EffortSegment }
+    git = { Add-GitSegment }
+    limit5h = { Add-LimitSegment '5h' $fhPct $fhRst $Cfg.VL_BG_5H }
+    limit7d = { Add-LimitSegment '7d' $wdPct $wdRst $Cfg.VL_BG_7D }
+    lines = { Add-LinesSegment }
+    model = { Add-ModelSegment }
+    node = { Add-NodeSegment }
+    project = { Add-ProjectSegment }
+    python = { Add-PythonSegment }
+    stash = { Add-StashSegment }
+    style = { Add-StyleSegment }
 }
 
 function Build-Segments([string]$List) {
-    $SegBgs.Clear(); $SegTxt.Clear()
-    foreach ($name in ($List -split '\s+' | Where-Object { $_ })) {
-        if ($SegmentBuilders.ContainsKey($name)) { & $SegmentBuilders[$name] }
+    $SegBgs.Clear()
+    $SegTxt.Clear()
+    foreach ($name in (Get-SegmentTokens $List)) {
+        if ($SegmentBuilders.Contains($name)) { & $SegmentBuilders[$name] }
     }
 }
 
 function Render-Row {
     if ($SegBgs.Count -eq 0) { return '' }
-    $out = $Rst + (Get-Fg $SegBgs[0]) + $G.CapL
+    $out = $Rst + (Get-Fg $SegBgs[0]) + $Cfg.VL_CAP_L
     for ($i = 0; $i -lt $SegBgs.Count; $i++) {
         $out += (Get-Bg $SegBgs[$i]) + $SegTxt[$i]
         if ($i -lt ($SegBgs.Count - 1)) {
-            $out += (Get-Bg $SegBgs[$i + 1]) + (Get-Fg $SegBgs[$i]) + $G.Sep
+            $out += (Get-Bg $SegBgs[$i + 1]) + (Get-Fg $SegBgs[$i]) + $Cfg.VL_SEP
         }
     }
-    $out += $Rst + (Get-Fg $SegBgs[$SegBgs.Count - 1]) + $G.CapR + $Rst
+    $out += $Rst + (Get-Fg $SegBgs[$SegBgs.Count - 1]) + $Cfg.VL_CAP_R + $Rst
     return $out
 }
 
-foreach ($list in @($Cfg.VL_SEGMENTS, $Cfg.VL_SEGMENTS2, $Cfg.VL_SEGMENTS3)) {
-    if ([string]::IsNullOrWhiteSpace($list)) { continue }
-    Build-Segments $list
-    if ($SegBgs.Count -gt 0) { Write-Output (Render-Row) }
+try {
+    foreach ($list in @($Cfg.VL_SEGMENTS, $Cfg.VL_SEGMENTS2, $Cfg.VL_SEGMENTS3)) {
+        if ([string]::IsNullOrWhiteSpace($list)) { continue }
+        Build-Segments $list
+        if ($SegBgs.Count -gt 0) { $OutputWriter.WriteLine((Render-Row)) }
+    }
+} finally {
+    $OutputWriter.Flush()
+    $OutputWriter.Dispose()
 }
+
+exit 0

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -236,7 +236,10 @@ function Decode-ShellWord([string]$Text, [bool]$PathContext) {
                 if ($ch -eq '$') {
                     if (-not $PathContext) { return [pscustomobject]@{ Success = $false; Value = '' } }
                     if ($Text.Substring($i).StartsWith('${HOME}', [System.StringComparison]::Ordinal)) { $i += 7 }
-                    elseif ($Text.Substring($i).StartsWith('$HOME', [System.StringComparison]::Ordinal)) { $i += 5 }
+                    elseif (
+                        $Text.Substring($i).StartsWith('$HOME', [System.StringComparison]::Ordinal) -and
+                        ($i + 5 -ge $Text.Length -or [string]$Text[$i + 5] -notmatch '[A-Za-z0-9_]')
+                    ) { $i += 5 }
                     else { return [pscustomobject]@{ Success = $false; Value = '' } }
                     if (-not (Add-Utf8Text $bytes $HomeDir)) { return [pscustomobject]@{ Success = $false; Value = '' } }
                     continue

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -4,8 +4,9 @@
 
   This slice implements the fixed pill main bar without Bash, jq, WSL, or
   PowerShell 7. Config is read from the same coralline.conf through a narrow,
-  non-executing Bash-word parser. Burn state, alternate styles/layouts, float
-  output, and subagent rows are implemented by later slices.
+  non-executing Bash-word parser. Burn and synced limit state share the same
+  immutable store as Bash; alternate styles/layouts, float output, and subagent
+  rows are implemented by later slices.
 #>
 
 # Claude Code registers this exact literal. It must leave before stdin, config,
@@ -398,15 +399,16 @@ function Test-PathInside([string]$Path, [string]$Root) {
 function Test-NoReparseComponents([string]$Path) {
     try { $root = [System.IO.Path]::GetPathRoot($Path) } catch { return $false }
     if ([string]::IsNullOrEmpty($root)) { return $false }
-    $relative = $Path.Substring($root.Length)
+    $parts = $Path.Substring($root.Length).Split(@('\'), [System.StringSplitOptions]::RemoveEmptyEntries)
     $current = $root
-    foreach ($part in $relative.Split(@('\'), [System.StringSplitOptions]::RemoveEmptyEntries)) {
-        $current = [System.IO.Path]::Combine($current, $part)
+    for ($i=0; $i -lt $parts.Length; $i++) {
+        $current = [System.IO.Path]::Combine($current, $parts[$i])
         try { $attrs = [System.IO.File]::GetAttributes($current) }
         catch [System.IO.FileNotFoundException] { return $true }
         catch [System.IO.DirectoryNotFoundException] { return $true }
         catch { return $false }
         if (($attrs -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) { return $false }
+        if ($i -lt ($parts.Length - 1) -and ($attrs -band [System.IO.FileAttributes]::Directory) -eq 0) { return $false }
     }
     return $true
 }
@@ -629,6 +631,8 @@ $G = @{
     Up = Glyph 0x2191
     Down = Glyph 0x2193
     Reset = Glyph 0x21BA
+    Check = Glyph 0x2713
+    BurnTo = Glyph 0x21E2
 }
 
 function Get-Fg([string]$Spec) {
@@ -707,6 +711,547 @@ function ConvertTo-Epoch([string]$Raw) {
 }
 
 $Now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+
+# Immutable burn and limit state. Percentages are integer milli-percent and all
+# midpoint decisions use exact Int64 quotient/remainder arithmetic.
+function ConvertTo-StatePct([string]$Raw) {
+    if ([string]::IsNullOrEmpty($Raw)) { return $null }
+    $match = [regex]::Match($Raw, '\A(0|[1-9][0-9]?|100)(?:\.([0-9]{1,6}))?\z', [Text.RegularExpressions.RegexOptions]::CultureInvariant)
+    if (-not $match.Success) { return $null }
+    $whole = 0
+    if (-not [int]::TryParse($match.Groups[1].Value, $IntegerStyle, $Invariant, [ref]$whole)) { return $null }
+    $fraction = $match.Groups[2].Value
+    if ($whole -eq 100 -and $fraction -match '[1-9]') { return $null }
+    $six = ($fraction + '000000').Substring(0, 6)
+    $keep = 0
+    $rest = 0
+    if (-not [int]::TryParse($six.Substring(0, 3), $IntegerStyle, $Invariant, [ref]$keep)) { return $null }
+    if (-not [int]::TryParse($six.Substring(3, 3), $IntegerStyle, $Invariant, [ref]$rest)) { return $null }
+    $milli = $whole * 1000 + $keep
+    if ($rest -gt 500 -or ($rest -eq 500 -and ($milli % 2) -eq 1)) { $milli++ }
+    if ($milli -lt 0 -or $milli -gt 100000) { return $null }
+    $q = 0L
+    $r = 0L
+    $q = [Math]::DivRem([long]$milli, 1000L, [ref]$r)
+    return [pscustomobject]@{
+        Milli = [int]$milli
+        Canonical = [string]::Format($Invariant, '{0:000}.{1:000}', $q, $r)
+    }
+}
+
+function ConvertTo-StateEpoch([string]$Raw, [int]$Width) {
+    if ([string]::IsNullOrEmpty($Raw) -or $Raw -notmatch '\A(?:0|[1-9][0-9]{0,11})\z') { return $null }
+    $value = 0L
+    if (-not [long]::TryParse($Raw, $IntegerStyle, $Invariant, [ref]$value)) { return $null }
+    if ($value -lt 0 -or $value -gt 253402300799L) { return $null }
+    if ($Width -eq 10 -and $value -gt 9999999999L) { return $null }
+    $format = 'D' + [string]$Width
+    return [pscustomobject]@{ Value = $value; Padded = $value.ToString($format, $Invariant) }
+}
+
+function ConvertTo-StatePayloadEpoch([string]$Raw, [int]$Width) {
+    if ([string]::IsNullOrEmpty($Raw)) { return $null }
+    if ($Raw.IndexOf('T') -ge 0) {
+        $value = ConvertTo-Epoch $Raw
+        if ($null -eq $value) { return $null }
+        return ConvertTo-StateEpoch ([string]$value) $Width
+    }
+    return ConvertTo-StateEpoch $Raw $Width
+}
+
+function Get-RoundEvenInt64([long]$Numerator, [long]$Denominator) {
+    if ($Numerator -lt 0 -or $Denominator -le 0) { return 0L }
+    $remainder = 0L
+    $quotient = [Math]::DivRem($Numerator, $Denominator, [ref]$remainder)
+    $twice = $remainder * 2L
+    if ($twice -gt $Denominator -or ($twice -eq $Denominator -and ($quotient % 2L) -eq 1L)) { $quotient++ }
+    return $quotient
+}
+
+function Format-StateRate([long]$ScaledNumerator, [long]$Denominator) {
+    if ($ScaledNumerator -lt 0 -or $Denominator -le 0) { return '0.0000000000' }
+    $scaled = Get-RoundEvenInt64 $ScaledNumerator $Denominator
+    $fraction = 0L
+    $whole = [Math]::DivRem($scaled, 10000000000L, [ref]$fraction)
+    return [string]::Format($Invariant, '{0}.{1:0000000000}', $whole, $fraction)
+}
+
+function Format-StatePct([int]$Milli) {
+    $fraction = 0L
+    $whole = [Math]::DivRem([long]$Milli, 1000L, [ref]$fraction)
+    return [string]::Format($Invariant, '{0:000}.{1:000}', $whole, $fraction)
+}
+
+function Get-StatePaths([string]$Base) {
+    $full = ConvertTo-LocalFullPath $Base ([Environment]::CurrentDirectory)
+    if ([string]::IsNullOrEmpty($full)) { return $null }
+    $root = $full
+    if ($root.EndsWith('.tsv', [StringComparison]::Ordinal)) { $root = $root.Substring(0, $root.Length - 4) }
+    $root += '.d'
+    return [pscustomobject]@{ Base = $full; Root = $root }
+}
+
+function Test-StateRoot([string]$Root) {
+    if ([string]::IsNullOrEmpty($Root) -or -not (Test-NoReparseComponents $Root)) { return $false }
+    try {
+        $attrs = [IO.File]::GetAttributes($Root)
+        if (($attrs -band [IO.FileAttributes]::ReparsePoint) -ne 0) { return $false }
+        return ($attrs -band [IO.FileAttributes]::Directory) -ne 0
+    } catch [IO.FileNotFoundException] { return $true }
+    catch [IO.DirectoryNotFoundException] { return $true }
+    catch { return $false }
+}
+
+function Test-StateRegularFile([string]$Path) {
+    if ([string]::IsNullOrEmpty($Path) -or -not (Test-NoReparseComponents $Path)) { return $false }
+    try {
+        $attrs = [IO.File]::GetAttributes($Path)
+        return (($attrs -band [IO.FileAttributes]::ReparsePoint) -eq 0 -and ($attrs -band [IO.FileAttributes]::Directory) -eq 0)
+    } catch { return $false }
+}
+
+function Get-EmptyStateDirectoryStatus([string]$Path) {
+    if ([string]::IsNullOrEmpty($Path) -or -not (Test-NoReparseComponents $Path)) { return [pscustomobject]@{ Success=$false; Empty=$false } }
+    $enumerator = $null
+    try {
+        $attrs = [IO.File]::GetAttributes($Path)
+        if (($attrs -band [IO.FileAttributes]::ReparsePoint) -ne 0 -or ($attrs -band [IO.FileAttributes]::Directory) -eq 0) { return [pscustomobject]@{ Success=$true; Empty=$false } }
+        $enumerator = [IO.Directory]::EnumerateFileSystemEntries($Path).GetEnumerator()
+        return [pscustomobject]@{ Success=$true; Empty=(-not $enumerator.MoveNext()) }
+    } catch { return [pscustomobject]@{ Success=$false; Empty=$false } }
+    finally { if ($null -ne $enumerator) { $enumerator.Dispose() } }
+}
+
+function Test-EmptyStateDirectory([string]$Path) {
+    $status = Get-EmptyStateDirectoryStatus $Path
+    return $status.Success -and $status.Empty
+}
+
+function Test-StateObjectExists([string]$Path) {
+    try { [void][IO.File]::GetAttributes($Path); return $true }
+    catch [IO.FileNotFoundException] { return $false }
+    catch [IO.DirectoryNotFoundException] { return $false }
+    catch { return $true }
+}
+
+function ConvertFrom-CanonicalStatePct([string]$Raw) {
+    if ($Raw -notmatch '\A(?:0[0-9]{2}|100)\.[0-9]{3}\z') { return $null }
+    $whole = 0
+    $fraction = 0
+    if (-not [int]::TryParse($Raw.Substring(0, 3), $IntegerStyle, $Invariant, [ref]$whole)) { return $null }
+    if (-not [int]::TryParse($Raw.Substring(4, 3), $IntegerStyle, $Invariant, [ref]$fraction)) { return $null }
+    $milli = $whole * 1000 + $fraction
+    if ($milli -gt 100000) { return $null }
+    return $milli
+}
+
+function ConvertFrom-BurnName([string]$Name, [long]$NowValue) {
+    $match = [regex]::Match($Name, '\Ab_([0-9]{12})_([0-9]{12})_((?:0[0-9]{2}|100)\.[0-9]{3})_([0-9]{4})\z', [Text.RegularExpressions.RegexOptions]::CultureInvariant)
+    if (-not $match.Success) { return $null }
+    $reset = 0L
+    $sample = 0L
+    if (-not [long]::TryParse($match.Groups[1].Value, $IntegerStyle, $Invariant, [ref]$reset)) { return $null }
+    if (-not [long]::TryParse($match.Groups[2].Value, $IntegerStyle, $Invariant, [ref]$sample)) { return $null }
+    if ($reset -gt 253402300799L -or $sample -gt 253402300799L) { return $null }
+    $pct = ConvertFrom-CanonicalStatePct $match.Groups[3].Value
+    if ($null -eq $pct) { return $null }
+    $plausible = $sample -le ($NowValue + 300L) -and $reset -ge $sample -and $reset -le ($NowValue + 21600L)
+    return [pscustomobject]@{ Name=$Name; Reset=$reset; Sample=$sample; Pct=[int]$pct; Plausible=$plausible }
+}
+
+function ConvertFrom-LimitName([string]$Name, [long]$NowValue, [long]$MaxAhead) {
+    $match = [regex]::Match($Name, '\A([0-9]{10})_((?:0[0-9]{2}|100)\.[0-9]{3})\z', [Text.RegularExpressions.RegexOptions]::CultureInvariant)
+    if (-not $match.Success) { return $null }
+    $reset = 0L
+    if (-not [long]::TryParse($match.Groups[1].Value, $IntegerStyle, $Invariant, [ref]$reset)) { return $null }
+    $pct = ConvertFrom-CanonicalStatePct $match.Groups[2].Value
+    if ($null -eq $pct) { return $null }
+    $plausible = $reset -gt $NowValue -and $reset -le ($NowValue + $MaxAhead)
+    return [pscustomobject]@{ Name=$Name; Reset=$reset; Pct=[int]$pct; Plausible=$plausible }
+}
+
+function Get-StateDirectorySnapshot([string]$Root, [string]$Kind, [int]$Cap, [long]$NowValue, [long]$MaxAhead) {
+    $entries = New-Object 'System.Collections.Generic.List[object]'
+    if (-not (Test-StateRoot $Root)) { return [pscustomobject]@{ Complete=$false; Raw=0; Entries=@() } }
+    if (-not [IO.Directory]::Exists($Root)) { return [pscustomobject]@{ Complete=$true; Raw=0; Entries=@() } }
+    $raw = 0
+    $enumerator = $null
+    try {
+        $enumerator = [IO.Directory]::EnumerateFileSystemEntries($Root).GetEnumerator()
+        while ($enumerator.MoveNext()) {
+            $path = [string]$enumerator.Current
+            $raw++
+            if ($raw -gt $Cap) { return [pscustomobject]@{ Complete=$false; Raw=$raw; Entries=@() } }
+            $full = ConvertTo-LocalFullPath $path $Root
+            if ([string]::IsNullOrEmpty($full) -or -not (Test-PathInside $full $Root)) { continue }
+            if (-not [IO.Path]::GetDirectoryName($full).Equals($Root, [StringComparison]::OrdinalIgnoreCase)) { continue }
+            $name = [IO.Path]::GetFileName($full)
+            try { $attrs = [IO.File]::GetAttributes($full) } catch { return [pscustomobject]@{ Complete=$false; Raw=$raw; Entries=@() } }
+            if (($attrs -band [IO.FileAttributes]::ReparsePoint) -ne 0) { continue }
+            if ($Kind -eq 'burn') {
+                $parsed = ConvertFrom-BurnName $name $NowValue
+                if ($null -eq $parsed -or ($attrs -band [IO.FileAttributes]::Directory) -ne 0) { continue }
+                try { if ((New-Object IO.FileInfo($full)).Length -ne 0) { continue } } catch { return [pscustomobject]@{ Complete=$false; Raw=$raw; Entries=@() } }
+            } else {
+                $parsed = ConvertFrom-LimitName $name $NowValue $MaxAhead
+                if ($null -eq $parsed -or ($attrs -band [IO.FileAttributes]::Directory) -eq 0) { continue }
+                $emptyStatus = Get-EmptyStateDirectoryStatus $full
+                if (-not $emptyStatus.Success) { return [pscustomobject]@{ Complete=$false; Raw=$raw; Entries=@() } }
+                if (-not $emptyStatus.Empty) { continue }
+            }
+            $parsed | Add-Member -NotePropertyName Path -NotePropertyValue $full
+            [void]$entries.Add($parsed)
+        }
+    } catch { return [pscustomobject]@{ Complete=$false; Raw=$raw; Entries=@() } }
+    finally { if ($null -ne $enumerator) { $enumerator.Dispose() } }
+    return [pscustomobject]@{ Complete=$true; Raw=$raw; Entries=$entries.ToArray() }
+}
+
+function ConvertFrom-LegacyRecord([string]$Record, [long]$NowValue) {
+    $fields = $Record.Split(@("`t"), [StringSplitOptions]::None)
+    if ($fields.Length -ne 3) { return $null }
+    $sampleValue = ConvertTo-StateEpoch $fields[0] 12
+    $pct = ConvertTo-StatePct $fields[1]
+    $resetValue = ConvertTo-StateEpoch $fields[2] 12
+    if ($null -eq $sampleValue -or $null -eq $pct -or $null -eq $resetValue) { return $null }
+    $sample = [long]$sampleValue.Value
+    $reset = [long]$resetValue.Value
+    if ($sample -gt ($NowValue + 300L) -or $reset -lt $sample -or $reset -gt ($NowValue + 21600L)) { return $null }
+    return [pscustomobject]@{ Reset=$reset; Sample=$sample; Pct=[int]$pct.Milli }
+}
+
+function Read-LegacyState([string]$Path, [long]$NowValue) {
+    $queue = New-Object 'System.Collections.Generic.Queue[object]'
+    if (-not [IO.File]::Exists($Path)) {
+        if (Test-StateObjectExists $Path) { return [pscustomobject]@{ Complete=$false; Rows=@() } }
+        if (Test-NoReparseComponents $Path) { return [pscustomobject]@{ Complete=$true; Rows=@() } }
+        return [pscustomobject]@{ Complete=$false; Rows=@() }
+    }
+    if (-not (Test-StateRegularFile $Path)) { return [pscustomobject]@{ Complete=$false; Rows=@() } }
+    $stream = $null
+    try {
+        $share = [IO.FileShare]::ReadWrite -bor [IO.FileShare]::Delete
+        $stream = New-Object IO.FileStream($Path, [IO.FileMode]::Open, [IO.FileAccess]::Read, $share, 4096, [IO.FileOptions]::SequentialScan)
+        $length = [long]$stream.Length
+        if ($length -gt 1048576L) { return [pscustomobject]@{ Complete=$false; Rows=@() } }
+        $buffer = New-Object byte[] 4096
+        $builder = New-Object Text.StringBuilder
+        $remaining = $length
+        $physical = 0
+        $recordLength = 0
+        $rowAscii = $true
+        while ($remaining -gt 0) {
+            $want = [int][Math]::Min([long]$buffer.Length, $remaining)
+            $read = $stream.Read($buffer, 0, $want)
+            if ($read -le 0) { return [pscustomobject]@{ Complete=$false; Rows=@() } }
+            $remaining -= $read
+            for ($i=0; $i -lt $read; $i++) {
+                $byte = [int]$buffer[$i]
+                if ($byte -eq 10) {
+                    $physical++
+                    if ($physical -gt 4096) { return [pscustomobject]@{ Complete=$false; Rows=@() } }
+                    if ($rowAscii) {
+                        $row = ConvertFrom-LegacyRecord $builder.ToString() $NowValue
+                        if ($null -ne $row) {
+                            if ($queue.Count -eq 512) { [void]$queue.Dequeue() }
+                            $queue.Enqueue($row)
+                        }
+                    }
+                    [void]$builder.Clear(); $recordLength=0; $rowAscii=$true
+                    continue
+                }
+                $recordLength++
+                if ($recordLength -gt 4096) { return [pscustomobject]@{ Complete=$false; Rows=@() } }
+                if ($byte -eq 9 -or $byte -eq 46 -or ($byte -ge 48 -and $byte -le 57)) { [void]$builder.Append([char]$byte) }
+                else { $rowAscii=$false }
+            }
+        }
+        if ($recordLength -gt 0) {
+            $physical++
+            if ($physical -gt 4096) { return [pscustomobject]@{ Complete=$false; Rows=@() } }
+            if ($rowAscii) {
+                $row = ConvertFrom-LegacyRecord $builder.ToString() $NowValue
+                if ($null -ne $row) {
+                    if ($queue.Count -eq 512) { [void]$queue.Dequeue() }
+                    $queue.Enqueue($row)
+                }
+            }
+        }
+        return [pscustomobject]@{ Complete=$true; Rows=$queue.ToArray() }
+    } catch { return [pscustomobject]@{ Complete=$false; Rows=@() } }
+    finally { if ($null -ne $stream) { $stream.Dispose() } }
+}
+
+function Sort-StateEntries([object[]]$Entries) {
+    $list = New-Object 'System.Collections.Generic.List[object]'
+    $list.AddRange($Entries)
+    $comparison = [System.Comparison[object]]{
+        param($left, $right)
+        return [string]::CompareOrdinal([string]$left.Name, [string]$right.Name)
+    }
+    $list.Sort($comparison)
+    return ,($list.ToArray())
+}
+
+function Get-BurnRetention([object[]]$Entries, [int]$Trim) {
+    $sorted = Sort-StateEntries $Entries
+    $candidates = New-Object 'System.Collections.Generic.List[object]'
+    $representatives = @{}
+    foreach ($entry in $sorted) {
+        if (-not $entry.Plausible) { [void]$candidates.Add($entry); continue }
+        $key = ([string]$entry.Reset) + '_' + ([string]$entry.Sample)
+        if (-not $representatives.ContainsKey($key)) { $representatives[$key] = $entry; continue }
+        $old = $representatives[$key]
+        $replace = $entry.Pct -gt $old.Pct -or ($entry.Pct -eq $old.Pct -and [string]::CompareOrdinal($entry.Name, $old.Name) -lt 0)
+        if ($replace) { [void]$candidates.Add($old); $representatives[$key] = $entry }
+        else { [void]$candidates.Add($entry) }
+    }
+    $reps = Sort-StateEntries @($representatives.Values)
+    $oldCount = $reps.Count - $Trim
+    if ($oldCount -lt 0) { $oldCount = 0 }
+    for ($i=0; $i -lt $oldCount; $i++) { [void]$candidates.Add($reps[$i]) }
+    return [pscustomobject]@{ Candidates=$candidates.ToArray(); Representatives=$reps }
+}
+
+function Get-LimitRetention([object[]]$Entries) {
+    $sorted = Sort-StateEntries $Entries
+    $winner = $null
+    foreach ($entry in $sorted) { if ($entry.Plausible) { $winner = $entry } }
+    $candidates = New-Object 'System.Collections.Generic.List[object]'
+    foreach ($entry in $sorted) { if ($null -eq $winner -or -not [object]::ReferenceEquals($entry, $winner)) { [void]$candidates.Add($entry) } }
+    return [pscustomobject]@{ Candidates=$candidates.ToArray(); Winner=$winner }
+}
+
+function Test-BurnDeleteCandidate([string]$Root, $Entry) {
+    if ($null -eq $Entry -or -not $Entry.Path.Equals([IO.Path]::Combine($Root, $Entry.Name), [StringComparison]::OrdinalIgnoreCase)) { return $false }
+    if (-not (Test-StateRoot $Root) -or -not [IO.Directory]::Exists($Root)) { return $false }
+    if ($null -eq (ConvertFrom-BurnName $Entry.Name $Now)) { return $false }
+    try {
+        $attrs = [IO.File]::GetAttributes($Entry.Path)
+        if (($attrs -band [IO.FileAttributes]::ReparsePoint) -ne 0 -or ($attrs -band [IO.FileAttributes]::Directory) -ne 0) { return $false }
+        return (New-Object IO.FileInfo($Entry.Path)).Length -eq 0
+    } catch { return $false }
+}
+
+function Test-LimitDeleteCandidate([string]$Root, $Entry, [long]$MaxAhead) {
+    if ($null -eq $Entry -or -not $Entry.Path.Equals([IO.Path]::Combine($Root, $Entry.Name), [StringComparison]::OrdinalIgnoreCase)) { return $false }
+    if (-not (Test-StateRoot $Root) -or -not [IO.Directory]::Exists($Root)) { return $false }
+    if ($null -eq (ConvertFrom-LimitName $Entry.Name $Now $MaxAhead)) { return $false }
+    return Test-EmptyStateDirectory $Entry.Path
+}
+
+function Remove-StateCandidates([string]$Root, [object[]]$Candidates, [string]$Kind, [long]$MaxAhead, [bool]$Mutate) {
+    if (-not $Mutate) { return [pscustomobject]@{ Resolved=0; Clean=($Candidates.Count -eq 0) } }
+    $limit = [Math]::Min(128, $Candidates.Count)
+    $resolved = 0
+    for ($i=0; $i -lt $limit; $i++) {
+        $entry = $Candidates[$i]
+        if (-not (Test-StateObjectExists $entry.Path)) { $resolved++; continue }
+        $safe = $false
+        if ($Kind -eq 'burn') { $safe = Test-BurnDeleteCandidate $Root $entry }
+        else { $safe = Test-LimitDeleteCandidate $Root $entry $MaxAhead }
+        if (-not $safe) { continue }
+        try {
+            if ($Kind -eq 'burn') { [IO.File]::Delete($entry.Path) }
+            else { [IO.Directory]::Delete($entry.Path, $false) }
+        } catch { }
+        if (-not (Test-StateObjectExists $entry.Path)) { $resolved++ }
+    }
+    return [pscustomobject]@{ Resolved=$resolved; Clean=($resolved -eq $Candidates.Count) }
+}
+
+function Get-CurrentLimit([string]$RawPct, [string]$RawReset, [long]$NowValue, [long]$MaxAhead) {
+    $pct = ConvertTo-StatePct $RawPct
+    $reset = ConvertTo-StatePayloadEpoch $RawReset 10
+    if ($null -eq $pct -or $null -eq $reset) { return [pscustomobject]@{ Valid=$false; Pct=0; Reset=0L } }
+    $value = [long]$reset.Value
+    if ($value -le $NowValue -or $value -gt ($NowValue + $MaxAhead)) { return [pscustomobject]@{ Valid=$false; Pct=0; Reset=0L } }
+    return [pscustomobject]@{ Valid=$true; Pct=[int]$pct.Milli; Reset=$value }
+}
+
+function Select-LimitResult($Snapshot, $Retention, $Current) {
+    $valid = $false
+    $reset = 0L
+    $pct = 0
+    if ($Snapshot.Complete -and $null -ne $Retention.Winner) { $valid=$true; $reset=[long]$Retention.Winner.Reset; $pct=[int]$Retention.Winner.Pct }
+    if ($Current.Valid -and (-not $valid -or $Current.Reset -gt $reset -or ($Current.Reset -eq $reset -and $Current.Pct -gt $pct))) {
+        $valid=$true; $reset=[long]$Current.Reset; $pct=[int]$Current.Pct
+    }
+    return [pscustomobject]@{ Valid=$valid; Reset=$reset; Pct=$pct }
+}
+
+function Publish-LimitState([string]$Root, $Current, $Snapshot, $Gc, [long]$MaxAhead, [bool]$Mutate) {
+    if (-not $Mutate -or -not $Snapshot.Complete -or -not $Gc.Clean -or -not $Current.Valid) { return $false }
+    if (($Snapshot.Raw - $Gc.Resolved) -ge 384) { return $false }
+    if (-not (Test-StateRoot $Root)) { return $false }
+    $name = $Current.Reset.ToString('D10', $Invariant) + '_' + (Format-StatePct $Current.Pct)
+    $path = [IO.Path]::Combine($Root, $name)
+    if (-not (Test-NoReparseComponents $path)) { return $false }
+    try { [void][IO.Directory]::CreateDirectory($path) } catch { return $false }
+    return Test-LimitDeleteCandidate $Root ([pscustomobject]@{ Name=$name; Path=$path }) $MaxAhead
+}
+
+function Publish-BurnState([string]$Root, $Current, $Snapshot, $Gc, [bool]$Mutate) {
+    if (-not $Mutate -or -not $Snapshot.Complete -or -not $Gc.Clean -or -not $Current.Valid) { return $false }
+    if (($Snapshot.Raw - $Gc.Resolved) -ge 3968) { return $false }
+    if (-not (Test-StateRoot $Root)) { return $false }
+    try { [void][IO.Directory]::CreateDirectory($Root) } catch { return $false }
+    if (-not (Test-StateRoot $Root) -or -not [IO.Directory]::Exists($Root)) { return $false }
+    for ($slot=0; $slot -lt 32; $slot++) {
+        $name = 'b_' + $Current.Reset.ToString('D12', $Invariant) + '_' + $Current.Sample.ToString('D12', $Invariant) + '_' + (Format-StatePct $Current.Pct) + '_' + $slot.ToString('D4', $Invariant)
+        $path = [IO.Path]::Combine($Root, $name)
+        try {
+            $stream = New-Object IO.FileStream($path, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
+            $stream.Dispose()
+            return $true
+        } catch [IO.IOException] {
+            if (Test-StateObjectExists $path) { continue }
+            return $false
+        } catch { return $false }
+    }
+    return $false
+}
+
+function Get-Burn5Estimate($Snapshot, $Retention, $Legacy, $Current, [long]$NowValue, [int]$Window) {
+    $warming = [pscustomobject]@{ State='warming'; Eta='inf'; Rate='0.0000000000'; Ttr=0L }
+    if (-not $Snapshot.Complete -or -not $Legacy.Complete) { return $warming }
+    $observations = New-Object 'System.Collections.Generic.List[object]'
+    foreach ($entry in $Retention.Representatives) { if ($entry.Plausible) { [void]$observations.Add($entry) } }
+    foreach ($row in $Legacy.Rows) { [void]$observations.Add($row) }
+    if ($Current.Valid) { [void]$observations.Add($Current) }
+    if ($observations.Count -eq 0) { return $warming }
+    $maxReset = 0L
+    foreach ($observation in $observations) { if ([long]$observation.Reset -gt $maxReset) { $maxReset = [long]$observation.Reset } }
+    if ($maxReset -le 0) { return $warming }
+    $dedup = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::Ordinal)
+    $perSecond = New-Object 'System.Collections.Generic.Dictionary[long,int]'
+    foreach ($observation in $observations) {
+        if ([long]$observation.Reset -ne $maxReset) { continue }
+        $key = ([string]$observation.Reset) + '_' + ([string]$observation.Sample) + '_' + ([string]$observation.Pct)
+        if (-not $dedup.Add($key)) { continue }
+        $sample = [long]$observation.Sample
+        $pct = [int]$observation.Pct
+        if (-not $perSecond.ContainsKey($sample) -or $pct -gt $perSecond[$sample]) { $perSecond[$sample] = $pct }
+    }
+    if ($perSecond.Count -eq 0) { return $warming }
+    $samples = [long[]]@($perSecond.Keys)
+    [Array]::Sort($samples)
+    $ttr = $maxReset - $NowValue
+    if ($ttr -lt 0) { $ttr = 0 }
+    $cutoff = $NowValue - $Window
+    $unusedRemainder = 0L
+    $minSpan = [Math]::DivRem([long]$Window, 10L, [ref]$unusedRemainder)
+    $firstTime = 0L; $firstPct = -1; $lastTime = 0L; $lastPct = -1; $crossings = 0; $anyCrossing = $false
+    for ($i=1; $i -lt $samples.Length; $i++) {
+        $aRem = 0L; $bRem = 0L
+        $a = [Math]::DivRem([long]$perSecond[$samples[$i-1]], 1000L, [ref]$aRem)
+        $b = [Math]::DivRem([long]$perSecond[$samples[$i]], 1000L, [ref]$bRem)
+        if ($b -le $a) { continue }
+        $anyCrossing = $true
+        $crossTime = $samples[$i]
+        if ($crossTime -ge $cutoff -and $crossTime -le $NowValue) {
+            if ($firstPct -lt 0) { $firstTime=$crossTime; $firstPct=[int]$b }
+            $lastTime=$crossTime; $lastPct=[int]$b; $crossings++
+        }
+    }
+    if ($crossings -ge 2 -and $lastTime -gt $firstTime -and $lastPct -gt $firstPct -and ($lastTime - $firstTime) -ge $minSpan) {
+        $span = $lastTime - $firstTime
+        $delta = [long]($lastPct - $firstPct)
+        $latest = [long]$perSecond[$samples[$samples.Length - 1]]
+        $eta = Get-RoundEvenInt64 ((100000L - $latest) * $span) ($delta * 1000L)
+        $rate = Format-StateRate ($delta * 10000000000L) $span
+        return [pscustomobject]@{ State='active'; Eta=$eta; Rate=$rate; Ttr=$ttr }
+    }
+    if ($anyCrossing -and $crossings -eq 0) { return [pscustomobject]@{ State='idle'; Eta='inf'; Rate='0.0000000000'; Ttr=$ttr } }
+    return [pscustomobject]@{ State='warming'; Eta='inf'; Rate='0.0000000000'; Ttr=$ttr }
+}
+
+function Get-Burn7Estimate($Limit, [long]$NowValue) {
+    if (-not $Limit.Valid) { return [pscustomobject]@{ Eta='inf'; Rate='0.0000000000'; Ttr=0L } }
+    $ttr = [long]$Limit.Reset - $NowValue
+    if ($ttr -lt 0) { $ttr = 0 }
+    $elapsed = $NowValue - ([long]$Limit.Reset - 604800L)
+    if ($Limit.Pct -le 0 -or $elapsed -lt 1 -or $elapsed -gt 691200L) { return [pscustomobject]@{ Eta='inf'; Rate='0.0000000000'; Ttr=$ttr } }
+    $rate = Format-StateRate ([long]$Limit.Pct * 10000000L) $elapsed
+    $eta = Get-RoundEvenInt64 ((100000L - [long]$Limit.Pct) * $elapsed) ([long]$Limit.Pct)
+    return [pscustomobject]@{ Eta=$eta; Rate=$rate; Ttr=$ttr }
+}
+
+function Get-BurnBinding($Five, $Seven) {
+    $fiveFinite = [string]$Five.Eta -ne 'inf'
+    $sevenFinite = [string]$Seven.Eta -ne 'inf'
+    if ($fiveFinite -and (-not $sevenFinite -or [long]$Five.Eta -le [long]$Seven.Eta)) {
+        return [pscustomobject]@{ State='active'; Label='5h'; Eta=[long]$Five.Eta; Rate=$Five.Rate; Ttr=[long]$Five.Ttr }
+    }
+    if ($sevenFinite) { return [pscustomobject]@{ State='active'; Label='7d'; Eta=[long]$Seven.Eta; Rate=$Seven.Rate; Ttr=[long]$Seven.Ttr } }
+    $state = 'warming'
+    if ($Five.State -eq 'idle') { $state = 'idle' }
+    return [pscustomobject]@{ State=$state; Label=''; Eta='inf'; Rate='0.0000000000'; Ttr=0L }
+}
+
+function Get-CorallineState([bool]$BurnGate, [bool]$Limit5Gate, [bool]$Limit7Gate) {
+    $mutate = [string]$env:CORALLINE_NO_SAMPLE -ne '1'
+    $window = Get-BoundedInt $Cfg.CORALLINE_BURN_WINDOW 600 60 86400
+    $trim = Get-BoundedInt $Cfg.BURN_TRIM 1500 1 3000
+    $current5 = Get-CurrentLimit $fhPct $fhRst $Now 21600L
+    $current7 = Get-CurrentLimit $wdPct $wdRst $Now 691200L
+    $currentBurn = [pscustomobject]@{ Valid=$false; Reset=0L; Sample=$Now; Pct=0 }
+    if ($current5.Valid -and $current5.Reset -ge $Now) { $currentBurn = [pscustomobject]@{ Valid=$true; Reset=[long]$current5.Reset; Sample=$Now; Pct=[int]$current5.Pct } }
+
+    $emptySnapshot = [pscustomobject]@{ Complete=$false; Raw=0; Entries=@() }
+    $emptyLegacy = [pscustomobject]@{ Complete=$false; Rows=@() }
+    $burnSnapshot=$emptySnapshot; $limit5Snapshot=$emptySnapshot; $limit7Snapshot=$emptySnapshot; $legacy=$emptyLegacy
+    $burnPaths=$null; $limit5Paths=$null; $limit7Paths=$null
+    if ($BurnGate) { $burnPaths = Get-StatePaths $Cfg.BURN_FILE }
+    if ($Limit5Gate) { $limit5Paths = Get-StatePaths $Cfg.RL5H_FILE }
+    if ($Limit7Gate) { $limit7Paths = Get-StatePaths $Cfg.RL7D_FILE }
+    $collision = $false
+    $roots = New-Object 'System.Collections.Generic.List[object]'
+    foreach ($candidateRoot in @($burnPaths, $limit5Paths, $limit7Paths)) { if ($null -ne $candidateRoot) { [void]$roots.Add($candidateRoot) } }
+    for ($i=0; $i -lt $roots.Count; $i++) {
+        for ($j=$i+1; $j -lt $roots.Count; $j++) { if ($roots[$i].Root.Equals($roots[$j].Root, [StringComparison]::OrdinalIgnoreCase)) { $collision=$true } }
+    }
+    if (-not $collision) {
+        if ($BurnGate -and $null -ne $burnPaths) {
+            $burnSnapshot = Get-StateDirectorySnapshot $burnPaths.Root 'burn' 4096 $Now 21600L
+            $legacy = Read-LegacyState $burnPaths.Base $Now
+            if (-not $legacy.Complete) { $burnSnapshot = [pscustomobject]@{ Complete=$false; Raw=$burnSnapshot.Raw; Entries=@() } }
+        }
+        if ($Limit5Gate -and $null -ne $limit5Paths) { $limit5Snapshot = Get-StateDirectorySnapshot $limit5Paths.Root 'limit' 512 $Now 21600L }
+        if ($Limit7Gate -and $null -ne $limit7Paths) { $limit7Snapshot = Get-StateDirectorySnapshot $limit7Paths.Root 'limit' 512 $Now 691200L }
+    }
+
+    $burnRetention = [pscustomobject]@{ Candidates=@(); Representatives=@() }
+    $limit5Retention = [pscustomobject]@{ Candidates=@(); Winner=$null }
+    $limit7Retention = [pscustomobject]@{ Candidates=@(); Winner=$null }
+    if ($burnSnapshot.Complete) { $burnRetention = Get-BurnRetention $burnSnapshot.Entries $trim }
+    if ($limit5Snapshot.Complete) { $limit5Retention = Get-LimitRetention $limit5Snapshot.Entries }
+    if ($limit7Snapshot.Complete) { $limit7Retention = Get-LimitRetention $limit7Snapshot.Entries }
+
+    $burnGc = [pscustomobject]@{ Resolved=0; Clean=$false }
+    $limit5Gc = [pscustomobject]@{ Resolved=0; Clean=$false }
+    $limit7Gc = [pscustomobject]@{ Resolved=0; Clean=$false }
+    if ($burnSnapshot.Complete) { $burnGc = Remove-StateCandidates $burnPaths.Root $burnRetention.Candidates 'burn' 21600L $mutate }
+    if ($limit5Snapshot.Complete) { $limit5Gc = Remove-StateCandidates $limit5Paths.Root $limit5Retention.Candidates 'limit' 21600L $mutate }
+    if ($limit7Snapshot.Complete) { $limit7Gc = Remove-StateCandidates $limit7Paths.Root $limit7Retention.Candidates 'limit' 691200L $mutate }
+
+    $limit5 = Select-LimitResult $limit5Snapshot $limit5Retention $current5
+    $limit7 = Select-LimitResult $limit7Snapshot $limit7Retention $current7
+    if ($BurnGate -and $burnSnapshot.Complete) { [void](Publish-BurnState $burnPaths.Root $currentBurn $burnSnapshot $burnGc $mutate) }
+    if ($Limit5Gate -and $limit5Snapshot.Complete) { [void](Publish-LimitState $limit5Paths.Root $current5 $limit5Snapshot $limit5Gc 21600L $mutate) }
+    if ($Limit7Gate -and $limit7Snapshot.Complete) { [void](Publish-LimitState $limit7Paths.Root $current7 $limit7Snapshot $limit7Gc 691200L $mutate) }
+
+    $five = Get-Burn5Estimate $burnSnapshot $burnRetention $legacy $currentBurn $Now $window
+    if ($Cfg.VL_LIMIT_SYNC -eq '1') { $seven = Get-Burn7Estimate $limit7 $Now }
+    else { $seven = Get-Burn7Estimate $current7 $Now }
+    $burn = Get-BurnBinding $five $seven
+    $burn | Add-Member -NotePropertyName Reported -NotePropertyValue ($current5.Valid -or $current7.Valid)
+    return [pscustomobject]@{
+        Burn=$burn; Five=$five; Seven=$seven; Limit5=$limit5; Limit7=$limit7
+        Current5=$current5; Current7=$current7; BurnSnapshotComplete=$burnSnapshot.Complete
+        Limit5SnapshotComplete=$limit5Snapshot.Complete; Limit7SnapshotComplete=$limit7Snapshot.Complete
+    }
+}
 
 function Format-Countdown([string]$ResetsAt) {
     $ep = ConvertTo-Epoch $ResetsAt
@@ -1038,6 +1583,14 @@ foreach ($list in @($Cfg.VL_SEGMENTS, $Cfg.VL_SEGMENTS2, $Cfg.VL_SEGMENTS3)) {
     foreach ($name in (Get-SegmentTokens $list)) { [void]$AllSegmentNames.Add($name) }
 }
 
+$BurnStateGate = $AllSegmentNames.Contains('burn')
+$Limit5StateGate = $Cfg.VL_LIMIT_SYNC -eq '1' -and $AllSegmentNames.Contains('limit5h')
+$Limit7StateGate = $Cfg.VL_LIMIT_SYNC -eq '1' -and ($AllSegmentNames.Contains('limit7d') -or $BurnStateGate)
+$State = $null
+if ($BurnStateGate -or $Limit5StateGate -or $Limit7StateGate) {
+    $State = Get-CorallineState $BurnStateGate $Limit5StateGate $Limit7StateGate
+}
+
 $GitState = @{ Branch = ''; Marks = ''; Ab = ''; Dirty = $false }
 $GitRoot = ''
 if ($AllSegmentNames.Contains('git') -or $AllSegmentNames.Contains('stash') -or $AllSegmentNames.Contains('project')) {
@@ -1119,9 +1672,10 @@ function Add-CtxSegment {
     Push-Segment $Cfg.VL_BG_CTX "${pfg} $($Cfg.VL_CTX_GLYPH) ${bar} ${pct}% ${dfg}$($G.Up)${ti} $($G.Down)${to} cr:${tcr} cw:${tcw} "
 }
 
-function Add-LimitSegment([string]$Label, [string]$RawPct, [string]$ResetsAt, [string]$Bg) {
+function Add-LimitSegment([string]$Label, [string]$RawPct, [string]$ResetsAt, [string]$Bg, [int]$PctMilli = -1) {
     $pct = 0
-    if (-not (Get-PctValue $RawPct ([ref]$pct))) { return }
+    if ($PctMilli -ge 0) { $pct = [int](Get-RoundEvenInt64 ([long]$PctMilli) 1000L) }
+    elseif (-not (Get-PctValue $RawPct ([ref]$pct))) { return }
     $bar = New-Bar $pct ([int]$Cfg.VL_BAR_WIDTH)
     $pfg = Get-Fg (Get-PctFg $pct)
     $countdown = Format-Countdown $ResetsAt
@@ -1131,6 +1685,62 @@ function Add-LimitSegment([string]$Label, [string]$RawPct, [string]$ResetsAt, [s
         $reset = "${dfg}$($G.Reset)${countdown}"
     }
     Push-Segment $Bg "${pfg} $Label ${bar} ${pct}% ${reset} "
+}
+
+function Add-Limit5Segment {
+    if ($Cfg.VL_LIMIT_SYNC -eq '1') {
+        if ($null -eq $State -or -not $State.Limit5.Valid) { return }
+        Add-LimitSegment '5h' (Format-StatePct $State.Limit5.Pct) ([string]$State.Limit5.Reset) $Cfg.VL_BG_5H $State.Limit5.Pct
+        return
+    }
+    Add-LimitSegment '5h' $fhPct $fhRst $Cfg.VL_BG_5H
+}
+
+function Add-Limit7Segment {
+    if ($Cfg.VL_LIMIT_SYNC -eq '1') {
+        if ($null -eq $State -or -not $State.Limit7.Valid) { return }
+        Add-LimitSegment '7d' (Format-StatePct $State.Limit7.Pct) ([string]$State.Limit7.Reset) $Cfg.VL_BG_7D $State.Limit7.Pct
+        return
+    }
+    Add-LimitSegment '7d' $wdPct $wdRst $Cfg.VL_BG_7D
+}
+
+function Format-Eta([long]$Seconds) {
+    $remainder = 0L
+    $days = [Math]::DivRem($Seconds, 86400L, [ref]$remainder)
+    $minutesRemainder = 0L
+    $hours = [Math]::DivRem($remainder, 3600L, [ref]$minutesRemainder)
+    $unused = 0L
+    $minutes = [Math]::DivRem($minutesRemainder, 60L, [ref]$unused)
+    if ($days -gt 0) { return [string]::Format($Invariant, '{0}d{1:00}h', $days, $hours) }
+    if ($hours -gt 0) { return [string]::Format($Invariant, '{0}h{1:00}m', $hours, $minutes) }
+    return [string]::Format($Invariant, '{0}m', $minutes)
+}
+
+function Add-BurnSegment {
+    if ($null -eq $State -or -not $State.Burn.Reported) { return }
+    $bg = $Cfg.VL_BG_BURN
+    if ([string]::IsNullOrEmpty($bg)) { $bg = $Cfg.VL_BG_5H }
+    if ($State.Burn.State -ne 'active') {
+        $fg = Get-Fg $Cfg.VL_FG_DIM
+        if ($State.Burn.State -eq 'warming') { Push-Segment $bg "${fg} $($Cfg.VL_BURN_GLYPH) $($G.Ellipsis) " }
+        else { Push-Segment $bg "${fg} $($Cfg.VL_BURN_GLYPH) $($G.Check) " }
+        return
+    }
+    $window = 604800L
+    if ($State.Burn.Label -eq '5h') { $window = 18000L }
+    $eta = [long]$State.Burn.Eta
+    $ttr = [long]$State.Burn.Ttr
+    if ($eta -gt $window) {
+        $fg = Get-Fg $Cfg.VL_FG_OK
+        Push-Segment $bg "${fg} $($Cfg.VL_BURN_GLYPH) $($G.Check) "
+        return
+    }
+    if ($eta -le $ttr) { $color = $Cfg.VL_FG_HOT }
+    elseif ((10L * $ttr) -ge (8L * $eta)) { $color = $Cfg.VL_FG_WARN }
+    else { $color = $Cfg.VL_FG_OK }
+    $fg = Get-Fg $color
+    Push-Segment $bg "${fg} $($Cfg.VL_BURN_GLYPH) $($State.Burn.Label) $($G.BurnTo) $(Format-Eta $eta) "
 }
 
 function Add-CostSegment {
@@ -1195,6 +1805,7 @@ function Add-PythonSegment {
 }
 
 $SegmentBuilders = [ordered]@{
+    burn = { Add-BurnSegment }
     clock = { Add-ClockSegment }
     cost = { Add-CostSegment }
     ctx = { Add-CtxSegment }
@@ -1202,8 +1813,8 @@ $SegmentBuilders = [ordered]@{
     duration = { Add-DurationSegment }
     effort = { Add-EffortSegment }
     git = { Add-GitSegment }
-    limit5h = { Add-LimitSegment '5h' $fhPct $fhRst $Cfg.VL_BG_5H }
-    limit7d = { Add-LimitSegment '7d' $wdPct $wdRst $Cfg.VL_BG_7D }
+    limit5h = { Add-Limit5Segment }
+    limit7d = { Add-Limit7Segment }
     lines = { Add-LinesSegment }
     model = { Add-ModelSegment }
     node = { Add-NodeSegment }

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -341,7 +341,10 @@ function Decode-ShellWord([string]$Text, [bool]$PathContext) {
         if ($ch -eq '$') {
             if (-not $PathContext) { return [pscustomobject]@{ Success = $false; Value = '' } }
             if ($Text.Substring($i).StartsWith('${HOME}', [System.StringComparison]::Ordinal)) { $i += 7 }
-            elseif ($Text.Substring($i).StartsWith('$HOME', [System.StringComparison]::Ordinal)) { $i += 5 }
+            elseif (
+                $Text.Substring($i).StartsWith('$HOME', [System.StringComparison]::Ordinal) -and
+                ($i + 5 -ge $Text.Length -or [string]$Text[$i + 5] -notmatch '[A-Za-z0-9_]')
+            ) { $i += 5 }
             else { return [pscustomobject]@{ Success = $false; Value = '' } }
             if (-not (Add-Utf8Text $bytes $HomeDir)) { return [pscustomobject]@{ Success = $false; Value = '' } }
             continue
@@ -658,13 +661,13 @@ foreach ($key in @($Cfg.Keys | Where-Object { $_ -like 'VL_BG_*' -or $_ -like 'V
 if (-not (Test-Color $Cfg.VL_LEAN_BG)) { $Cfg.VL_LEAN_BG = '' }
 if (-not (Test-Color $Cfg.VL_LEAN_FG)) { $Cfg.VL_LEAN_FG = '' }
 
-$Cfg.VL_STYLE = switch ([string]$Cfg.VL_STYLE) {
+$Cfg.VL_STYLE = switch -CaseSensitive ([string]$Cfg.VL_STYLE) {
     'pill' { 'pill'; break }
     'lean' { 'lean'; break }
     'classic' { 'classic'; break }
     default { 'pill' }
 }
-$Cfg.VL_LAYOUT = switch ([string]$Cfg.VL_LAYOUT) {
+$Cfg.VL_LAYOUT = switch -CaseSensitive ([string]$Cfg.VL_LAYOUT) {
     'fixed' { 'fixed'; break }
     'auto' { 'auto'; break }
     default { 'fixed' }
@@ -2018,13 +2021,15 @@ $SegmentBuilders = [ordered]@{
     stash = { Add-StashSegment }
     style = { Add-StyleSegment }
 }
+$SupportedSegmentNames = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
+foreach ($name in $SegmentBuilders.Keys) { [void]$SupportedSegmentNames.Add([string]$name) }
 
 function Build-Segments([string]$List) {
     $SegBgs.Clear()
     $SegTxt.Clear()
     $SegLen.Clear()
     foreach ($name in (Get-SegmentTokens $List)) {
-        if ($SegmentBuilders.Contains($name)) { & $SegmentBuilders[$name] }
+        if ($SupportedSegmentNames.Contains($name)) { & $SegmentBuilders[$name] }
     }
 }
 

--- a/statusline.sh
+++ b/statusline.sh
@@ -439,16 +439,6 @@ state_same_path() {  # true for proven or platform-conservative store-root ident
   return 1
 }
 
-state_dir_empty() {
-  local child
-  [ -d "$1" ] && [ ! -L "$1" ] || return 1
-  for child in "$1"/* "$1"/.[!.]* "$1"/..?*; do
-    [ -e "$child" ] || [ -L "$child" ] || continue
-    return 1
-  done
-  return 0
-}
-
 state_burn_name() {  # → _SBN_* for one strict live basename
   local name="$1" pr ps pc LC_ALL=C
   _SBN_RST=""; _SBN_SAMP=""; _SBN_PCT=""; _SBN_SLOT=""
@@ -488,7 +478,7 @@ state_add_limit_path() {  # $1=5|7 $2=path $3=name
   if [ "$which" = 5 ]; then _SL5_RAW=$(( _SL5_RAW + 1 )); max=$RL_MAX_5H
   else _SL7_RAW=$(( _SL7_RAW + 1 )); max=$RL_MAX_7D; fi
   state_limit_name "$name" || return 0
-  state_dir_empty "$path" || return 0
+  [ -d "$path" ] && [ ! -L "$path" ] || return 0
   if [ "$_SLN_RST" -gt "$NOW" ] && [ "$_SLN_RST" -le $(( NOW + max )) ]; then plausible=1; fi
   if [ "$which" = 5 ]; then
     i=${#_SL5_NAMES[@]}; _SL5_NAMES[$i]="$name"; _SL5_PATHS[$i]="$path"
@@ -496,6 +486,19 @@ state_add_limit_path() {  # $1=5|7 $2=path $3=name
   else
     i=${#_SL7_NAMES[@]}; _SL7_NAMES[$i]="$name"; _SL7_PATHS[$i]="$path"
     _SL7_RSTS[$i]="$_SLN_RST"; _SL7_PCTS[$i]="$_SLN_PCT"; _SL7_PLAUS[$i]="$plausible"
+  fi
+}
+
+state_mark_limit_nonempty() {  # $1=5|7 $2=strict parent basename
+  local which="$1" name="$2" i
+  if [ "$which" = 5 ]; then
+    for ((i=0; i<${#_SL5_NAMES[@]}; i++)); do
+      [ "${_SL5_NAMES[$i]}" = "$name" ] && _SL5_PLAUS[$i]=0
+    done
+  else
+    for ((i=0; i<${#_SL7_NAMES[@]}; i++)); do
+      [ "${_SL7_NAMES[$i]}" = "$name" ] && _SL7_PLAUS[$i]=0
+    done
   fi
 }
 
@@ -517,7 +520,7 @@ state_snapshot() {  # one framed controller for every gated state root + legacy 
   _LEG_RSTS=(); _LEG_SAMPS=(); _LEG_PCTS=()
   exec 9< <(
     if [ "${#_STATE_FIND_ARGS[@]}" -gt 0 ]; then
-      LC_ALL=C find -P "${_STATE_FIND_ARGS[@]}" ! -name . -prune -print0 2>/dev/null
+      LC_ALL=C find -P "${_STATE_FIND_ARGS[@]}" -mindepth 1 -maxdepth 2 -print0 2>/dev/null
       _sf=$?
     else
       _sf=0
@@ -604,6 +607,27 @@ state_snapshot() {  # one framed controller for every gated state root + legacy 
         [ "$phase" = paths ] || { bad=1; continue; }
         combined=$(( combined + 1 )); matched=0
         if [ "$_STATE_BURN_GATE" = 1 ]; then
+          case "$record" in ("$_SB_ROOT/./"*/*) matched=1 ;; esac
+        fi
+        if [ "$matched" -eq 0 ] && [ "$_STATE_RL5_GATE" = 1 ]; then
+          case "$record" in
+            ("$_SL5_ROOT/./"*/*)
+              name="${record#"$_SL5_ROOT/./"}"; name="${name%%/*}"
+              state_mark_limit_nonempty 5 "$name"; _SL5_CHILD_RAW=$(( _SL5_CHILD_RAW + 1 )); matched=1
+              [ "$_SL5_CHILD_RAW" -le 512 ] || stream_over=1
+              ;;
+          esac
+        fi
+        if [ "$matched" -eq 0 ] && [ "$_STATE_RL7_GATE" = 1 ]; then
+          case "$record" in
+            ("$_SL7_ROOT/./"*/*)
+              name="${record#"$_SL7_ROOT/./"}"; name="${name%%/*}"
+              state_mark_limit_nonempty 7 "$name"; _SL7_CHILD_RAW=$(( _SL7_CHILD_RAW + 1 )); matched=1
+              [ "$_SL7_CHILD_RAW" -le 512 ] || stream_over=1
+              ;;
+          esac
+        fi
+        if [ "$matched" -eq 0 ] && [ "$_STATE_BURN_GATE" = 1 ]; then
           case "$record" in ("$_SB_ROOT/./"*) name="${record#"$_SB_ROOT/./"}"; state_add_burn_path "$_SB_ROOT/$name" "$name"; matched=1 ;; esac
           [ "$_SB_RAW" -le 4096 ] || stream_over=1
         fi
@@ -794,7 +818,7 @@ state_revalidate_limit() {
   state_no_symlink_path "$root" || return 1
   [ "$_SNP" = "$root" ] && [ -d "$root" ] || return 1
   state_limit_name "$name" || return 1
-  state_dir_empty "$path"
+  [ -d "$path" ] && [ ! -L "$path" ]
 }
 
 state_gc() {
@@ -1032,8 +1056,8 @@ state_prepare() {  # one state snapshot/GC/publication/estimate pass per render
   fi
 
   _SB_NAMES=(); _SB_PATHS=(); _SB_RSTS=(); _SB_SAMPS=(); _SB_PCTS=(); _SB_PLAUS=(); _SB_RAW=0
-  _SL5_NAMES=(); _SL5_PATHS=(); _SL5_RSTS=(); _SL5_PCTS=(); _SL5_PLAUS=(); _SL5_RAW=0
-  _SL7_NAMES=(); _SL7_PATHS=(); _SL7_RSTS=(); _SL7_PCTS=(); _SL7_PLAUS=(); _SL7_RAW=0
+  _SL5_NAMES=(); _SL5_PATHS=(); _SL5_RSTS=(); _SL5_PCTS=(); _SL5_PLAUS=(); _SL5_RAW=0; _SL5_CHILD_RAW=0
+  _SL7_NAMES=(); _SL7_PATHS=(); _SL7_RSTS=(); _SL7_PCTS=(); _SL7_PLAUS=(); _SL7_RAW=0; _SL7_CHILD_RAW=0
   _STATE_FIND_ARGS=(); _STATE_LEGACY_READ=0
   _SB_DIR_PREOK=1; _SL5_DIR_PREOK=1; _SL7_DIR_PREOK=1; _LEG_PREOK=1
   _SB_DIR_COMPLETE=0; _SL5_COMPLETE=0; _SL7_COMPLETE=0; _LEG_COMPLETE=0; _SB_COMPLETE=0

--- a/statusline.sh
+++ b/statusline.sh
@@ -1175,25 +1175,27 @@ fi
 IFS=$'\037' read -r cwd model ctx_pct tok_in tok_out tok_cr tok_cw \
                  fh_pct fh_rst wd_pct wd_rst cost \
                  lines_add lines_del out_style dur_ms effort <<JSON
-$(printf '%s' "$input" | jq -r '[
-  (.workspace.current_dir // .cwd // ""),
-  (.model.display_name // ""),
-  (.context_window.used_percentage // "" | tostring),
-  (.context_window.total_input_tokens // 0),
-  (.context_window.total_output_tokens // 0),
-  (.context_window.current_usage.cache_read_input_tokens // 0),
-  (.context_window.current_usage.cache_creation_input_tokens // 0),
-  (.rate_limits.five_hour.used_percentage // "" | tostring),
-  (.rate_limits.five_hour.resets_at // "" | tostring),
-  (.rate_limits.seven_day.used_percentage // "" | tostring),
-  (.rate_limits.seven_day.resets_at // "" | tostring),
-  (.cost.total_cost_usd // "" | tostring),
-  (.cost.total_lines_added // 0),
-  (.cost.total_lines_removed // 0),
-  (.output_style.name // ""),
-  (.cost.total_duration_ms // 0),
-  (.effort.level // "")
-] | map(tostring) | join("")' 2>/dev/null)
+$(printf '%s' "$input" | jq -r '
+  def scrub: tostring | gsub("[\\x00-\\x1f\\x7f\u0080-\u009f]"; "");
+  [
+    (.workspace.current_dir // .cwd // ""),
+    (.model.display_name // ""),
+    (.context_window.used_percentage // "" | tostring),
+    (.context_window.total_input_tokens // 0),
+    (.context_window.total_output_tokens // 0),
+    (.context_window.current_usage.cache_read_input_tokens // 0),
+    (.context_window.current_usage.cache_creation_input_tokens // 0),
+    (.rate_limits.five_hour.used_percentage // "" | tostring),
+    (.rate_limits.five_hour.resets_at // "" | tostring),
+    (.rate_limits.seven_day.used_percentage // "" | tostring),
+    (.rate_limits.seven_day.resets_at // "" | tostring),
+    (.cost.total_cost_usd // "" | tostring),
+    (.cost.total_lines_added // 0),
+    (.cost.total_lines_removed // 0),
+    (.output_style.name // ""),
+    (.cost.total_duration_ms // 0),
+    (.effort.level // "")
+  ] | map(scrub) | join("")' 2>/dev/null)
 JSON
 
 _SEG_SCAN=" $VL_SEGMENTS $VL_SEGMENTS2 $VL_SEGMENTS3 "

--- a/statusline.sh
+++ b/statusline.sh
@@ -299,223 +299,807 @@ fmt_eta() {  # → _ETA ; $1=seconds (mirrors fmt_countdown's d/h/m formatting)
   else                      printf -v _ETA '%dm' "$m"; fi
 }
 
-burn_sample() {  # append one 5h sample; $1=now $2=pct(raw) $3=resets_at(raw)
-  [ -n "$2" ] || return 0
-  to_epoch "$3" || return 0
-  # Reject an implausibly-far-future reset (corrupt/sentinel snapshot): this is the
-  # 5h window, which resets within hours, so anything past now+RL_MAX_5H would
-  # otherwise poison the burn projection permanently (see #32).
-  [ "$_EP" -le "$(( $1 + RL_MAX_5H ))" ] || return 0
-  # [ -d ] is a builtin (steady state stays fork-free); mkdir forks only on the
-  # first render after a fresh install, when ~/.claude/coralline/ doesn't exist.
-  [ -d "${BURN_FILE%/*}" ] || mkdir -p "${BURN_FILE%/*}" 2>/dev/null
-  printf '%s\t%s\t%s\n' "$1" "$2" "$_EP" >> "$BURN_FILE" 2>/dev/null
+# ── Immutable burn / limit state ──────────────────────────────────────────────
+# State percentages are canonical integer milli-percent. Filenames, not file
+# contents or enumeration order, are the shared source of truth.
+state_pct() {  # → _SP_MILLI _SP_CANON; strict raw decimal, ties-to-even at .001
+  local raw="$1" whole frac six keep rest milli LC_ALL=C
+  _SP_MILLI=""; _SP_CANON=""
+  [[ "$raw" =~ ^(0|[1-9][0-9]?|100)(\.([0-9]{1,6}))?$ ]] || return 1
+  whole="${BASH_REMATCH[1]}"; frac="${BASH_REMATCH[3]}"
+  if [ "$whole" = 100 ]; then
+    case "$frac" in (*[!0]*) return 1 ;; esac
+  fi
+  six="${frac}000000"; six="${six:0:6}"
+  keep=${six:0:3}; rest=${six:3:3}
+  milli=$(( 10#$whole * 1000 + 10#$keep ))
+  if [ $(( 10#$rest )) -gt 500 ] || { [ $(( 10#$rest )) -eq 500 ] && [ $(( milli % 2 )) -eq 1 ]; }; then
+    milli=$(( milli + 1 ))
+  fi
+  [ "$milli" -le 100000 ] || return 1
+  _SP_MILLI=$milli
+  printf -v _SP_CANON '%03d.%03d' $(( milli / 1000 )) $(( milli % 1000 ))
 }
 
-# The store is a SET of atomically-created directory entries under <file>.d, each
-# named "<reset:%010d>_<pct:%07.3f>". Fixed widths make lexical order == numeric
-# order (reset dominates, pct tie-breaks), so the last entry is the current
-# window's high-water. Three race-free primitives, with no shared append and no
-# whole-file rewrite (so the rename-unlinks-the-inode hazard of a single mutable
-# file cannot occur):
-#   add  = one mkdir (atomic; concurrent adds make distinct names; idempotent)
-#   read = ls | sort | tail -1
-#   gc   = rmdir every snapshot entry below the snapshot max. Removing a non-max
-#          element cannot change the max, and entries added after the snapshot are
-#          untouched, so a concurrent higher add is never lost (no lock needed).
-rl_dir() { _RLD="${1%.tsv}.d"; }
+state_epoch() {  # → _SE_VALUE _SE_PAD; $1=strict epoch $2=width (10 or 12)
+  local raw="$1" width="$2" value
+  _SE_VALUE=""; _SE_PAD=""
+  case "$raw" in (0|[1-9][0-9]*) ;; (*) return 1 ;; esac
+  case "$raw" in (*[!0-9]*) return 1 ;; esac
+  [ "${#raw}" -le 12 ] || return 1
+  value=$(( 10#$raw ))
+  [ "$value" -ge 0 ] && [ "$value" -le 253402300799 ] || return 1
+  [ "$width" != 10 ] || [ "$value" -le 9999999999 ] || return 1
+  _SE_VALUE=$value
+  printf -v _SE_PAD "%0${width}d" "$value"
+}
 
-rl_sample() {  # $1=file $2=pct(raw int/float) $3=resets_at(raw) $4=max secs ahead
-  [ -n "$2" ] || return 0
-  to_epoch "$3" || return 0
-  # Reject an implausibly-far-future reset (corrupt/sentinel snapshot): a value past
-  # now plus this window's ceiling ($4) would win rl_latest's high-water forever and
-  # rmdir every real entry (see #32). The caller passes RL_MAX_5H or RL_MAX_7D so a
-  # stale 5h value days out is rejected, not just an absurd one. Guarded on NOW and
-  # on $4 being supplied so direct unit calls without a clock keep recording.
-  [ -z "${NOW:-}" ] || [ -z "${4:-}" ] || [ "$_EP" -le "$(( NOW + $4 ))" ] || return 0
-  rl_dir "$1"
-  if [ ! -d "$_RLD" ]; then
-    mkdir -p "$_RLD" 2>/dev/null
-    # One-shot migration: a pre-dir-set build kept a flat <file>.tsv (+ tmp); the
-    # dir-set never touches it, so drop it once when the dir is first created.
-    rm -f "$1" "$1".*.tmp 2>/dev/null
+state_payload_epoch() {  # → _SE_*; canonical ISO UTC or strict epoch only
+  local raw="$1" width="$2"
+  case "$raw" in
+    (*T*) to_epoch "$raw" || return 1; state_epoch "$_EP" "$width" ;;
+    (*) state_epoch "$raw" "$width" ;;
+  esac
+}
+
+state_round_even() {  # → _RE; exact nonnegative rational midpoint-to-even
+  local n="$1" d="$2" q r twice
+  _RE=0
+  [ "$d" -gt 0 ] || return 1
+  q=$(( n / d )); r=$(( n % d )); twice=$(( r * 2 ))
+  if [ "$twice" -gt "$d" ] || { [ "$twice" -eq "$d" ] && [ $(( q % 2 )) -eq 1 ]; }; then
+    q=$(( q + 1 ))
   fi
-  local r p
-  printf -v r '%010d' "$_EP" 2>/dev/null || return 0
-  printf -v p '%07.3f' "$2"  2>/dev/null || return 0
-  mkdir "$_RLD/${r}_${p}" 2>/dev/null
+  _RE=$q
+}
+
+state_rate10() {  # → _RATE10; $1=scaled numerator $2=denominator
+  local scaled
+  state_round_even "$1" "$2" || { _RATE10="0.0000000000"; return 1; }
+  scaled=$_RE
+  printf -v _RATE10 '%d.%010d' $(( scaled / 10000000000 )) $(( scaled % 10000000000 ))
+}
+
+state_drive_lower() {  # → _SDL
+  case "$1" in
+    (A|a) _SDL=a ;; (B|b) _SDL=b ;; (C|c) _SDL=c ;; (D|d) _SDL=d ;;
+    (E|e) _SDL=e ;; (F|f) _SDL=f ;; (G|g) _SDL=g ;; (H|h) _SDL=h ;;
+    (I|i) _SDL=i ;; (J|j) _SDL=j ;; (K|k) _SDL=k ;; (L|l) _SDL=l ;;
+    (M|m) _SDL=m ;; (N|n) _SDL=n ;; (O|o) _SDL=o ;; (P|p) _SDL=p ;;
+    (Q|q) _SDL=q ;; (R|r) _SDL=r ;; (S|s) _SDL=s ;; (T|t) _SDL=t ;;
+    (U|u) _SDL=u ;; (V|v) _SDL=v ;; (W|w) _SDL=w ;; (X|x) _SDL=x ;;
+    (Y|y) _SDL=y ;; (Z|z) _SDL=z ;; (*) return 1 ;;
+  esac
+}
+
+state_abs_path() {  # → _SAP; lexical absolute path, including MSYS drive forms
+  local p="$1" drive rest part out=""
+  _SAP=""
+  [ -n "$p" ] || return 1
+  p="${p//\\//}"
+  case "$p" in
+    (//*) return 1 ;;
+    ([abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ]:/*)
+      drive=${p:0:1}; state_drive_lower "$drive" || return 1
+      p="/${_SDL}/${p:3}" ;;
+    (/*) ;;
+    (*) p="$PWD/$p" ;;
+  esac
+  rest="${p#/}"
+  while :; do
+    part="${rest%%/*}"
+    case "$part" in
+      (''|.) ;;
+      (..) [ -n "$out" ] || return 1; out="${out%/*}" ;;
+      (*) out="${out:+$out/}$part" ;;
+    esac
+    [ "$rest" = "$part" ] && break
+    rest="${rest#*/}"
+  done
+  _SAP="/${out}"
+  [ "$_SAP" != "/" ] || _SAP="/"
+}
+
+state_no_symlink_path() {  # → _SNP; every existing ancestor and target is non-link
+  local path="$1" rest part cur="" tail
+  _SNP=""
+  state_abs_path "$path" || return 1
+  path="$_SAP"; rest="${path#/}"
+  while [ -n "$rest" ]; do
+    part="${rest%%/*}"; tail="${rest#*/}"
+    cur="$cur/$part"
+    [ -L "$cur" ] && return 1
+    if [ "$tail" != "$rest" ] && [ -e "$cur" ] && [ ! -d "$cur" ]; then return 1; fi
+    [ "$tail" = "$rest" ] && break
+    rest="$tail"
+  done
+  _SNP="$path"
+}
+
+state_store_path() {  # → _SS_BASE _SS_ROOT from configured base
+  state_abs_path "$1" || return 1
+  _SS_BASE="$_SAP"
+  _SS_ROOT="${_SS_BASE%.tsv}.d"
+  [ "$_SS_ROOT" != "$_SS_BASE" ] || _SS_ROOT="${_SS_BASE}.d"
+}
+
+state_same_path() {  # true for proven or platform-conservative store-root identity
+  local left="$1" right="$2" had_nocase=0 same=1
+  [ "$left" = "$right" ] && return 0
+  if [ -e "$left" ] && [ -e "$right" ] && [ "$left" -ef "$right" ]; then return 0; fi
+  case "${OSTYPE:-}" in
+    (darwin*|mingw*|msys*)
+      shopt -q nocasematch && had_nocase=1
+      shopt -s nocasematch
+      [[ "$left" == "$right" ]] && same=0
+      [ "$had_nocase" = 1 ] || shopt -u nocasematch
+      return "$same"
+      ;;
+  esac
+  return 1
+}
+
+state_dir_empty() {
+  local child
+  [ -d "$1" ] && [ ! -L "$1" ] || return 1
+  for child in "$1"/* "$1"/.[!.]* "$1"/..?*; do
+    [ -e "$child" ] || [ -L "$child" ] || continue
+    return 1
+  done
   return 0
 }
 
-rl_latest() {  # $1=file $2=max secs ahead → _LL_PCT _LL_RST (epoch)
-  _LL_PCT=""; _LL_RST=""
-  rl_dir "$1"; [ -d "$_RLD" ] || return 0
-  # ONE snapshot for both the max and the GC. A second listing could include an
-  # entry added after `hi` was chosen, and the loop would rmdir that fresher (and
-  # possibly higher) entry. Iterating the same snapshot means post-snapshot adds
-  # are never deletion candidates, so a concurrent higher add is never lost.
-  local snap hi d cut="" kept=""
-  # A store poisoned before this fix (a 2030 sentinel written by an old preview)
-  # would still pin every read: rl_latest picks the max reset and rmdirs the rest.
-  # So drop entries beyond now plus this window's ceiling ($2) on read too. That
-  # keeps the sentinel out of the high-water AND prunes it, so the store self-heals
-  # (#32). Guarded on NOW (and on $2 being supplied) so direct unit calls without a
-  # clock keep every entry. A real reset is never that far out, so a concurrent
-  # legitimate add is never a pruning candidate.
-  [ -z "${NOW:-}" ] || [ -z "${2:-}" ] || cut=$(( NOW + $2 ))
-  snap=$(ls -1 "$_RLD" 2>/dev/null | grep '^[0-9]' | sort)
-  [ -n "$snap" ] || return 0
-  for d in $snap; do
-    if [ -n "$cut" ] && [ "$(( 10#${d%_*} ))" -gt "$cut" ]; then
-      rmdir "$_RLD/$d" 2>/dev/null            # purge the poisoned sentinel entry
-    else
-      kept="${kept}${kept:+ }$d"
-    fi
-  done
-  [ -n "$kept" ] || return 0
-  hi="${kept##* }"             # kept is built in sorted order, so the last is the max
-  _LL_RST=$(( 10#${hi%_*} ))   # 10# avoids the leading-zero octal trap on the reset
-  _LL_PCT="${hi#*_}"           # keep as string so a fractional pct is preserved
-  for d in $kept; do
-    [ "$d" = "$hi" ] || rmdir "$_RLD/$d" 2>/dev/null
-  done
+state_burn_name() {  # → _SBN_* for one strict live basename
+  local name="$1" pr ps pc LC_ALL=C
+  _SBN_RST=""; _SBN_SAMP=""; _SBN_PCT=""; _SBN_SLOT=""
+  [[ "$name" =~ ^b_([0-9]{12})_([0-9]{12})_((0[0-9]{2}|100)\.[0-9]{3})_([0-9]{4})$ ]] || return 1
+  pr="${BASH_REMATCH[1]}"; ps="${BASH_REMATCH[2]}"; pc="${BASH_REMATCH[3]}"
+  _SBN_RST=$(( 10#$pr )); _SBN_SAMP=$(( 10#$ps ))
+  [ "$_SBN_RST" -le 253402300799 ] && [ "$_SBN_SAMP" -le 253402300799 ] || return 1
+  _SBN_PCT=$(( 10#${pc:0:3} * 1000 + 10#${pc:4:3} ))
+  [ "$_SBN_PCT" -le 100000 ] || return 1
+  _SBN_SLOT="${BASH_REMATCH[5]}"
 }
 
-burn_eta_5h() {  # → _B5_STATE _B5_ETA _B5_RATE _B5_TTR ; trims $BURN_FILE
-  _B5_STATE="warming"; _B5_ETA="inf"; _B5_RATE="0"; _B5_TTR="0"
-  [ -f "$BURN_FILE" ] || return 0
-  local tmp="$BURN_FILE.$$.tmp" out
-  out=$(awk -F'\t' -v now="$NOW" -v win="$CORALLINE_BURN_WINDOW" \
-            -v trim="$BURN_TRIM" -v tmp="$tmp" -v maxahead="$RL_MAX_5H" '
-    $2 != "" {
-      e = $1 + 0; r = $3 + 0
-      # Drop a row whose reset is implausibly far out (a 2030 sentinel from an old
-      # sample preview). Left in, it becomes the "current window" below and starves
-      # the real samples; dropping it on read self-heals a pre-fix poisoned file (#32).
-      if (r > now + maxahead) { dropped = 1; next }
-      if (!(e in seen)) { ord[++n] = e; seen[e] = 1 }
-      pct[e] = $2 + 0; rst[e] = r
-    }
-    END {
-      if (n == 0) { print "warming inf 0 0"; next_done = 1 }
-      if (!next_done) {
-        # Fit the slope over the CURRENT window only. The sample file is shared
-        # by every concurrent session writing to this host; idle ones keep
-        # appending stale snapshots from earlier windows (a different reset).
-        # Mixing windows lets the fit pair two samples seconds apart but tens of
-        # percent apart, giving a near-vertical rate and a bogus ~1m ETA. The
-        # current window is the one with the latest reset; keep only its samples
-        # (cord[1..m]) in file order, then run the recent-slope fit over them.
-        cur = 0
-        for (i = 1; i <= n; i++) if (rst[ord[i]] > cur) cur = rst[ord[i]]
-        m = 0
-        for (i = 1; i <= n; i++) if (rst[ord[i]] == cur) cord[++m] = ord[i]
-        # Within the current window usage only ever rises until the window
-        # resets, so any decrease here is cache-lag jitter between concurrent
-        # sessions (their rate-limit caches refresh at different moments), NOT a
-        # reset — a real reset lands in a new window and was filtered out above.
-        # Anchoring the fit at the window start keeps a few jitter down-blips
-        # from collapsing it onto the last 1-2 samples and exploding the slope
-        # into a bogus ~1m ETA.
-        start = 1
-        le = cord[m]; lp = pct[le]
-        ttr = cur - now; if (ttr < 0) ttr = 0
-        cwin = now - win
-        # Crossings must span at least this long to trust a slope. Cache-lag
-        # jitter between sessions is second-scale, so a sub-minute span is noise;
-        # a genuine fast burn still rises over many seconds and clears this, so
-        # the guard rejects only second-scale noise, not real fast consumption.
-        minspan = int(win / 10)
-        fc_t = 0; fc_p = -1; lc_t = 0; lc_p = -1; ncross = 0; anycross = 0
-        for (i = start + 1; i <= m; i++) {
-          a = int(pct[cord[i-1]]); b = int(pct[cord[i]])
-          if (b > a) {
-            anycross = 1; ct = cord[i]
-            if (ct >= cwin && ct <= now) {
-              if (fc_p < 0) { fc_t = ct; fc_p = b }
-              lc_t = ct; lc_p = b; ncross++
+state_limit_name() {  # → _SLN_RST _SLN_PCT for one strict limit basename
+  local name="$1" pr pc LC_ALL=C
+  _SLN_RST=""; _SLN_PCT=""
+  [[ "$name" =~ ^([0-9]{10})_((0[0-9]{2}|100)\.[0-9]{3})$ ]] || return 1
+  pr="${BASH_REMATCH[1]}"; pc="${BASH_REMATCH[2]}"
+  _SLN_RST=$(( 10#$pr ))
+  _SLN_PCT=$(( 10#${pc:0:3} * 1000 + 10#${pc:4:3} ))
+  [ "$_SLN_PCT" -le 100000 ] || return 1
+}
+
+state_add_burn_path() {
+  local path="$1" name="$2" i plausible=0
+  _SB_RAW=$(( _SB_RAW + 1 ))
+  state_burn_name "$name" || return 0
+  [ -f "$path" ] && [ ! -L "$path" ] && [ ! -s "$path" ] || return 0
+  if [ "$_SBN_SAMP" -le $(( NOW + 300 )) ] && [ "$_SBN_RST" -ge "$_SBN_SAMP" ] \
+     && [ "$_SBN_RST" -le $(( NOW + RL_MAX_5H )) ]; then plausible=1; fi
+  i=${#_SB_NAMES[@]}
+  _SB_NAMES[$i]="$name"; _SB_PATHS[$i]="$path"; _SB_RSTS[$i]="$_SBN_RST"
+  _SB_SAMPS[$i]="$_SBN_SAMP"; _SB_PCTS[$i]="$_SBN_PCT"; _SB_PLAUS[$i]="$plausible"
+}
+
+state_add_limit_path() {  # $1=5|7 $2=path $3=name
+  local which="$1" path="$2" name="$3" i plausible=0 max
+  if [ "$which" = 5 ]; then _SL5_RAW=$(( _SL5_RAW + 1 )); max=$RL_MAX_5H
+  else _SL7_RAW=$(( _SL7_RAW + 1 )); max=$RL_MAX_7D; fi
+  state_limit_name "$name" || return 0
+  state_dir_empty "$path" || return 0
+  if [ "$_SLN_RST" -gt "$NOW" ] && [ "$_SLN_RST" -le $(( NOW + max )) ]; then plausible=1; fi
+  if [ "$which" = 5 ]; then
+    i=${#_SL5_NAMES[@]}; _SL5_NAMES[$i]="$name"; _SL5_PATHS[$i]="$path"
+    _SL5_RSTS[$i]="$_SLN_RST"; _SL5_PCTS[$i]="$_SLN_PCT"; _SL5_PLAUS[$i]="$plausible"
+  else
+    i=${#_SL7_NAMES[@]}; _SL7_NAMES[$i]="$name"; _SL7_PATHS[$i]="$path"
+    _SL7_RSTS[$i]="$_SLN_RST"; _SL7_PCTS[$i]="$_SLN_PCT"; _SL7_PLAUS[$i]="$plausible"
+  fi
+}
+
+state_add_legacy_record() {
+  local record="$1" a b c rest i
+  case "$record" in (*$'\t'*$'\t'*) ;; (*) return 1 ;; esac
+  a="${record%%$'\t'*}"; rest="${record#*$'\t'}"
+  b="${rest%%$'\t'*}"; c="${rest#*$'\t'}"
+  case "$c" in (*$'\t'*) return 1 ;; esac
+  [[ "$a" =~ ^[0-9]{12}$ ]] && [[ "$b" =~ ^[0-9]{12}$ ]] && [[ "$c" =~ ^[0-9]{1,6}$ ]] || return 1
+  [ "$(( 10#$c ))" -le 100000 ] || return 1
+  i=${#_LEG_RSTS[@]}
+  _LEG_RSTS[$i]=$(( 10#$a )); _LEG_SAMPS[$i]=$(( 10#$b )); _LEG_PCTS[$i]=$(( 10#$c ))
+}
+
+state_snapshot() {  # one framed controller for every gated state root + legacy TSV
+  local record name phase=paths ctrl=$'\001' f_seen=0 l_seen=0 e_seen=0 bad=0
+  local f_status=missing l_status=missing combined=0 matched stream_over=0
+  _LEG_RSTS=(); _LEG_SAMPS=(); _LEG_PCTS=()
+  exec 9< <(
+    if [ "${#_STATE_FIND_ARGS[@]}" -gt 0 ]; then
+      LC_ALL=C find -P "${_STATE_FIND_ARGS[@]}" ! -name . -prune -print0 2>/dev/null
+      _sf=$?
+    else
+      _sf=0
+    fi
+    printf '\001F:%s\0' "$_sf" || exit 0
+    if [ "$_STATE_LEGACY_READ" = 1 ]; then
+      LC_ALL=C od -An -v -N 1048577 -tu1 -- "$_SB_BASE" 2>/dev/null | LC_ALL=C awk \
+        -v now="$NOW" -v maxahead="$RL_MAX_5H" '
+        function pct_milli(raw, parts, whole, frac, six, keep, rest, milli, last) {
+          if (raw !~ /^(0|[1-9][0-9]?|100)(\.[0-9]{1,6})?$/) return -1
+          parts = split(raw, p, "."); whole = p[1]
+          frac = (parts == 2 ? p[2] : "")
+          if (whole == "100" && frac ~ /[1-9]/) return -1
+          six = substr(frac "000000", 1, 6)
+          keep = substr(six, 1, 3) + 0; rest = substr(six, 4, 3) + 0
+          milli = (whole + 0) * 1000 + keep
+          if (rest > 500 || (rest == 500 && milli % 2 == 1)) milli++
+          if (milli < 0 || milli > 100000) return -1
+          return milli
+        }
+        function epoch_ok(raw, value) {
+          if (raw !~ /^(0|[1-9][0-9]*)$/ || length(raw) > 12) return 0
+          if (length(raw) == 12 && raw > "253402300799") return 0
+          return 1
+        }
+        function finish_record( fields, nf, sample, reset, pctm, canon, slot) {
+          rows++
+          if (rows > 4096) { bad = 1; return }
+          if (!row_ascii) { rec = ""; rec_len = 0; row_ascii = 1; return }
+          nf = split(rec, fields, "\t")
+          if (nf == 3 && epoch_ok(fields[1]) && epoch_ok(fields[3])) {
+            sample = fields[1] + 0; reset = fields[3] + 0; pctm = pct_milli(fields[2])
+            if (pctm >= 0 && sample <= now + 300 && reset >= sample && reset <= now + maxahead) {
+              canon = sprintf("%012d\t%012d\t%d", reset, sample, pctm)
+              valid++
+              slot = ((valid - 1) % 512) + 1
+              ring[slot] = canon
             }
           }
+          rec = ""; rec_len = 0; row_ascii = 1
         }
-        if (ncross >= 2 && lc_t > fc_t && lc_p > fc_p && (lc_t - fc_t) >= minspan) {
-          rate = (lc_p - fc_p) / (lc_t - fc_t)
-          eta = (100 - lp) / rate; if (eta < 0) eta = 0
-          printf "active %.0f %.10f %d\n", eta, rate, ttr
-        } else if (anycross && ncross == 0) {
-          print "idle inf 0 " ttr
-        } else {
-          print "warming inf 0 " ttr
+        BEGIN { row_ascii = 1 }
+        {
+          for (i = 1; i <= NF; i++) {
+            byte = $i + 0; bytes++
+            if (bytes > 1048576) { bad = 1; exit 42 }
+            if (byte == 10) { finish_record(); if (bad) exit 42; continue }
+            rec_len++
+            if (rec_len > 4096) { bad = 1; exit 42 }
+            if (byte == 9 || byte == 46 || (byte >= 48 && byte <= 57)) rec = rec sprintf("%c", byte)
+            else row_ascii = 0
+          }
         }
-        # Trim on PHYSICAL rows (NR), not distinct seconds (n): sub-second render
-        # bursts (resize storms) append same-second rows that n dedups away, so an
-        # n-based cap would never fire and the file would grow unbounded. The
-        # rewrite emits the deduped last-`trim` seconds, so it also collapses the
-        # burst rows. Fires when the file exceeds the cap, or when a sentinel row
-        # was dropped above, so the poisoned row is purged from the file too (#32).
-        if (NR > trim || dropped) {
-          lo = n - trim + 1; if (lo < 1) lo = 1
-          for (i = lo; i <= n; i++)
-            printf "%d\t%s\t%d\n", ord[i], pct[ord[i]], rst[ord[i]] > tmp
-        }
-      }
-    }
-  ' "$BURN_FILE")
-  [ -f "$tmp" ] && mv "$tmp" "$BURN_FILE" 2>/dev/null
-  for _f in "$BURN_FILE".*.tmp; do        # sweep tmps orphaned by dead sessions
-    [ -e "$_f" ] || break                  # literal glob → no orphans
-    [ "$_f" = "$tmp" ] || rm -f "$_f" 2>/dev/null
+        END {
+          if (!bad && rec_len > 0) finish_record()
+          if (bad) exit 42
+          first = valid - 511; if (first < 1) first = 1
+          for (i = first; i <= valid; i++) printf "%s%c", ring[((i - 1) % 512) + 1], 0
+        }'
+      _sp=("${PIPESTATUS[@]}")
+      printf '\001L:%s:%s\0' "${_sp[0]}" "${_sp[1]}" || exit 0
+    else
+      printf '\001L:0:0\0' || exit 0
+    fi
+    printf '\001E\0'
+  )
+  while IFS= read -r -d '' -u 9 record; do
+    case "$record" in
+      ("${ctrl}F:"*)
+        [ "$phase" = paths ] && [ "$f_seen" -eq 0 ] || { bad=1; continue; }
+        f_seen=1; f_status="${record#?F:}"; phase=legacy
+        case "$f_status" in (''|*[!0-9]*) bad=1 ;; esac
+        ;;
+      ("${ctrl}L:"*)
+        [ "$phase" = legacy ] && [ "$l_seen" -eq 0 ] || { bad=1; continue; }
+        l_seen=1; l_status="${record#?L:}"; phase=end
+        case "$l_status" in ([0-9]*:[0-9]*) ;; (*) bad=1 ;; esac
+        ;;
+      ("${ctrl}E")
+        [ "$phase" = end ] && [ "$e_seen" -eq 0 ] || { bad=1; continue; }
+        e_seen=1; phase=done
+        ;;
+      (/*)
+        [ "$phase" = paths ] || { bad=1; continue; }
+        combined=$(( combined + 1 )); matched=0
+        if [ "$_STATE_BURN_GATE" = 1 ]; then
+          case "$record" in ("$_SB_ROOT/./"*) name="${record#"$_SB_ROOT/./"}"; state_add_burn_path "$_SB_ROOT/$name" "$name"; matched=1 ;; esac
+          [ "$_SB_RAW" -le 4096 ] || stream_over=1
+        fi
+        if [ "$matched" -eq 0 ] && [ "$_STATE_RL5_GATE" = 1 ]; then
+          case "$record" in ("$_SL5_ROOT/./"*) name="${record#"$_SL5_ROOT/./"}"; state_add_limit_path 5 "$_SL5_ROOT/$name" "$name"; matched=1 ;; esac
+          [ "$_SL5_RAW" -le 512 ] || stream_over=1
+        fi
+        if [ "$matched" -eq 0 ] && [ "$_STATE_RL7_GATE" = 1 ]; then
+          case "$record" in ("$_SL7_ROOT/./"*) name="${record#"$_SL7_ROOT/./"}"; state_add_limit_path 7 "$_SL7_ROOT/$name" "$name"; matched=1 ;; esac
+          [ "$_SL7_RAW" -le 512 ] || stream_over=1
+        fi
+        [ "$matched" -eq 1 ] || bad=1
+        [ "$combined" -le 5120 ] || stream_over=1
+        if [ "$stream_over" -eq 1 ]; then exec 9<&-; break; fi
+        ;;
+      (*)
+        if [ "$phase" = legacy ] && [ "${record:0:1}" != "$ctrl" ]; then
+          state_add_legacy_record "$record" || bad=1
+        else bad=1; fi
+        ;;
+    esac
   done
-  read -r _B5_STATE _B5_ETA _B5_RATE _B5_TTR <<EOF
-$out
-EOF
+  exec 9<&- 2>/dev/null || true
+  if [ "$stream_over" -eq 1 ]; then
+    _SB_DIR_COMPLETE=0; _SL5_COMPLETE=0; _SL7_COMPLETE=0; _LEG_COMPLETE=0
+    _LEG_RSTS=(); _LEG_SAMPS=(); _LEG_PCTS=()
+    return 0
+  fi
+  [ "$f_seen" -eq 1 ] && [ "$l_seen" -eq 1 ] && [ "$e_seen" -eq 1 ] && [ "$phase" = done ] || bad=1
+  [ "$bad" -eq 0 ] || { _SB_DIR_COMPLETE=0; _SL5_COMPLETE=0; _SL7_COMPLETE=0; _LEG_COMPLETE=0; _LEG_RSTS=(); _LEG_SAMPS=(); _LEG_PCTS=(); return 0; }
+  if [ "$f_status" = 0 ]; then
+    [ "$_SB_DIR_PREOK" = 1 ] && _SB_DIR_COMPLETE=1
+    [ "$_SL5_DIR_PREOK" = 1 ] && _SL5_COMPLETE=1
+    [ "$_SL7_DIR_PREOK" = 1 ] && _SL7_COMPLETE=1
+  fi
+  if [ "$l_status" = 0:0 ] && [ "$_LEG_PREOK" = 1 ]; then _LEG_COMPLETE=1
+  else _LEG_RSTS=(); _LEG_SAMPS=(); _LEG_PCTS=(); fi
 }
 
-burn_eta_7d() {  # → _B7_* (stateless); $1=pct(=wd_pct) $2=resets_at(=wd_rst)
-  local p7="${1:-$wd_pct}" r7="${2:-$wd_rst}"
-  _B7_ETA="inf"; _B7_RATE="0"; _B7_TTR="0"
-  [ -n "$p7" ] || return 0
-  to_epoch "$r7" || return 0
-  read -r _B7_ETA _B7_RATE _B7_TTR <<EOF
-$(awk -v p="$p7" -v r="$_EP" -v now="$NOW" 'BEGIN {
-    ttr = r - now; if (ttr < 0) ttr = 0
-    ws = r - 7 * 86400; el = now - ws
-    if (p + 0 <= 0 || el <= 0) { print "inf 0 " ttr; exit }
-    rate = (p + 0) / el
-    eta = (100 - (p + 0)) / rate; if (eta < 0) eta = 0
-    printf "%.0f %.10f %d\n", eta, rate, ttr
-  }')
-EOF
+state_sort_order() {  # → _SORT_ORDER; stable bottom-up merge sort of _SORT_KEYS
+  local n i width left mid right a b k pick LC_ALL=C
+  local work=()
+  _SORT_ORDER=(); n=${#_SORT_KEYS[@]}
+  for ((i=0; i<n; i++)); do _SORT_ORDER[$i]=$i; done
+  width=1
+  while [ "$width" -lt "$n" ]; do
+    work=(); left=0
+    while [ "$left" -lt "$n" ]; do
+      mid=$(( left + width )); [ "$mid" -gt "$n" ] && mid=$n
+      right=$(( left + width + width )); [ "$right" -gt "$n" ] && right=$n
+      a=$left; b=$mid; k=$left
+      while [ "$a" -lt "$mid" ] || [ "$b" -lt "$right" ]; do
+        if [ "$b" -ge "$right" ]; then pick=${_SORT_ORDER[$a]}; a=$(( a + 1 ))
+        elif [ "$a" -ge "$mid" ]; then pick=${_SORT_ORDER[$b]}; b=$(( b + 1 ))
+        elif [[ "${_SORT_KEYS[${_SORT_ORDER[$b]}]}" < "${_SORT_KEYS[${_SORT_ORDER[$a]}]}" ]]; then
+          pick=${_SORT_ORDER[$b]}; b=$(( b + 1 ))
+        else pick=${_SORT_ORDER[$a]}; a=$(( a + 1 ))
+        fi
+        work[$k]=$pick; k=$(( k + 1 ))
+      done
+      left=$right
+    done
+    _SORT_ORDER=("${work[@]}"); width=$(( width + width ))
+  done
+}
+
+state_sort_burn() {
+  local i j n
+  local names=() paths=() rsts=() samps=() pcts=() plaus=()
+  _SORT_KEYS=("${_SB_NAMES[@]}"); state_sort_order; n=${#_SORT_ORDER[@]}
+  for ((i=0; i<n; i++)); do
+    j=${_SORT_ORDER[$i]}; names[$i]="${_SB_NAMES[$j]}"; paths[$i]="${_SB_PATHS[$j]}"
+    rsts[$i]="${_SB_RSTS[$j]}"; samps[$i]="${_SB_SAMPS[$j]}"
+    pcts[$i]="${_SB_PCTS[$j]}"; plaus[$i]="${_SB_PLAUS[$j]}"
+  done
+  _SB_NAMES=("${names[@]}"); _SB_PATHS=("${paths[@]}"); _SB_RSTS=("${rsts[@]}")
+  _SB_SAMPS=("${samps[@]}"); _SB_PCTS=("${pcts[@]}"); _SB_PLAUS=("${plaus[@]}")
+  _SORT_KEYS=(); _SORT_ORDER=()
+}
+
+state_sort_limit() {  # $1=5|7
+  local which="$1" i j n
+  local names=() paths=() rsts=() pcts=() plaus=()
+  if [ "$which" = 5 ]; then _SORT_KEYS=("${_SL5_NAMES[@]}"); else _SORT_KEYS=("${_SL7_NAMES[@]}"); fi
+  state_sort_order; n=${#_SORT_ORDER[@]}
+  for ((i=0; i<n; i++)); do
+    j=${_SORT_ORDER[$i]}
+    if [ "$which" = 5 ]; then
+      names[$i]="${_SL5_NAMES[$j]}"; paths[$i]="${_SL5_PATHS[$j]}"; rsts[$i]="${_SL5_RSTS[$j]}"
+      pcts[$i]="${_SL5_PCTS[$j]}"; plaus[$i]="${_SL5_PLAUS[$j]}"
+    else
+      names[$i]="${_SL7_NAMES[$j]}"; paths[$i]="${_SL7_PATHS[$j]}"; rsts[$i]="${_SL7_RSTS[$j]}"
+      pcts[$i]="${_SL7_PCTS[$j]}"; plaus[$i]="${_SL7_PLAUS[$j]}"
+    fi
+  done
+  if [ "$which" = 5 ]; then
+    _SL5_NAMES=("${names[@]}"); _SL5_PATHS=("${paths[@]}"); _SL5_RSTS=("${rsts[@]}")
+    _SL5_PCTS=("${pcts[@]}"); _SL5_PLAUS=("${plaus[@]}")
+  else
+    _SL7_NAMES=("${names[@]}"); _SL7_PATHS=("${paths[@]}"); _SL7_RSTS=("${rsts[@]}")
+    _SL7_PCTS=("${pcts[@]}"); _SL7_PLAUS=("${plaus[@]}")
+  fi
+  _SORT_KEYS=(); _SORT_ORDER=()
+}
+
+state_burn_retention() {
+  local i n key group_key="" rep=-1 j keep_from reps=0 LC_ALL=C
+  local group=() rep_names=() rep_paths=() rep_rsts=() rep_samps=() rep_pcts=()
+  _SB_CAND_NAMES=(); _SB_CAND_PATHS=()
+  state_sort_burn
+  n=${#_SB_NAMES[@]}
+  for ((i=0; i<=n; i++)); do
+    if [ "$i" -lt "$n" ] && [ "${_SB_PLAUS[$i]}" = 1 ]; then key="${_SB_RSTS[$i]}_${_SB_SAMPS[$i]}"; else key=""; fi
+    if [ -n "$group_key" ] && { [ "$key" != "$group_key" ] || [ "$i" -eq "$n" ]; }; then
+      for j in "${group[@]}"; do
+        if [ "$j" -ne "$rep" ]; then
+          _SB_CAND_NAMES[${#_SB_CAND_NAMES[@]}]="${_SB_NAMES[$j]}"
+          _SB_CAND_PATHS[${#_SB_CAND_PATHS[@]}]="${_SB_PATHS[$j]}"
+        fi
+      done
+      rep_names[$reps]="${_SB_NAMES[$rep]}"; rep_paths[$reps]="${_SB_PATHS[$rep]}"
+      rep_rsts[$reps]="${_SB_RSTS[$rep]}"; rep_samps[$reps]="${_SB_SAMPS[$rep]}"; rep_pcts[$reps]="${_SB_PCTS[$rep]}"
+      reps=$(( reps + 1 )); group=(); group_key=""; rep=-1
+    fi
+    [ "$i" -lt "$n" ] || continue
+    if [ "${_SB_PLAUS[$i]}" != 1 ]; then
+      _SB_CAND_NAMES[${#_SB_CAND_NAMES[@]}]="${_SB_NAMES[$i]}"
+      _SB_CAND_PATHS[${#_SB_CAND_PATHS[@]}]="${_SB_PATHS[$i]}"
+      continue
+    fi
+    key="${_SB_RSTS[$i]}_${_SB_SAMPS[$i]}"
+    if [ -z "$group_key" ]; then group_key="$key"; rep=$i; group=($i)
+    else
+      group[${#group[@]}]=$i
+      if [ "${_SB_PCTS[$i]}" -gt "${_SB_PCTS[$rep]}" ] || { [ "${_SB_PCTS[$i]}" -eq "${_SB_PCTS[$rep]}" ] && [[ "${_SB_NAMES[$i]}" < "${_SB_NAMES[$rep]}" ]]; }; then rep=$i; fi
+    fi
+  done
+  keep_from=$(( reps - BURN_TRIM )); [ "$keep_from" -lt 0 ] && keep_from=0
+  for ((i=0; i<keep_from; i++)); do
+    _SB_CAND_NAMES[${#_SB_CAND_NAMES[@]}]="${rep_names[$i]}"
+    _SB_CAND_PATHS[${#_SB_CAND_PATHS[@]}]="${rep_paths[$i]}"
+  done
+  _SB_REP_RSTS=(); _SB_REP_SAMPS=(); _SB_REP_PCTS=()
+  for ((i=0; i<reps; i++)); do
+    _SB_REP_RSTS[${#_SB_REP_RSTS[@]}]="${rep_rsts[$i]}"
+    _SB_REP_SAMPS[${#_SB_REP_SAMPS[@]}]="${rep_samps[$i]}"
+    _SB_REP_PCTS[${#_SB_REP_PCTS[@]}]="${rep_pcts[$i]}"
+  done
+  _SB_CAND_TOTAL=${#_SB_CAND_PATHS[@]}
+}
+
+state_limit_retention() {  # $1=5|7
+  local which="$1" i n winner=-1
+  state_sort_limit "$which"
+  if [ "$which" = 5 ]; then
+    _SL5_CAND_NAMES=(); _SL5_CAND_PATHS=(); n=${#_SL5_NAMES[@]}
+    for ((i=0; i<n; i++)); do [ "${_SL5_PLAUS[$i]}" = 1 ] && winner=$i; done
+    for ((i=0; i<n; i++)); do
+      [ "$i" -eq "$winner" ] && continue
+      _SL5_CAND_NAMES[${#_SL5_CAND_NAMES[@]}]="${_SL5_NAMES[$i]}"; _SL5_CAND_PATHS[${#_SL5_CAND_PATHS[@]}]="${_SL5_PATHS[$i]}"
+    done
+    _SL5_CAND_TOTAL=${#_SL5_CAND_PATHS[@]}; _SL5_STORED_VALID=0
+    if [ "$winner" -ge 0 ]; then _SL5_STORED_VALID=1; _SL5_STORED_RST="${_SL5_RSTS[$winner]}"; _SL5_STORED_PCT="${_SL5_PCTS[$winner]}"; fi
+  else
+    _SL7_CAND_NAMES=(); _SL7_CAND_PATHS=(); n=${#_SL7_NAMES[@]}
+    for ((i=0; i<n; i++)); do [ "${_SL7_PLAUS[$i]}" = 1 ] && winner=$i; done
+    for ((i=0; i<n; i++)); do
+      [ "$i" -eq "$winner" ] && continue
+      _SL7_CAND_NAMES[${#_SL7_CAND_NAMES[@]}]="${_SL7_NAMES[$i]}"; _SL7_CAND_PATHS[${#_SL7_CAND_PATHS[@]}]="${_SL7_PATHS[$i]}"
+    done
+    _SL7_CAND_TOTAL=${#_SL7_CAND_PATHS[@]}; _SL7_STORED_VALID=0
+    if [ "$winner" -ge 0 ]; then _SL7_STORED_VALID=1; _SL7_STORED_RST="${_SL7_RSTS[$winner]}"; _SL7_STORED_PCT="${_SL7_PCTS[$winner]}"; fi
+  fi
+}
+
+state_revalidate_burn() {
+  local path="$1" name="$2"
+  [ "$path" = "$_SB_ROOT/$name" ] || return 1
+  state_no_symlink_path "$_SB_ROOT" || return 1
+  [ "$_SNP" = "$_SB_ROOT" ] && [ -d "$_SB_ROOT" ] || return 1
+  state_burn_name "$name" || return 1
+  [ -f "$path" ] && [ ! -L "$path" ] && [ ! -s "$path" ]
+}
+
+state_revalidate_limit() {
+  local root="$1" path="$2" name="$3"
+  [ "$path" = "$root/$name" ] || return 1
+  state_no_symlink_path "$root" || return 1
+  [ "$_SNP" = "$root" ] && [ -d "$root" ] || return 1
+  state_limit_name "$name" || return 1
+  state_dir_empty "$path"
+}
+
+state_gc() {
+  local i limit path name id idx resolved_b=0 resolved_5=0 resolved_7=0
+  local rm_paths=() rm_ids=() rm_indexes=()
+  _SB_REMOVED=0; _SL5_REMOVED=0; _SL7_REMOVED=0
+  if [ "$_STATE_MUTATE" = 1 ] && [ "$_SB_COMPLETE" = 1 ]; then
+    limit=${#_SB_CAND_PATHS[@]}; [ "$limit" -gt 128 ] && limit=128
+    for ((i=0; i<limit; i++)); do
+      path="${_SB_CAND_PATHS[$i]}"; name="${_SB_CAND_NAMES[$i]}"
+      if [ ! -e "$path" ] && [ ! -L "$path" ]; then resolved_b=$(( resolved_b + 1 ))
+      elif state_revalidate_burn "$path" "$name"; then
+        idx=${#rm_paths[@]}; rm_paths[$idx]="$path"; rm_ids[$idx]=b; rm_indexes[$idx]=$i
+      fi
+    done
+  fi
+  if [ "$_STATE_MUTATE" = 1 ] && [ "$_SL5_COMPLETE" = 1 ]; then
+    limit=${#_SL5_CAND_PATHS[@]}; [ "$limit" -gt 128 ] && limit=128
+    for ((i=0; i<limit; i++)); do
+      path="${_SL5_CAND_PATHS[$i]}"; name="${_SL5_CAND_NAMES[$i]}"
+      if [ ! -e "$path" ] && [ ! -L "$path" ]; then resolved_5=$(( resolved_5 + 1 ))
+      elif state_revalidate_limit "$_SL5_ROOT" "$path" "$name"; then
+        idx=${#rm_paths[@]}; rm_paths[$idx]="$path"; rm_ids[$idx]=5; rm_indexes[$idx]=$i
+      fi
+    done
+  fi
+  if [ "$_STATE_MUTATE" = 1 ] && [ "$_SL7_COMPLETE" = 1 ]; then
+    limit=${#_SL7_CAND_PATHS[@]}; [ "$limit" -gt 128 ] && limit=128
+    for ((i=0; i<limit; i++)); do
+      path="${_SL7_CAND_PATHS[$i]}"; name="${_SL7_CAND_NAMES[$i]}"
+      if [ ! -e "$path" ] && [ ! -L "$path" ]; then resolved_7=$(( resolved_7 + 1 ))
+      elif state_revalidate_limit "$_SL7_ROOT" "$path" "$name"; then
+        idx=${#rm_paths[@]}; rm_paths[$idx]="$path"; rm_ids[$idx]=7; rm_indexes[$idx]=$i
+      fi
+    done
+  fi
+  if [ "${#rm_paths[@]}" -gt 0 ]; then rm -df -- "${rm_paths[@]}" 2>/dev/null || true; fi
+  for ((i=0; i<${#rm_paths[@]}; i++)); do
+    path="${rm_paths[$i]}"; id="${rm_ids[$i]}"
+    if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+      case "$id" in (b) resolved_b=$(( resolved_b + 1 )) ;; (5) resolved_5=$(( resolved_5 + 1 )) ;; (7) resolved_7=$(( resolved_7 + 1 )) ;; esac
+    fi
+  done
+  _SB_REMOVED=$resolved_b; _SL5_REMOVED=$resolved_5; _SL7_REMOVED=$resolved_7
+  _SB_CLEAN=0; _SL5_CLEAN=0; _SL7_CLEAN=0
+  [ "$_SB_CAND_TOTAL" -eq "$resolved_b" ] && _SB_CLEAN=1
+  [ "$_SL5_CAND_TOTAL" -eq "$resolved_5" ] && _SL5_CLEAN=1
+  [ "$_SL7_CAND_TOTAL" -eq "$resolved_7" ] && _SL7_CLEAN=1
+}
+
+state_select_limit() {  # $1=5|7, includes the current canonical payload value
+  local which="$1" valid=0 rst=0 pct=0 crst cpct
+  if [ "$which" = 5 ]; then
+    if [ "$_SL5_COMPLETE" = 1 ] && [ "$_SL5_STORED_VALID" = 1 ]; then valid=1; rst=$_SL5_STORED_RST; pct=$_SL5_STORED_PCT; fi
+    if [ "$_CUR5_VALID" = 1 ]; then crst=$_CUR5_RST; cpct=$_CUR5_PCT
+    else crst=0; cpct=0; fi
+  else
+    if [ "$_SL7_COMPLETE" = 1 ] && [ "$_SL7_STORED_VALID" = 1 ]; then valid=1; rst=$_SL7_STORED_RST; pct=$_SL7_STORED_PCT; fi
+    if [ "$_CUR7_VALID" = 1 ]; then crst=$_CUR7_RST; cpct=$_CUR7_PCT
+    else crst=0; cpct=0; fi
+  fi
+  if [ "$crst" -gt 0 ] && { [ "$valid" -eq 0 ] || [ "$crst" -gt "$rst" ] || { [ "$crst" -eq "$rst" ] && [ "$cpct" -gt "$pct" ]; }; }; then
+    valid=1; rst=$crst; pct=$cpct
+  fi
+  if [ "$which" = 5 ]; then _STATE_RL5_VALID=$valid; _STATE_RL5_RST=$rst; _STATE_RL5_PCT=$pct
+  else _STATE_RL7_VALID=$valid; _STATE_RL7_RST=$rst; _STATE_RL7_PCT=$pct; fi
+}
+
+state_publish() {
+  local raw_post i slot name path
+  local mkdir_paths=()
+  _PUB_BURN=0; _PUB5=0; _PUB7=0
+  if [ "$_STATE_MUTATE" = 1 ] && [ "$_SB_COMPLETE" = 1 ] && [ "$_SB_CLEAN" = 1 ] && [ "$_CUR_BURN_VALID" = 1 ]; then
+    raw_post=$(( _SB_RAW - _SB_REMOVED ))
+    [ "$raw_post" -lt 3968 ] && _PUB_BURN=1
+  fi
+  if [ "$_STATE_MUTATE" = 1 ] && [ "$_SL5_COMPLETE" = 1 ] && [ "$_SL5_CLEAN" = 1 ] && [ "$_CUR5_VALID" = 1 ]; then
+    raw_post=$(( _SL5_RAW - _SL5_REMOVED )); [ "$raw_post" -lt 384 ] && _PUB5=1
+  fi
+  if [ "$_STATE_MUTATE" = 1 ] && [ "$_SL7_COMPLETE" = 1 ] && [ "$_SL7_CLEAN" = 1 ] && [ "$_CUR7_VALID" = 1 ]; then
+    raw_post=$(( _SL7_RAW - _SL7_REMOVED )); [ "$raw_post" -lt 384 ] && _PUB7=1
+  fi
+  if [ "$_PUB_BURN" = 1 ] && [ ! -d "$_SB_ROOT" ]; then
+    state_no_symlink_path "$_SB_ROOT" && mkdir_paths[${#mkdir_paths[@]}]="$_SB_ROOT" || _PUB_BURN=0
+  fi
+  if [ "$_PUB5" = 1 ]; then
+    printf -v name '%010d_%03d.%03d' "$_CUR5_RST" $(( _CUR5_PCT / 1000 )) $(( _CUR5_PCT % 1000 ))
+    _PUB5_PATH="$_SL5_ROOT/$name"
+    state_no_symlink_path "$_PUB5_PATH" && mkdir_paths[${#mkdir_paths[@]}]="$_PUB5_PATH" || _PUB5=0
+  fi
+  if [ "$_PUB7" = 1 ]; then
+    printf -v name '%010d_%03d.%03d' "$_CUR7_RST" $(( _CUR7_PCT / 1000 )) $(( _CUR7_PCT % 1000 ))
+    _PUB7_PATH="$_SL7_ROOT/$name"
+    state_no_symlink_path "$_PUB7_PATH" && mkdir_paths[${#mkdir_paths[@]}]="$_PUB7_PATH" || _PUB7=0
+  fi
+  if [ "${#mkdir_paths[@]}" -gt 0 ]; then mkdir -p -- "${mkdir_paths[@]}" 2>/dev/null || true; fi
+  if [ "$_PUB5" = 1 ]; then state_revalidate_limit "$_SL5_ROOT" "$_PUB5_PATH" "${_PUB5_PATH##*/}" || _PUB5=0; fi
+  if [ "$_PUB7" = 1 ]; then state_revalidate_limit "$_SL7_ROOT" "$_PUB7_PATH" "${_PUB7_PATH##*/}" || _PUB7=0; fi
+  if [ "$_PUB_BURN" = 1 ]; then
+    state_no_symlink_path "$_SB_ROOT" || _PUB_BURN=0
+    [ "$_SNP" = "$_SB_ROOT" ] && [ -d "$_SB_ROOT" ] && [ ! -L "$_SB_ROOT" ] || _PUB_BURN=0
+  fi
+  if [ "$_PUB_BURN" = 1 ]; then
+    set -C
+    for ((slot=0; slot<32; slot++)); do
+      printf -v name 'b_%012d_%012d_%03d.%03d_%04d' "$_CUR_BURN_RST" "$_CUR_BURN_SAMP" \
+        $(( _CUR_BURN_PCT / 1000 )) $(( _CUR_BURN_PCT % 1000 )) "$slot"
+      path="$_SB_ROOT/$name"
+      if { : > "$path"; } 2>/dev/null; then _PUB_BURN_PATH="$path"; break; fi
+      [ -e "$path" ] || [ -L "$path" ] || break
+    done
+    set +C
+  fi
+}
+
+state_est_insert() {  # insert one observation into _EST_* ordered by reset/sample/pct
+  local rst="$1" samp="$2" pct="$3" key i j n LC_ALL=C
+  printf -v key '%012d_%012d_%06d' "$rst" "$samp" "$pct"
+  n=${#_EST_KEYS[@]}; j=$n
+  while [ "$j" -gt 0 ] && [[ "$key" < "${_EST_KEYS[$((j-1))]}" ]]; do
+    _EST_KEYS[$j]="${_EST_KEYS[$((j-1))]}"; _EST_RSTS[$j]="${_EST_RSTS[$((j-1))]}"
+    _EST_SAMPS[$j]="${_EST_SAMPS[$((j-1))]}"; _EST_PCTS[$j]="${_EST_PCTS[$((j-1))]}"; j=$(( j - 1 ))
+  done
+  _EST_KEYS[$j]="$key"; _EST_RSTS[$j]="$rst"; _EST_SAMPS[$j]="$samp"; _EST_PCTS[$j]="$pct"
+}
+
+burn_eta_5h() {  # → _B5_STATE _B5_ETA _B5_RATE _B5_TTR from complete state snapshot
+  local i n maxrst=0 rst samp pct last_key="" last_samp=-1 last_pct=0
+  local a b ct cutoff fc_t=0 fc_p=-1 lc_t=0 lc_p=-1 ncross=0 anycross=0
+  local minspan span delta latest_pct=0
+  _B5_STATE=warming; _B5_ETA=inf; _B5_RATE="0.0000000000"; _B5_TTR=0
+  [ "$_SB_COMPLETE" = 1 ] || return 0
+  for ((i=0; i<${#_SB_REP_RSTS[@]}; i++)); do [ "${_SB_REP_RSTS[$i]}" -gt "$maxrst" ] && maxrst="${_SB_REP_RSTS[$i]}"; done
+  for ((i=0; i<${#_LEG_RSTS[@]}; i++)); do [ "${_LEG_RSTS[$i]}" -gt "$maxrst" ] && maxrst="${_LEG_RSTS[$i]}"; done
+  [ "$_CUR_BURN_VALID" != 1 ] || [ "$_CUR_BURN_RST" -le "$maxrst" ] || maxrst=$_CUR_BURN_RST
+  [ "$maxrst" -gt 0 ] || return 0
+  _EST_KEYS=(); _EST_RSTS=(); _EST_SAMPS=(); _EST_PCTS=()
+  for ((i=0; i<${#_SB_REP_RSTS[@]}; i++)); do
+    [ "${_SB_REP_RSTS[$i]}" -eq "$maxrst" ] && state_est_insert "${_SB_REP_RSTS[$i]}" "${_SB_REP_SAMPS[$i]}" "${_SB_REP_PCTS[$i]}"
+  done
+  for ((i=0; i<${#_LEG_RSTS[@]}; i++)); do
+    [ "${_LEG_RSTS[$i]}" -eq "$maxrst" ] && state_est_insert "${_LEG_RSTS[$i]}" "${_LEG_SAMPS[$i]}" "${_LEG_PCTS[$i]}"
+  done
+  [ "$_CUR_BURN_VALID" != 1 ] || [ "$_CUR_BURN_RST" -ne "$maxrst" ] || state_est_insert "$_CUR_BURN_RST" "$_CUR_BURN_SAMP" "$_CUR_BURN_PCT"
+  _SER_SAMPS=(); _SER_PCTS=(); n=${#_EST_KEYS[@]}
+  for ((i=0; i<n; i++)); do
+    rst="${_EST_RSTS[$i]}"; samp="${_EST_SAMPS[$i]}"; pct="${_EST_PCTS[$i]}"
+    key="${rst}_${samp}_${pct}"
+    [ "$key" = "$last_key" ] && continue
+    last_key="$key"
+    if [ "$samp" -ne "$last_samp" ]; then
+      _SER_SAMPS[${#_SER_SAMPS[@]}]="$samp"; _SER_PCTS[${#_SER_PCTS[@]}]="$pct"; last_samp=$samp
+    elif [ "$pct" -gt "${_SER_PCTS[$(( ${#_SER_PCTS[@]} - 1 ))]}" ]; then
+      _SER_PCTS[$(( ${#_SER_PCTS[@]} - 1 ))]="$pct"
+    fi
+  done
+  n=${#_SER_SAMPS[@]}; [ "$n" -gt 0 ] || return 0
+  latest_pct="${_SER_PCTS[$((n-1))]}"; _B5_TTR=$(( maxrst - NOW )); [ "$_B5_TTR" -lt 0 ] && _B5_TTR=0
+  cutoff=$(( NOW - CORALLINE_BURN_WINDOW )); minspan=$(( CORALLINE_BURN_WINDOW / 10 ))
+  for ((i=1; i<n; i++)); do
+    a=$(( ${_SER_PCTS[$((i-1))]} / 1000 )); b=$(( ${_SER_PCTS[$i]} / 1000 ))
+    if [ "$b" -gt "$a" ]; then
+      anycross=1; ct="${_SER_SAMPS[$i]}"
+      if [ "$ct" -ge "$cutoff" ] && [ "$ct" -le "$NOW" ]; then
+        if [ "$fc_p" -lt 0 ]; then fc_t=$ct; fc_p=$b; fi
+        lc_t=$ct; lc_p=$b; ncross=$(( ncross + 1 ))
+      fi
+    fi
+  done
+  if [ "$ncross" -ge 2 ] && [ "$lc_t" -gt "$fc_t" ] && [ "$lc_p" -gt "$fc_p" ] && [ $(( lc_t - fc_t )) -ge "$minspan" ]; then
+    span=$(( lc_t - fc_t )); delta=$(( lc_p - fc_p ))
+    state_rate10 $(( delta * 10000000000 )) "$span"; _B5_RATE="$_RATE10"
+    state_round_even $(( (100000 - latest_pct) * span )) $(( delta * 1000 ))
+    _B5_ETA=$_RE; _B5_STATE=active
+  elif [ "$anycross" -eq 1 ] && [ "$ncross" -eq 0 ]; then _B5_STATE=idle
+  fi
+}
+
+burn_eta_7d() {  # → _B7_*; $1=pct_milli $2=reset epoch
+  local pct="${1:-}" rst="${2:-}" elapsed
+  _B7_ETA=inf; _B7_RATE="0.0000000000"; _B7_TTR=0
+  [ -n "$pct" ] && [ -n "$rst" ] || return 0
+  _B7_TTR=$(( rst - NOW )); [ "$_B7_TTR" -lt 0 ] && _B7_TTR=0
+  elapsed=$(( NOW - (rst - 604800) ))
+  [ "$pct" -gt 0 ] && [ "$elapsed" -ge 1 ] && [ "$elapsed" -le "$RL_MAX_7D" ] || return 0
+  state_rate10 $(( pct * 10000000 )) "$elapsed"; _B7_RATE="$_RATE10"
+  state_round_even $(( (100000 - pct) * elapsed )) "$pct"; _B7_ETA=$_RE
 }
 
 burn_estimate() {  # → _BURN_STATE _BURN_LABEL _BURN_ETA _BURN_RATE _BURN_TTR
-  burn_eta_5h
-  # 5h already reads the shared sample file, so it is cross-session. For 7d, when
-  # limit-sync is on, project from the same synced value the limit7d segment shows
-  # so burn and limit7d cannot contradict each other on a stale local snapshot.
-  if [ "$VL_LIMIT_SYNC" = "1" ]; then
-    rl_latest "$RL7D_FILE" "$RL_MAX_7D"
-    if [ -n "$_LL_PCT" ]; then burn_eta_7d "$_LL_PCT" "$_LL_RST"; else burn_eta_7d; fi
-  else
-    burn_eta_7d
-  fi
   local f5=0 f7=0
-  [ "$_B5_ETA" != "inf" ] && f5=1
-  [ "$_B7_ETA" != "inf" ] && f7=1
+  [ "$_B5_ETA" != inf ] && f5=1
+  [ "$_B7_ETA" != inf ] && f7=1
   if [ "$f5" = 1 ] && { [ "$f7" = 0 ] || [ "$_B5_ETA" -le "$_B7_ETA" ]; }; then
-    _BURN_STATE="active"; _BURN_LABEL="5h"
-    _BURN_ETA="$_B5_ETA"; _BURN_RATE="$_B5_RATE"; _BURN_TTR="$_B5_TTR"
+    _BURN_STATE=active; _BURN_LABEL=5h; _BURN_ETA=$_B5_ETA; _BURN_RATE=$_B5_RATE; _BURN_TTR=$_B5_TTR
   elif [ "$f7" = 1 ]; then
-    _BURN_STATE="active"; _BURN_LABEL="7d"
-    _BURN_ETA="$_B7_ETA"; _BURN_RATE="$_B7_RATE"; _BURN_TTR="$_B7_TTR"
+    _BURN_STATE=active; _BURN_LABEL=7d; _BURN_ETA=$_B7_ETA; _BURN_RATE=$_B7_RATE; _BURN_TTR=$_B7_TTR
   else
-    _BURN_ETA="inf"; _BURN_RATE="0"; _BURN_TTR="0"; _BURN_LABEL=""
-    if [ "$_B5_STATE" = "idle" ]; then _BURN_STATE="idle"; else _BURN_STATE="warming"; fi
+    _BURN_ETA=inf; _BURN_RATE="0.0000000000"; _BURN_TTR=0; _BURN_LABEL=""
+    if [ "$_B5_STATE" = idle ]; then _BURN_STATE=idle; else _BURN_STATE=warming; fi
   fi
 }
 
+state_prepare() {  # one state snapshot/GC/publication/estimate pass per render
+  local root i
+  _STATE_MUTATE=1; [ "${CORALLINE_NO_SAMPLE:-0}" = 1 ] && _STATE_MUTATE=0
+  RL_MAX_5H=21600; RL_MAX_7D=691200
+  case "$CORALLINE_BURN_WINDOW" in (''|*[!0-9]*) CORALLINE_BURN_WINDOW=600 ;; esac
+  [ "${#CORALLINE_BURN_WINDOW}" -le 5 ] && [ "$CORALLINE_BURN_WINDOW" -ge 60 ] 2>/dev/null \
+    && [ "$CORALLINE_BURN_WINDOW" -le 86400 ] 2>/dev/null || CORALLINE_BURN_WINDOW=600
+  case "$BURN_TRIM" in (''|*[!0-9]*) BURN_TRIM=1500 ;; esac
+  [ "${#BURN_TRIM}" -le 4 ] && [ "$BURN_TRIM" -ge 1 ] 2>/dev/null \
+    && [ "$BURN_TRIM" -le 3000 ] 2>/dev/null || BURN_TRIM=1500
+
+  _CUR5_VALID=0; _CUR7_VALID=0; _CUR_BURN_VALID=0
+  if state_pct "$fh_pct"; then
+    _CUR5_PCT=$_SP_MILLI
+    if state_payload_epoch "$fh_rst" 10; then
+      _CUR5_RST=$_SE_VALUE; _CUR5_RST_PAD=$_SE_PAD
+      [ "$_CUR5_RST" -gt "$NOW" ] && [ "$_CUR5_RST" -le $(( NOW + RL_MAX_5H )) ] && _CUR5_VALID=1
+    fi
+  fi
+  if state_pct "$wd_pct"; then
+    _CUR7_PCT=$_SP_MILLI
+    if state_payload_epoch "$wd_rst" 10; then
+      _CUR7_RST=$_SE_VALUE; _CUR7_RST_PAD=$_SE_PAD
+      [ "$_CUR7_RST" -gt "$NOW" ] && [ "$_CUR7_RST" -le $(( NOW + RL_MAX_7D )) ] && _CUR7_VALID=1
+    fi
+  fi
+  if [ "$_CUR5_VALID" = 1 ]; then
+    state_epoch "$NOW" 12
+    _CUR_BURN_SAMP=$_SE_VALUE; _CUR_BURN_SAMP_PAD=$_SE_PAD
+    _CUR_BURN_RST=$_CUR5_RST; _CUR_BURN_PCT=$_CUR5_PCT
+    [ "$_CUR_BURN_SAMP" -le $(( NOW + 300 )) ] && [ "$_CUR_BURN_RST" -ge "$_CUR_BURN_SAMP" ] && _CUR_BURN_VALID=1
+  fi
+
+  _SB_NAMES=(); _SB_PATHS=(); _SB_RSTS=(); _SB_SAMPS=(); _SB_PCTS=(); _SB_PLAUS=(); _SB_RAW=0
+  _SL5_NAMES=(); _SL5_PATHS=(); _SL5_RSTS=(); _SL5_PCTS=(); _SL5_PLAUS=(); _SL5_RAW=0
+  _SL7_NAMES=(); _SL7_PATHS=(); _SL7_RSTS=(); _SL7_PCTS=(); _SL7_PLAUS=(); _SL7_RAW=0
+  _STATE_FIND_ARGS=(); _STATE_LEGACY_READ=0
+  _SB_DIR_PREOK=1; _SL5_DIR_PREOK=1; _SL7_DIR_PREOK=1; _LEG_PREOK=1
+  _SB_DIR_COMPLETE=0; _SL5_COMPLETE=0; _SL7_COMPLETE=0; _LEG_COMPLETE=0; _SB_COMPLETE=0
+
+  if [ "$_STATE_BURN_GATE" = 1 ]; then
+    if state_store_path "$BURN_FILE"; then _SB_BASE=$_SS_BASE; _SB_ROOT=$_SS_ROOT
+    else _SB_DIR_PREOK=0; _LEG_PREOK=0; fi
+    if [ "$_SB_DIR_PREOK" = 1 ]; then
+      state_no_symlink_path "$_SB_ROOT" || _SB_DIR_PREOK=0
+      if [ "$_SB_DIR_PREOK" = 1 ] && { [ -e "$_SB_ROOT" ] || [ -L "$_SB_ROOT" ]; }; then
+        [ -d "$_SB_ROOT" ] && [ ! -L "$_SB_ROOT" ] || _SB_DIR_PREOK=0
+        [ "$_SB_DIR_PREOK" = 0 ] || _STATE_FIND_ARGS[${#_STATE_FIND_ARGS[@]}]="$_SB_ROOT/."
+      fi
+      state_no_symlink_path "$_SB_BASE" || _LEG_PREOK=0
+      if [ "$_LEG_PREOK" = 1 ] && { [ -e "$_SB_BASE" ] || [ -L "$_SB_BASE" ]; }; then
+        [ -f "$_SB_BASE" ] && [ ! -L "$_SB_BASE" ] || _LEG_PREOK=0
+        [ "$_LEG_PREOK" = 0 ] || _STATE_LEGACY_READ=1
+      fi
+    fi
+  fi
+  if [ "$_STATE_RL5_GATE" = 1 ]; then
+    if state_store_path "$RL5H_FILE"; then _SL5_ROOT=$_SS_ROOT; else _SL5_DIR_PREOK=0; fi
+    if [ "$_SL5_DIR_PREOK" = 1 ]; then
+      state_no_symlink_path "$_SL5_ROOT" || _SL5_DIR_PREOK=0
+      if [ "$_SL5_DIR_PREOK" = 1 ] && { [ -e "$_SL5_ROOT" ] || [ -L "$_SL5_ROOT" ]; }; then
+        [ -d "$_SL5_ROOT" ] && [ ! -L "$_SL5_ROOT" ] || _SL5_DIR_PREOK=0
+        [ "$_SL5_DIR_PREOK" = 0 ] || _STATE_FIND_ARGS[${#_STATE_FIND_ARGS[@]}]="$_SL5_ROOT/."
+      fi
+    fi
+  fi
+  if [ "$_STATE_RL7_GATE" = 1 ]; then
+    if state_store_path "$RL7D_FILE"; then _SL7_ROOT=$_SS_ROOT; else _SL7_DIR_PREOK=0; fi
+    if [ "$_SL7_DIR_PREOK" = 1 ]; then
+      state_no_symlink_path "$_SL7_ROOT" || _SL7_DIR_PREOK=0
+      if [ "$_SL7_DIR_PREOK" = 1 ] && { [ -e "$_SL7_ROOT" ] || [ -L "$_SL7_ROOT" ]; }; then
+        [ -d "$_SL7_ROOT" ] && [ ! -L "$_SL7_ROOT" ] || _SL7_DIR_PREOK=0
+        [ "$_SL7_DIR_PREOK" = 0 ] || _STATE_FIND_ARGS[${#_STATE_FIND_ARGS[@]}]="$_SL7_ROOT/."
+      fi
+    fi
+  fi
+  if [ "$_STATE_BURN_GATE" = 1 ] && [ "$_STATE_RL5_GATE" = 1 ] && state_same_path "$_SB_ROOT" "$_SL5_ROOT"; then _SB_DIR_PREOK=0; _SL5_DIR_PREOK=0; fi
+  if [ "$_STATE_BURN_GATE" = 1 ] && [ "$_STATE_RL7_GATE" = 1 ] && state_same_path "$_SB_ROOT" "$_SL7_ROOT"; then _SB_DIR_PREOK=0; _SL7_DIR_PREOK=0; fi
+  if [ "$_STATE_RL5_GATE" = 1 ] && [ "$_STATE_RL7_GATE" = 1 ] && state_same_path "$_SL5_ROOT" "$_SL7_ROOT"; then _SL5_DIR_PREOK=0; _SL7_DIR_PREOK=0; fi
+
+  state_snapshot
+  if [ "$_STATE_BURN_GATE" = 1 ]; then [ "$_SB_DIR_COMPLETE" = 1 ] && [ "$_LEG_COMPLETE" = 1 ] && _SB_COMPLETE=1; fi
+  if [ "$_SB_COMPLETE" = 1 ]; then state_burn_retention; else _SB_CAND_NAMES=(); _SB_CAND_PATHS=(); _SB_CAND_TOTAL=0; _SB_REP_RSTS=(); _SB_REP_SAMPS=(); _SB_REP_PCTS=(); fi
+  if [ "$_SL5_COMPLETE" = 1 ]; then state_limit_retention 5; else _SL5_CAND_NAMES=(); _SL5_CAND_PATHS=(); _SL5_CAND_TOTAL=0; _SL5_STORED_VALID=0; fi
+  if [ "$_SL7_COMPLETE" = 1 ]; then state_limit_retention 7; else _SL7_CAND_NAMES=(); _SL7_CAND_PATHS=(); _SL7_CAND_TOTAL=0; _SL7_STORED_VALID=0; fi
+  state_gc
+  state_select_limit 5; state_select_limit 7
+  state_publish
+  burn_eta_5h
+  if [ "$VL_LIMIT_SYNC" = 1 ] && [ "$_STATE_RL7_VALID" = 1 ]; then burn_eta_7d "$_STATE_RL7_PCT" "$_STATE_RL7_RST"
+  elif [ "$_CUR7_VALID" = 1 ]; then burn_eta_7d "$_CUR7_PCT" "$_CUR7_RST"
+  else burn_eta_7d "" ""; fi
+  burn_estimate
+  _STATE_READY=1
+}
+
 seg_burn() {  # range-to-empty ETA until the binding 5h/7d limit hits 100% at the recent burn rate
-  [ -n "$fh_pct" ] || [ -n "$wd_pct" ] || return 0
+  if [ "${_STATE_READY:-0}" = 1 ]; then
+    [ "${_CUR5_VALID:-0}" = 1 ] || [ "${_CUR7_VALID:-0}" = 1 ] || return 0
+  else
+    [ -n "$fh_pct" ] || [ -n "$wd_pct" ] || return 0
+  fi
   # _BURN_* is precomputed once per render (see the burn_estimate call beside the
   # sampler below), so the visible and float passes share one computation.
   local bg="${VL_BG_BURN:-$VL_BG_5H}"
@@ -786,31 +1370,33 @@ seg_ctx() {  # context-window gauge with input/output/cache token counts
   push "$VL_BG_CTX" "${fgc} ${VL_CTX_GLYPH} ${_BAR} ${ci}% ${fgd}↑${ti} ↓${to} cr:${tcr} cw:${tcw} "
 }
 
-seg_limit() {  # $1=label $2=pct $3=resets_at $4=bg
+seg_limit() {  # $1=label $2=pct $3=resets_at $4=bg $5=canonical pct_milli(optional)
   [ -n "$2" ] || return 0
   local v fgc rst=""
-  printf -v v '%.0f' "$2" 2>/dev/null || v=0
+  if [ -n "${5:-}" ]; then state_round_even "$5" 1000; v=$_RE
+  else printf -v v '%.0f' "$2" 2>/dev/null || v=0; fi
   make_bar "$v"; pct_fg "$v"
   fg "$_PFG"; fgc="$_FG"
   fmt_countdown "$3"
   if [ -n "$_CD" ]; then fg "$VL_FG_DIM"; rst="${_FG}↺${_CD}"; fi
   push "$4" "${fgc} $1 ${_BAR} ${v}% ${rst} "
 }
-# With VL_LIMIT_SYNC, show the freshest cross-session value for the current
-# window (falling back to this session's own snapshot when none is recorded).
+# With VL_LIMIT_SYNC, render the once-per-render canonical state result.
 seg_limit5h() {  # 5h rate-limit gauge with reset countdown
-  local p="$fh_pct" r="$fh_rst"
-  if [ "$VL_LIMIT_SYNC" = "1" ]; then
-    rl_latest "$RL5H_FILE" "$RL_MAX_5H"; [ -n "$_LL_PCT" ] && { p="$_LL_PCT"; r="$_LL_RST"; }
+  local p="$fh_pct" r="$fh_rst" m=""
+  if [ "$VL_LIMIT_SYNC" = 1 ]; then
+    [ "${_STATE_RL5_VALID:-0}" = 1 ] || return 0
+    m=$_STATE_RL5_PCT; printf -v p '%d.%03d' $(( m / 1000 )) $(( m % 1000 )); r=$_STATE_RL5_RST
   fi
-  seg_limit "5h" "$p" "$r" "$VL_BG_5H"
+  seg_limit "5h" "$p" "$r" "$VL_BG_5H" "$m"
 }
 seg_limit7d() {  # 7d rate-limit gauge with reset countdown
-  local p="$wd_pct" r="$wd_rst"
-  if [ "$VL_LIMIT_SYNC" = "1" ]; then
-    rl_latest "$RL7D_FILE" "$RL_MAX_7D"; [ -n "$_LL_PCT" ] && { p="$_LL_PCT"; r="$_LL_RST"; }
+  local p="$wd_pct" r="$wd_rst" m=""
+  if [ "$VL_LIMIT_SYNC" = 1 ]; then
+    [ "${_STATE_RL7_VALID:-0}" = 1 ] || return 0
+    m=$_STATE_RL7_PCT; printf -v p '%d.%03d' $(( m / 1000 )) $(( m % 1000 )); r=$_STATE_RL7_RST
   fi
-  seg_limit "7d" "$p" "$r" "$VL_BG_7D"
+  seg_limit "7d" "$p" "$r" "$VL_BG_7D" "$m"
 }
 
 seg_cost() {  # session cost in USD
@@ -1202,27 +1788,18 @@ _SEG_SCAN=" $VL_SEGMENTS $VL_SEGMENTS2 $VL_SEGMENTS3 "
 [ "$VL_FLOAT" = "1" ] && _SEG_SCAN="$_SEG_SCAN$VL_FLOAT_SEGMENTS "
 case "$_SEG_SCAN" in *" git "*|*" stash "*|*" project "*) read_git ;; esac
 
-# Sample only when the burn segment is actually shown — the segment list is the
-# single source of truth, so enabling burn in configure.sh just works. _SEG_SCAN
-# also covers VL_FLOAT_SEGMENTS, so burn samples even when it's only in the float
-# readout (mirrors how read_git is gated above).
-#
-# CORALLINE_NO_SAMPLE=1 makes a render read-only: it skips every write to the
-# cross-session stores. A preview/verification render (sample-input.json carries
-# a year-2030 sentinel reset) would otherwise win the high-water forever and prune
-# the real entries, so the documented preview commands set this flag (see #32).
-if [ "${CORALLINE_NO_SAMPLE:-0}" != 1 ]; then
-  case "$_SEG_SCAN" in *" burn "*) burn_sample "$NOW" "$fh_pct" "$fh_rst" ;; esac
-  # limit-sync records to its own high-water store (separate from the burn file),
-  # only for the limit segment that is actually shown.
-  if [ "$VL_LIMIT_SYNC" = "1" ]; then
-    case "$_SEG_SCAN" in *" limit5h "*) rl_sample "$RL5H_FILE" "$fh_pct" "$fh_rst" "$RL_MAX_5H" ;; esac
-    # burn also consumes the synced 7d (below), so sample it whenever burn shows too,
-    # otherwise burn would read a stale/older synced 7d instead of this render's value.
-    case "$_SEG_SCAN" in *" limit7d "*|*" burn "*) rl_sample "$RL7D_FILE" "$wd_pct" "$wd_rst" "$RL_MAX_7D" ;; esac
-  fi
+# Burn and synced limits share one bounded snapshot. The disabled/default path
+# never opens the controller; CORALLINE_NO_SAMPLE keeps the same reads but makes
+# GC, publication, healing, and root creation impossible.
+_STATE_READY=0; _STATE_BURN_GATE=0; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0
+case "$_SEG_SCAN" in (*" burn "*) _STATE_BURN_GATE=1 ;; esac
+if [ "$VL_LIMIT_SYNC" = 1 ]; then
+  case "$_SEG_SCAN" in (*" limit5h "*) _STATE_RL5_GATE=1 ;; esac
+  case "$_SEG_SCAN" in (*" limit7d "*|*" burn "*) _STATE_RL7_GATE=1 ;; esac
 fi
-case "$_SEG_SCAN" in *" burn "*) burn_estimate ;; esac
+if [ "$_STATE_BURN_GATE" = 1 ] || [ "$_STATE_RL5_GATE" = 1 ] || [ "$_STATE_RL7_GATE" = 1 ]; then
+  state_prepare
+fi
 
 # Defensive ANSI stripper (the VL_NOCOLOR path should already emit none) → _PLAIN.
 strip_ansi() {

--- a/statusline.sh
+++ b/statusline.sh
@@ -697,6 +697,7 @@ state_sort_order() {  # → _SORT_ORDER; stable bottom-up merge sort of _SORT_KE
 state_sort_burn() {
   local i j n
   local names=() paths=() rsts=() samps=() pcts=() plaus=()
+  [ "${#_SB_NAMES[@]}" -gt 0 ] || return 0
   _SORT_KEYS=("${_SB_NAMES[@]}"); state_sort_order; n=${#_SORT_ORDER[@]}
   for ((i=0; i<n; i++)); do
     j=${_SORT_ORDER[$i]}; names[$i]="${_SB_NAMES[$j]}"; paths[$i]="${_SB_PATHS[$j]}"
@@ -711,7 +712,13 @@ state_sort_burn() {
 state_sort_limit() {  # $1=5|7
   local which="$1" i j n
   local names=() paths=() rsts=() pcts=() plaus=()
-  if [ "$which" = 5 ]; then _SORT_KEYS=("${_SL5_NAMES[@]}"); else _SORT_KEYS=("${_SL7_NAMES[@]}"); fi
+  if [ "$which" = 5 ]; then
+    [ "${#_SL5_NAMES[@]}" -gt 0 ] || return 0
+    _SORT_KEYS=("${_SL5_NAMES[@]}")
+  else
+    [ "${#_SL7_NAMES[@]}" -gt 0 ] || return 0
+    _SORT_KEYS=("${_SL7_NAMES[@]}")
+  fi
   state_sort_order; n=${#_SORT_ORDER[@]}
   for ((i=0; i<n; i++)); do
     j=${_SORT_ORDER[$i]}

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -1,364 +1,407 @@
 #!/usr/bin/env bash
-# Unit tests for the burn-rate segment helpers. Each function is pulled live
-# from statusline.sh so the tests can never drift from the implementation.
-#   bash test/test-burn.sh
+# Immutable burn / limit state regressions. Helpers are extracted live from the
+# runtime so the parser, estimator, and trust-boundary tests cannot drift.
 set -u
 HERE=$(cd "$(dirname "$0")" && pwd)
 SCRIPT="$HERE/../statusline.sh"
-TMPD=$(mktemp -d)
-trap 'rm -rf "$TMPD"' EXIT
+case "$(uname -s)" in Darwin) TEST_TMP=/private/tmp ;; *) TEST_TMP=${TMPDIR:-/tmp} ;; esac
+TMPD=$(mktemp -d "$TEST_TMP/coralline-burn.XXXXXX")
+trap 'rm -rf "$TMPD"' EXIT HUP INT TERM
 fail=0
-ok()   { printf 'ok    %s\n' "$1"; }
-bad()  { printf 'FAIL  %s — %s\n' "$1" "$2"; fail=1; }
-eq()   { [ "$2" = "$3" ] && ok "$1" || bad "$1" "want=$3 got=$2"; }
+pass=0
+ok() { printf 'ok    %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf 'FAIL  %s — %s\n' "$1" "$2"; fail=$((fail + 1)); }
+eq() { [ "$2" = "$3" ] && ok "$1" || bad "$1" "want=$3 got=$2"; }
+true_case() { local name="$1"; shift; if "$@"; then ok "$name"; else bad "$name" "condition failed"; fi; }
+count_entries() {
+  _COUNT=0
+  [ -d "$1" ] || return 0
+  for _CE in "$1"/* "$1"/.[!.]* "$1"/..?*; do
+    [ -e "$_CE" ] || [ -L "$_CE" ] || continue
+    _COUNT=$(( _COUNT + 1 ))
+  done
+}
+first_name() {
+  _FIRST=""
+  for _FN in "$1"/*; do [ -e "$_FN" ] || continue; _FIRST=${_FN##*/}; break; done
+}
 
-# Pull the helpers under test out of the real script.
-eval "$(sed -n '/^to_epoch() {/,/^}/p'     "$SCRIPT")"
-eval "$(sed -n '/^fmt_eta() {/,/^}/p'       "$SCRIPT")"
-eval "$(sed -n '/^burn_sample() {/,/^}/p'   "$SCRIPT")"
+# Pull the production implementations. The state block ends immediately before
+# seg_burn; delete that opening line so eval sees complete function definitions.
+eval "$(sed -n '/^to_epoch() {/,/^}/p' "$SCRIPT")"
+eval "$(sed -n '/^fmt_eta() {/,/^}/p' "$SCRIPT")"
+eval "$(sed -n '/^state_pct() {/,/^seg_burn() {/p' "$SCRIPT" | sed '$d')"
+eval "$(sed -n '/^fg() {/,/^}/p' "$SCRIPT")"
+eval "$(sed -n '/^push() {/,/^}/p' "$SCRIPT")"
+eval "$(sed -n '/^seg_burn() {/,/^}/p' "$SCRIPT")"
 
-# Per-window sentinel ceilings the samplers reference (mirrors statusline.sh; #32).
-RL_MAX_5H=$(( 6 * 3600 )); RL_MAX_7D=$(( 8 * 86400 ))
-
-# fmt_eta
-fmt_eta 0;       eq "fmt_eta 0m"     "$_ETA" "0m"
-fmt_eta 2820;    eq "fmt_eta 47m"    "$_ETA" "47m"
-fmt_eta 7080;    eq "fmt_eta 1h58m"  "$_ETA" "1h58m"
-fmt_eta 127800;  eq "fmt_eta 1d11h"  "$_ETA" "1d11h"
-
-# burn_sample appends one row with the reset converted to epoch
-BURN_FILE="$TMPD/burn.tsv"
-burn_sample 1781794590 6 1781811000
-eq "sample row" "$(cat "$BURN_FILE")" "$(printf '1781794590\t6\t1781811000')"
-
-# empty pct → no-op (file unchanged)
-burn_sample 1781794600 "" 1781811000
-eq "sample empty-pct no-op" "$(wc -l < "$BURN_FILE" | tr -d ' ')" "1"
-
-# missing parent dir → created on demand, sample still written (issue #17 bug)
-BURN_FILE="$TMPD/nodir/burn.tsv"
-burn_sample 1781794590 6 1781811000
-eq "sample creates missing dir" "$(cat "$BURN_FILE" 2>/dev/null)" "$(printf '1781794590\t6\t1781811000')"
-
-eval "$(sed -n '/^burn_eta_5h() {/,/^}/p' "$SCRIPT")"
+RL_MAX_5H=21600
+RL_MAX_7D=691200
 CORALLINE_BURN_WINDOW=600
 BURN_TRIM=1500
+VL_LIMIT_SYNC=0
+CORALLINE_NO_SAMPLE=0
 
-# rl_sample / rl_latest: directory-as-set high-water store (cross-session limit sync).
-# Entry = <reset:%010d>_<pct:%07.3f> dir; read = max; gc = drop below-max. So pct
-# reads back fixed-width (e.g. 034.000), which display (%.0f) and burn (awk +0) parse.
-eval "$(sed -n '/^rl_dir() {/,/^}/p'    "$SCRIPT")"
-eval "$(sed -n '/^rl_sample() {/,/^}/p' "$SCRIPT")"
-eval "$(sed -n '/^rl_latest() {/,/^}/p' "$SCRIPT")"
-RLF="$TMPD/limit.tsv"
-# mixed windows: current window = latest reset (2000), its max pct = 34. pct 51
-# belongs to an OLDER window (reset 1500) and must not win.
-rl_sample "$RLF" 10 1000; rl_sample "$RLF" 34 2000; rl_sample "$RLF" 31 2000
-rl_sample "$RLF" 9 2000;  rl_sample "$RLF" 51 1500
-rl_latest "$RLF"
-eq "rl_latest pct" "$_LL_PCT" "034.000"
-eq "rl_latest rst" "$_LL_RST" "2000"
-# same-window cache-lag: highest pct wins regardless of insertion order
-rm -rf "$TMPD/limit.d"
-rl_sample "$RLF" 40 2000; rl_sample "$RLF" 44 2000; rl_sample "$RLF" 41 2000
-rl_latest "$RLF"; eq "rl_latest same-window max" "$_LL_PCT" "044.000"
-# fractional pct preserved (not quantized to an integer)
-rm -rf "$TMPD/limit.d"
-rl_sample "$RLF" 41.2 2000
-rl_latest "$RLF"; eq "rl_latest float pct" "$_LL_PCT" "041.200"
-# missing store → empty (caller falls back to the session's own snapshot)
-rl_latest "$TMPD/none.tsv"; eq "rl_latest missing" "$_LL_PCT" ""
-# a brand-new window (later reset, lower pct) supersedes the old high-water
-rm -rf "$TMPD/limit.d"
-rl_sample "$RLF" 80 2000; rl_sample "$RLF" 3 9000
-rl_latest "$RLF"; eq "rl_latest new window pct" "$_LL_PCT" "003.000"
-eq "rl_latest new window rst" "$_LL_RST" "9000"
-# leading-zero reset must decode as decimal, not octal (10# guard)
-rm -rf "$TMPD/limit.d"
-rl_sample "$RLF" 5 8; rl_latest "$RLF"; eq "rl_latest octal-safe rst" "$_LL_RST" "8"
-# gc keeps only the current-window high-water entry after a read
-rm -rf "$TMPD/limit.d"
-rl_sample "$RLF" 50 2000; rl_sample "$RLF" 48 2000; rl_sample "$RLF" 47 2000
-rl_latest "$RLF"
-eq "rl_latest gc keeps one" "$(ls -1 "$TMPD/limit.d" | wc -l | tr -d ' ')" "1"
-rl_latest "$RLF"; eq "rl_latest gc keeps max" "$_LL_PCT" "050.000"
-# migration: a legacy flat-file store is removed when the dir-set is first created
-rm -rf "$TMPD/limit.d"; printf 'x' > "$TMPD/limit.tsv"
-rl_sample "$RLF" 12 2000
-eq "rl legacy flat-file removed" "$([ -e "$TMPD/limit.tsv" ] && echo present || echo gone)" "gone"
-eq "rl dir-set created"          "$([ -d "$TMPD/limit.d" ]  && echo yes || echo no)" "yes"
+# Strict percent grammar and exact decimal ties-to-even canonicalization.
+pct_case() {
+  if state_pct "$2"; then eq "$1 milli" "$_SP_MILLI" "$3"; eq "$1 canonical" "$_SP_CANON" "$4"
+  else bad "$1" "unexpected rejection"; fi
+}
+pct_reject() { if state_pct "$2"; then bad "$1" "accepted as $_SP_CANON"; else ok "$1"; fi; }
+pct_case 'pct zero' '0' 0 '000.000'
+pct_case 'pct integer' '41' 41000 '041.000'
+pct_case 'pct six decimals' '41.200000' 41200 '041.200'
+pct_case 'pct even midpoint stays' '1.2345' 1234 '001.234'
+pct_case 'pct odd midpoint rises' '1.2355' 1236 '001.236'
+pct_case 'pct below midpoint' '1.234499' 1234 '001.234'
+pct_case 'pct above midpoint' '1.234501' 1235 '001.235'
+pct_case 'pct carry to 100' '99.9995' 100000 '100.000'
+pct_case 'pct exact 100' '100.000000' 100000 '100.000'
+for _BAD_PCT in -0 00 01 +1 ' 1' '1 ' 100.000001 1,2 1e2 NaN Infinity 1.1234567 .5; do
+  pct_reject "pct rejects $_BAD_PCT" "$_BAD_PCT"
+done
 
-# sentinel guard (#32): a far-future reset (e.g. sample-input.json's year-2030
-# preview value) must be dropped when NOW is known, so a preview render can never
-# win the high-water and prune the real window. NOW is set for these cases only.
-RLS="$TMPD/limit-sentinel.tsv"; NOW=1781794590
-rl_sample "$RLS" 30 1781811000 "$RL_MAX_5H"           # real ~4.5h window: kept
-rl_sample "$RLS" 99 1893490200 "$RL_MAX_5H"           # 2030 sentinel: dropped
-rl_latest "$RLS" "$RL_MAX_5H"
-eq "rl_sample drops sentinel pct" "$_LL_PCT" "030.000"
-eq "rl_sample drops sentinel rst" "$_LL_RST" "1781811000"
-# per-window ceiling: a 5h reset days out is corrupt (a 5h window resets within
-# hours), but the same offset is valid for the 7d window. The ceiling is the caller's.
-RLW="$TMPD/limit-window.tsv"; twodays=$(( NOW + 2*86400 ))
-rl_sample "$RLW" 20 "$twodays" "$RL_MAX_5H"           # 2d out under 5h ceiling: dropped
-rl_latest "$RLW" "$RL_MAX_5H"; eq "rl 5h ceiling drops 2d reset" "$_LL_PCT" ""
-rl_sample "$RLW" 20 "$twodays" "$RL_MAX_7D"           # 2d out under 7d ceiling: kept
-rl_latest "$RLW" "$RL_MAX_7D"; eq "rl 7d ceiling keeps 2d reset" "$_LL_PCT" "020.000"
-# read-side heal: a store poisoned BEFORE this fix already holds the sentinel entry.
-# On read rl_latest must ignore it for the high-water AND rmdir it, so the next real
-# render recovers instead of staying pinned.
-RLH="$TMPD/limit-heal.tsv"; rl_dir "$RLH"; mkdir -p "$_RLD"
-mkdir "$_RLD/1781811000_030.000" "$_RLD/1893490200_099.000"   # real entry + 2030 sentinel
-rl_latest "$RLH" "$RL_MAX_5H"
-eq "rl_latest heals poisoned pct"  "$_LL_PCT" "030.000"
-eq "rl_latest heals poisoned rst"  "$_LL_RST" "1781811000"
-eq "rl_latest prunes sentinel dir" "$([ -d "$_RLD/1893490200_099.000" ] && echo present || echo gone)" "gone"
-# burn_sample applies the 5h bound, keyed off its own now ($1)
-BURN_FILE="$TMPD/burn-sentinel.tsv"
-burn_sample 1781794590 50 1781811000                  # real window: appended
-burn_sample 1781794590 99 1893490200                  # 2030 sentinel: dropped
-eq "burn_sample drops sentinel" "$([ -f "$BURN_FILE" ] && wc -l < "$BURN_FILE" | tr -d ' ' || echo 0)" "1"
-NOW=""
+# Strict epochs: no signs, decimals, leading zeroes, or overflow.
+state_epoch 0 12; eq 'epoch zero' "$_SE_PAD" '000000000000'
+state_epoch 253402300799 12; eq 'epoch max' "$_SE_VALUE" '253402300799'
+state_epoch 9999999999 10; eq 'limit epoch max' "$_SE_PAD" '9999999999'
+for _BAD_EP in -0 +1 01 1.0 253402300800 10000000000; do
+  if state_epoch "$_BAD_EP" 10; then bad "epoch rejects $_BAD_EP" "accepted $_SE_PAD"; else ok "epoch rejects $_BAD_EP"; fi
+done
 
-# helper: write a fixture and run the estimator at a given "now"
-run5h() { BURN_FILE="$TMPD/b5.tsv"; printf '%b' "$1" > "$BURN_FILE"; NOW="$2"; burn_eta_5h; }
+# Exact rational midpoint-to-even and fixed ten-decimal rates.
+state_round_even 5 2; eq 'round-even 2.5 to even' "$_RE" 2
+state_round_even 7 2; eq 'round-even 3.5 to even' "$_RE" 4
+state_round_even 4 3; eq 'round-even below half' "$_RE" 1
+state_round_even 5 3; eq 'round-even above half' "$_RE" 2
+state_rate10 10000000000 3; eq 'rate non-divisible' "$_RATE10" '0.3333333333'
+state_rate10 19999999999 2; eq 'rate rounding carry' "$_RATE10" '1.0000000000'
 
-# active: 6→7 at +60s, 7→8 at +300s; now=+360s; reset 4h25m out.
-# crossings in window: (60,7),(300,8) → rate=(8-7)/(300-60)=1/240 %/s
-# now pct=8 → ETA=(100-8)/(1/240)=22080s=6h08m
-run5h "1000000\t6\t1015900\n1000060\t7\t1015900\n1000300\t8\t1015900\n1000360\t8\t1015900\n" 1000360
-eq "5h active state" "$_B5_STATE" "active"
-eq "5h active eta"   "$_B5_ETA"   "22080"
-eq "5h ttr"          "$_B5_TTR"   "15540"
+# Store derivation and MSYS/native-drive path identity are lexical and fork-free.
+PWD_SAVE=$PWD
+cd "$TMPD"
+state_store_path relative.tsv; eq 'relative store root' "$_SS_ROOT" "$TMPD/relative.d"
+state_store_path C:/tmp/state.tsv; eq 'native drive store root' "$_SS_ROOT" '/c/tmp/state.d'
+state_store_path 'C:\tmp\state.tsv'; eq 'backslash drive store root' "$_SS_ROOT" '/c/tmp/state.d'
+state_store_path /c/tmp/state.tsv; eq 'MSYS drive store root' "$_SS_ROOT" '/c/tmp/state.d'
+cd "$PWD_SAVE"
 
-# read-side heal: a burn file poisoned before this fix holds a far-future reset row.
-# burn_eta_5h must ignore it (fit the real window, not stay warming) and purge it,
-# so the same active fit lands and the sentinel row is gone from the file.
-run5h "1000000\t6\t1015900\n1000060\t7\t1015900\n1000300\t8\t1015900\n1000360\t8\t1015900\n9999000\t41\t99999999\n" 1000360
-eq "burn read ignores sentinel state" "$_B5_STATE" "active"
-eq "burn read ignores sentinel eta"   "$_B5_ETA"   "22080"
-eq "burn read purges sentinel" "$(grep -c 99999999 "$TMPD/b5.tsv" | tr -d ' ')" "0"
+reset_state_case() {
+  local root="$1"
+  rm -rf "$root"; mkdir -p "$root"
+  BURN_FILE="$root/burn.tsv"; RL5H_FILE="$root/limit5.tsv"; RL7D_FILE="$root/limit7.tsv"
+  NOW=1000000; fh_pct=41.2; fh_rst=1015900; wd_pct=30; wd_rst=1345600
+  CORALLINE_BURN_WINDOW=600; BURN_TRIM=1500; VL_LIMIT_SYNC=1; CORALLINE_NO_SAMPLE=0
+  _STATE_BURN_GATE=1; _STATE_RL5_GATE=1; _STATE_RL7_GATE=1; _STATE_READY=0
+}
 
-# idle: only crossing is older than the 600s window (at +0s); now=+1200s
-run5h "1000000\t6\t1015900\n1000010\t7\t1015900\n1001200\t7\t1015900\n" 1001200
-eq "5h idle state" "$_B5_STATE" "idle"
-eq "5h idle eta"   "$_B5_ETA"   "inf"
+# Store-root identity covers exact strings, existing filesystem objects, and the
+# conservative Darwin/MSYS case rule without leaking nocasematch state.
+true_case 'same-path exact string' state_same_path "$TMPD/missing-root" "$TMPD/missing-root"
+mkdir -p "$TMPD/same-object"
+true_case 'same-path existing filesystem object' state_same_path "$TMPD/same-object" "$TMPD/same-object/."
+_NCM_WAS=0; shopt -q nocasematch && _NCM_WAS=1
+shopt -u nocasematch
+case "${OSTYPE:-}" in
+  (darwin*|mingw*|msys*) true_case 'same-path conservatively folds platform case' state_same_path "$TMPD/Missing-Root" "$TMPD/missing-root" ;;
+  (*) if state_same_path "$TMPD/Missing-Root" "$TMPD/missing-root"; then bad 'same-path keeps case-sensitive spellings distinct' 'reported same path'; else ok 'same-path keeps case-sensitive spellings distinct'; fi ;;
+esac
+if shopt -q nocasematch; then bad 'same-path restores disabled nocasematch' 'left enabled'; else ok 'same-path restores disabled nocasematch'; fi
+shopt -s nocasematch
+state_same_path "$TMPD/Missing-Root" "$TMPD/missing-root" >/dev/null 2>&1 || true
+if shopt -q nocasematch; then ok 'same-path preserves enabled nocasematch'; else bad 'same-path preserves enabled nocasematch' 'left disabled'; fi
+[ "$_NCM_WAS" = 1 ] || shopt -u nocasematch
 
-# warming: a single crossing, in window
-run5h "1000000\t6\t1015900\n1000060\t7\t1015900\n" 1000100
-eq "5h warming state" "$_B5_STATE" "warming"
-eq "5h warming eta"   "$_B5_ETA"   "inf"
-
-# reset: pct drops mid-file → pre-drop discarded, then only one crossing → warming
-run5h "1000000\t80\t1004000\n1000060\t81\t1004000\n1000120\t1\t1019000\n1000180\t2\t1019000\n" 1000200
-eq "5h reset→warming" "$_B5_STATE" "warming"
-
-# empty file → warming/inf
-run5h "" 1000000
-eq "5h empty state" "$_B5_STATE" "warming"
-eq "5h empty eta"   "$_B5_ETA"   "inf"
-
-# cross-window isolation: a shared file where an idle session's stale snapshots
-# (50,51 / older reset 1010000) are interleaved with the current window
-# (6,7,8 / later reset 1015900). The estimate must use ONLY the current window —
-# pre-fix the mixed series mis-fit; now it fits the real 6→7→8 slope.
-# crossings (current window): (1000120,7),(1000300,8) → rate=1/180 %/s
-# now pct=8 → ETA=(100-8)*180=16560s
-run5h "1000000\t6\t1015900\n1000060\t50\t1010000\n1000120\t7\t1015900\n1000180\t51\t1010000\n1000300\t8\t1015900\n1000360\t8\t1015900\n" 1000360
-eq "5h cross-window state" "$_B5_STATE" "active"
-eq "5h cross-window eta"   "$_B5_ETA"   "16560"
-eq "5h cross-window ttr"   "$_B5_TTR"   "15540"
-
-# same-window jitter: concurrent sessions' caches disagree by a point or two, so
-# pct dips mid-window (13→12) though usage only ever rises. A decrease used to
-# reset `start` to the tail and fit the slope over the last 1-2 samples (1s apart)
-# → bogus ~1m ETA. Now the fit is anchored at the window start and spans the
-# first→last crossing: (1000150,11)→(1000400,16) = 5%/250s, lp=16 → ETA=84/0.02=4200.
-run5h "1000050\t10\t1015900\n1000150\t11\t1015900\n1000380\t13\t1015900\n1000398\t12\t1015900\n1000399\t14\t1015900\n1000400\t16\t1015900\n" 1000400
-eq "5h jitter state" "$_B5_STATE" "active"
-eq "5h jitter eta"   "$_B5_ETA"   "4200"
-eq "5h jitter ttr"   "$_B5_TTR"   "15500"
-
-# min-span guard: a tiny late burst (two crossings 2s apart, nothing earlier in
-# window) is too short to trust → warming, not a wild fast ETA.
-run5h "1000000\t9\t1015900\n1000398\t10\t1015900\n1000400\t11\t1015900\n" 1000400
-eq "5h short-span guard" "$_B5_STATE" "warming"
-
-# but a genuine fast burn that spans more than the guard (win/10=60s) must show,
-# not be hidden as warming: 1→5→9→10 over 90s. fc=(1000010,5) lc=(1000100,10),
-# span=90s ≥ 60s → rate=5/90, lp=10 → ETA=90/(5/90)=1620.
-run5h "1000000\t1\t1015900\n1000010\t5\t1015900\n1000070\t9\t1015900\n1000100\t10\t1015900\n" 1000100
-eq "5h fast-burn shows state" "$_B5_STATE" "active"
-eq "5h fast-burn shows eta"   "$_B5_ETA"   "1620"
-
-# trim: 5 rows, trim=3 → file keeps last 3
-BURN_TRIM=3
-run5h "1\t6\t9\n2\t6\t9\n3\t7\t9\n4\t7\t9\n5\t8\t9\n" 6
-eq "5h trim rowcount" "$(wc -l < "$TMPD/b5.tsv" | tr -d ' ')" "3"
-eq "5h trim first-kept" "$(head -1 "$TMPD/b5.tsv" | cut -f1)" "3"
-# trim on PHYSICAL rows: 6 same-second rows (only 2 distinct seconds) with trim=3
-# must still trim — a distinct-second cap would never fire and the file would grow.
-BURN_TRIM=3
-run5h "1\t6\t9\n1\t6\t9\n1\t6\t9\n2\t7\t9\n2\t7\t9\n2\t7\t9\n" 3
-eq "5h trim same-second rows" "$(wc -l < "$TMPD/b5.tsv" | tr -d ' ')" "2"
-BURN_TRIM=1500
-
-eval "$(sed -n '/^burn_eta_7d() {/,/^}/p' "$SCRIPT")"
-
-# 7d: used 30%, window opened 3 days ago (elapsed=259200s), reset 4 days out.
-# rate=30/259200 %/s; ETA=(100-30)/rate=70*259200/30=604800s=7d00h
-WS=$(( 1000000 - 259200 )); R7=$(( WS + 604800 ))
-wd_pct=30; wd_rst=$R7; NOW=1000000; burn_eta_7d
-eq "7d eta"  "$_B7_ETA" "604800"
-eq "7d ttr"  "$_B7_TTR" "345600"
-
-# 7d unused → inf
-wd_pct=0; wd_rst=$R7; NOW=1000000; burn_eta_7d
-eq "7d unused eta" "$_B7_ETA" "inf"
-
-# 7d not reported → inf
-wd_pct=""; wd_rst=""; NOW=1000000; burn_eta_7d
-eq "7d empty eta" "$_B7_ETA" "inf"
-
-eval "$(sed -n '/^fg() {/,/^}/p'            "$SCRIPT")"
-eval "$(sed -n '/^push() {/,/^}/p'          "$SCRIPT")"
-eval "$(sed -n '/^burn_estimate() {/,/^}/p' "$SCRIPT")"
-eval "$(sed -n '/^seg_burn() {/,/^}/p'      "$SCRIPT")"
-VL_BURN_GLYPH="↗"; VL_BG_BURN=""; VL_BG_5H=237; VL_LAYOUT="fixed"
-VL_FG_OK=114; VL_FG_WARN=179; VL_FG_HOT=167; VL_FG_DIM=245
-VL_NOCOLOR=0   # fg()/push() reference it (statusline default); set under `set -u`
-VL_LIMIT_SYNC=0   # burn_estimate branches on it (statusline default); set under `set -u`
-fh_pct=8 wd_pct=0
-
-# stub the two estimators so binding logic is tested in isolation
-mk5h() { _B5_STATE="$1"; _B5_ETA="$2"; _B5_RATE="$3"; _B5_TTR="$4"; }
-mk7d() {                 _B7_ETA="$1"; _B7_RATE="$2"; _B7_TTR="$3"; }
-burn_eta_5h() { mk5h "$M5S" "$M5E" "$M5R" "$M5T"; }
-burn_eta_7d() { mk7d "$M7E" "$M7R" "$M7T"; }
-
-# 5h roomy (eta 6h), 7d binding (eta 2h) → label 7d
-M5S=active M5E=21600 M5R=0 M5T=15000  M7E=7200 M7R=0 M7T=86400
-burn_estimate
-eq "binding label 7d"  "$_BURN_LABEL" "7d"
-eq "binding eta 7d"    "$_BURN_ETA"   "7200"
-
-# 5h binding (eta 1h) vs 7d (eta 10h) → label 5h
-M5S=active M5E=3600 M5R=0 M5T=9000  M7E=36000 M7R=0 M7T=200000
-burn_estimate
-eq "binding label 5h"  "$_BURN_LABEL" "5h"
-
-# 5h idle + 7d unused → idle, no label
-M5S=idle M5E=inf M5R=0 M5T=0  M7E=inf M7R=0 M7T=0
-burn_estimate
-eq "binding idle"      "$_BURN_STATE" "idle"
-eq "binding idle nolabel" "$_BURN_LABEL" ""
-
-# render: all-good ✓ is window-absolute — 7d binding with eta 24d15h > the 7d window
-# (you couldn't empty even a full window at this pace) → bright-green ✓, no number.
-SEG_BGS=(); SEG_TXT=(); SEG_LEN=()
-M5S=active M5E=inf M5R=0 M5T=0  M7E=2127600 M7R=0 M7T=3600
-burn_estimate
-seg_burn
-case "${SEG_TXT[0]}" in *"↗ ✓"*) ok "render all-good 7d check" ;; *) bad "render all-good 7d check" "got=${SEG_TXT[0]}" ;; esac
-case "${SEG_TXT[0]}" in *"⇢"*) bad "all-good drops countdown" "got=${SEG_TXT[0]}" ;; *) ok "all-good drops countdown" ;; esac
-case "${SEG_TXT[0]}" in *$'\033[38;5;114m'*) ok "all-good OK colour" ;; *) bad "all-good OK colour" "no OK fg in ${SEG_TXT[0]}" ;; esac
-
-# the window is per-label: 5h binding with eta 20000s (> the 5h/18000s window) → ✓ too
-SEG_BGS=(); SEG_TXT=(); SEG_LEN=()
-M5S=active M5E=20000 M5R=0 M5T=600  M7E=inf M7R=0 M7T=0
-burn_estimate
-seg_burn
-case "${SEG_TXT[0]}" in *"↗ ✓"*) ok "render all-good 5h check" ;; *) bad "render all-good 5h check" "got=${SEG_TXT[0]}" ;; esac
-
-# regression: eta 4h50m is *under* the 5h window, so it must NOT collapse to ✓ — it
-# shows the number, coloured green here (comfortable vs reset: eta 17400 > 1.25·ttr 7200).
-SEG_BGS=(); SEG_TXT=(); SEG_LEN=()
-M5S=active M5E=17400 M5R=0 M5T=7200  M7E=inf M7R=0 M7T=0
-burn_estimate
-seg_burn
-case "${SEG_TXT[0]}" in *"↗ 5h ⇢ 4h50m"*) ok "render green number" ;; *) bad "render green number" "got=${SEG_TXT[0]}" ;; esac
-case "${SEG_TXT[0]}" in *"✓"*) bad "under-window keeps number" "got=${SEG_TXT[0]}" ;; *) ok "under-window keeps number" ;; esac
-case "${SEG_TXT[0]}" in *$'\033[38;5;114m'*) ok "green number OK colour" ;; *) bad "green number OK colour" "no OK fg in ${SEG_TXT[0]}" ;; esac
-
-# render: active 5h binding, eta 5m ≤ ttr 10m → you empty before reset → HOT colour,
-# and the actionable countdown number is kept.
-SEG_BGS=(); SEG_TXT=(); SEG_LEN=()
-M5S=active M5E=300 M5R=0 M5T=600  M7E=inf M7R=0 M7T=0
-burn_estimate
-seg_burn
-case "${SEG_TXT[0]}" in *$'\033[38;5;167m'*) ok "render HOT colour" ;; *) bad "render HOT colour" "no HOT fg in ${SEG_TXT[0]}" ;; esac
-case "${SEG_TXT[0]}" in *"⇢ "*) ok "HOT keeps countdown" ;; *) bad "HOT keeps countdown" "got=${SEG_TXT[0]}" ;; esac
-
-# render: idle → dim all-good ✓ (not burning), no dash placeholder
-SEG_BGS=(); SEG_TXT=(); SEG_LEN=()
-M5S=idle M5E=inf M5R=0 M5T=0  M7E=inf M7R=0 M7T=0
-burn_estimate
-seg_burn
-case "${SEG_TXT[0]}" in *"↗ ✓"*) ok "render idle check" ;; *) bad "render idle check" "got=${SEG_TXT[0]}" ;; esac
-case "${SEG_TXT[0]}" in *$'\033[38;5;245m'*) ok "render idle dim" ;; *) bad "render idle dim" "no DIM fg in ${SEG_TXT[0]}" ;; esac
-
-# render: active 5h binding, eta 1000s, ttr 900s → ratio 0.9 ∈ [0.8,1) → WARN colour,
-# and the countdown number is kept (only the green band collapses to ✓).
-SEG_BGS=(); SEG_TXT=(); SEG_LEN=()
-M5S=active M5E=1000 M5R=0 M5T=900  M7E=inf M7R=0 M7T=0
-burn_estimate
-seg_burn
-case "${SEG_TXT[0]}" in *$'\033[38;5;179m'*) ok "render WARN colour" ;; *) bad "render WARN colour" "no WARN fg in ${SEG_TXT[0]}" ;; esac
-case "${SEG_TXT[0]}" in *"⇢ "*) ok "WARN keeps countdown" ;; *) bad "WARN keeps countdown" "got=${SEG_TXT[0]}" ;; esac
-
-# render: warming (cold start, no data) → dim ↗ … — a distinct "no data yet" mark,
-# NOT the ✓ that idle/all-good use, so a fresh install doesn't look healthy-green.
-SEG_BGS=(); SEG_TXT=(); SEG_LEN=()
-M5S=warming M5E=inf M5R=0 M5T=0  M7E=inf M7R=0 M7T=0
-burn_estimate
-seg_burn
-case "${SEG_TXT[0]}" in *"↗ …"*) ok "render warming check" ;; *) bad "render warming check" "got=${SEG_TXT[0]}" ;; esac
-case "${SEG_TXT[0]}" in *"✓"*) bad "warming is not ✓" "got=${SEG_TXT[0]}" ;; *) ok "warming is not ✓" ;; esac
-case "${SEG_TXT[0]}" in *$'\033[38;5;245m'*) ok "render warming dim" ;; *) bad "render warming dim" "no DIM fg in ${SEG_TXT[0]}" ;; esac
-
-# contract: seg_burn renders a PRECOMPUTED estimate and must NOT recompute. The
-# stubs say warming, but the precomputed _BURN_* says active/5h — seg_burn has to
-# honour the globals (burn_estimate is hoisted to run once per render, upstream of
-# seg_burn, so float and visible passes share one computation).
-SEG_BGS=(); SEG_TXT=(); SEG_LEN=()
-M5S=warming M5E=inf M5R=0 M5T=0  M7E=inf M7R=0 M7T=0
-_BURN_STATE=active _BURN_LABEL=5h _BURN_ETA=1000 _BURN_RATE=0 _BURN_TTR=900
-seg_burn
-case "${SEG_TXT[0]}" in *"↗ 5h ⇢ "*) ok "seg_burn renders precomputed estimate" ;; *) bad "seg_burn renders precomputed estimate" "got=${SEG_TXT[0]}" ;; esac
-
-# tie-break: equal ETAs (5000s) → 5h wins via -le comparison
-M5S=active M5E=5000 M5R=0 M5T=9000  M7E=5000 M7R=0 M7T=9000
-burn_estimate
-eq "tie→5h"            "$_BURN_LABEL" "5h"
-
-# guard: neither limit reported → segment renders nothing
-SEG_BGS=(); SEG_TXT=(); SEG_LEN=()
-fh_pct="" wd_pct=""
-seg_burn
-eq "neither-reported renders nothing" "${#SEG_TXT[@]}" "0"
-
-# ── integration: the sampler runs iff `burn` is in the segment list (issue #17) ─
-# Drives the whole statusline.sh so the top-level gate is exercised end to end.
-if command -v jq >/dev/null 2>&1; then
-  gate_run() {  # $1=VL_SEGMENTS → "written" if a sample landed, else "absent"
-    local conf="$TMPD/conf.sh" bf="$TMPD/gate/burn.tsv" in="$TMPD/gate-input.json" soon
-    rm -rf "$TMPD/gate"
-    printf 'VL_SEGMENTS=%q\n' "$1" > "$conf"
-    # Give the fixture a plausible near-future reset (raw epoch; to_epoch accepts
-    # it) so the sentinel guard (#32) doesn't correctly drop the sample and mask
-    # the gate under test. The bundled sample-input.json keeps its 2030 sentinel.
-    soon=$(( $(date +%s) + 10800 ))
-    jq --arg r "$soon" \
-       '.rate_limits.five_hour.resets_at=$r | .rate_limits.seven_day.resets_at=$r' \
-       "$HERE/sample-input.json" > "$in"
-    CORALLINE_CONFIG="$conf" CORALLINE_BURN_FILE="$bf" \
-      bash "$SCRIPT" < "$in" >/dev/null 2>&1
-    [ -f "$bf" ] && echo written || echo absent
-  }
-  eq "gate: burn listed → samples"    "$(gate_run 'dir burn clock')" "written"
-  eq "gate: burn absent → no samples" "$(gate_run 'dir clock')"      "absent"
+# A case-only 5h/7d root alias must fail both stores closed before retention or
+# publication. Run the physical alias regression only when the volume proves it.
+CASE="$TMPD/case-root-collision"; reset_state_case "$CASE"; _STATE_BURN_GATE=0
+RL5H_FILE="$CASE/State/limit.tsv"; RL7D_FILE="$CASE/state/limit.tsv"
+mkdir -p "$CASE/State/limit.d/0001015900_040.000" "$CASE/State/limit.d/0001345600_029.000"
+if [ -d "$CASE/state/limit.d" ] && [ "$CASE/State/limit.d" -ef "$CASE/state/limit.d" ]; then
+  state_prepare
+  eq 'case-only alias marks 5h incomplete' "$_SL5_COMPLETE" 0
+  eq 'case-only alias marks 7d incomplete' "$_SL7_COMPLETE" 0
+  true_case 'case-only alias preserves canonical 5h entry' test -d "$CASE/State/limit.d/0001015900_040.000"
+  true_case 'case-only alias preserves canonical 7d entry' test -d "$CASE/State/limit.d/0001345600_029.000"
+  count_entries "$CASE/State/limit.d"; eq 'case-only alias publishes nothing' "$_COUNT" 2
 else
-  ok "gate integration (skipped: no jq)"
+  ok 'case-only 5h/7d alias unavailable on case-sensitive volume'
 fi
 
-[ "$fail" -eq 0 ] && echo "ALL PASS" || { echo "SOME FAILED"; exit 1; }
+# A cold render publishes immutable zero-byte burn entries and limit directories.
+CASE="$TMPD/publication"; reset_state_case "$CASE"; state_prepare
+first_name "$CASE/burn.d"; eq 'burn strict live name' "$_FIRST" 'b_000001015900_000001000000_041.200_0000'
+true_case 'burn entry zero-byte regular file' test ! -s "$CASE/burn.d/$_FIRST"
+true_case 'limit5 canonical directory' test -d "$CASE/limit5.d/0001015900_041.200"
+true_case 'limit7 canonical directory' test -d "$CASE/limit7.d/0001345600_030.000"
+true_case 'new runtime never creates legacy burn TSV' test ! -e "$CASE/burn.tsv"
+for _L in "$CASE/burn.d"/*; do case ${_L##*/} in l_*) bad 'no l_* entries' "found ${_L##*/}" ;; esac; done
+ok 'no l_* entries'
+
+# Same-second collisions consume deterministic slots and never overwrite.
+state_prepare
+true_case 'same-second slot 0001 committed' test -f "$CASE/burn.d/b_000001015900_000001000000_041.200_0001"
+i=0
+while [ "$i" -lt 32 ]; do printf -v _S '%04d' "$i"; : > "$CASE/burn.d/b_000001015900_000001000000_041.200_$_S"; i=$((i + 1)); done
+count_entries "$CASE/burn.d"; _BEFORE=$_COUNT
+_SB_RAW=0; _SB_REMOVED=0; _SB_COMPLETE=1; _SB_CLEAN=1; _SL5_COMPLETE=0; _SL7_COMPLETE=0; _STATE_MUTATE=1
+state_publish; count_entries "$CASE/burn.d"; eq '32 occupied slots skip without growth' "$_COUNT" "$_BEFORE"
+
+# Legacy TSV is a permanent bounded read-only source, never append/trim/heal.
+CASE="$TMPD/legacy"; reset_state_case "$CASE"; fh_pct=8
+printf '999640\t6\t1015900\n999700\t7\t1015900\n999940\t8\t1015900\n1000000\t8\t1015900\n9999999\t99\t99999999\n' > "$BURN_FILE"
+cp "$BURN_FILE" "$CASE/legacy.before"
+state_prepare
+cmp -s "$BURN_FILE" "$CASE/legacy.before" && ok 'legacy bytes preserved under mutation' || bad 'legacy bytes preserved under mutation' 'content changed'
+eq 'legacy estimator active' "$_B5_STATE" active
+eq 'legacy estimator eta' "$_B5_ETA" 22080
+true_case 'live samples publish only into .d' test -d "$CASE/burn.d"
+
+# Exact estimator contract: same-second maximum, rational rate/ETA, and reset isolation.
+NOW=1000360; CORALLINE_BURN_WINDOW=600; _SB_COMPLETE=1; _CUR_BURN_VALID=0
+_SB_REP_RSTS=(1015900 1015900 1015900 1015900)
+_SB_REP_SAMPS=(1000000 1000060 1000300 1000360)
+_SB_REP_PCTS=(6000 7000 8000 8000)
+_LEG_RSTS=(); _LEG_SAMPS=(); _LEG_PCTS=()
+burn_eta_5h
+eq '5h active state' "$_B5_STATE" active
+eq '5h exact eta' "$_B5_ETA" 22080
+eq '5h exact rate' "$_B5_RATE" '0.0041666667'
+eq '5h ttr' "$_B5_TTR" 15540
+_SB_REP_RSTS=(1015900 1015900 1015900 1015900 1015900)
+_SB_REP_SAMPS=(1000000 1000060 1000060 1000300 1000360)
+_SB_REP_PCTS=(6000 6500 7000 8000 8000)
+burn_eta_5h; eq 'same-second maximum is order-independent' "$_B5_ETA" 22080
+_SB_REP_RSTS=(1010000 1010000 1015900 1015900 1015900 1015900)
+_SB_REP_SAMPS=(1000060 1000180 1000000 1000120 1000300 1000360)
+_SB_REP_PCTS=(50000 51000 6000 7000 8000 8000)
+burn_eta_5h; eq 'latest reset isolates old windows' "$_B5_ETA" 16560
+
+NOW=1000000; burn_eta_7d 30000 1345600
+eq '7d exact eta' "$_B7_ETA" 604800
+eq '7d exact rate' "$_B7_RATE" '0.0001157407'
+eq '7d ttr' "$_B7_TTR" 345600
+burn_eta_7d 0 1345600; eq '7d zero pct is infinite' "$_B7_ETA" inf
+_B5_STATE=active; _B5_ETA=5000; _B5_RATE=x; _B5_TTR=9000
+_B7_ETA=5000; _B7_RATE=y; _B7_TTR=9000
+burn_estimate; eq 'binding ETA tie chooses 5h' "$_BURN_LABEL" 5h
+
+# Renderer consumes the precomputed result and never triggers state I/O itself.
+VL_BURN_GLYPH='↗'; VL_BG_BURN=''; VL_BG_5H=237; VL_LAYOUT=fixed
+VL_FG_OK=114; VL_FG_WARN=179; VL_FG_HOT=167; VL_FG_DIM=245; VL_NOCOLOR=0
+fh_pct=8; wd_pct=0; _STATE_READY=0
+SEG_BGS=(); SEG_TXT=(); SEG_LEN=(); _BURN_STATE=active; _BURN_LABEL=5h; _BURN_ETA=1000; _BURN_RATE=0; _BURN_TTR=900
+seg_burn
+case "${SEG_TXT[0]}" in *'↗ 5h ⇢ 16m'*) ok 'burn renderer uses precomputed estimate' ;; *) bad 'burn renderer uses precomputed estimate' "${SEG_TXT[0]}" ;; esac
+case "${SEG_TXT[0]}" in *$'\033[38;5;179m'*) ok 'burn warning color' ;; *) bad 'burn warning color' 'missing warning fg' ;; esac
+
+# No-sample is strictly read-only for legacy, live stores, GC candidates, and
+# missing roots. A poisoned strict sentinel remains physically present.
+CASE="$TMPD/no-sample"; reset_state_case "$CASE"
+mkdir -p "$CASE/burn.d" "$CASE/limit5.d/9999999999_099.000" "$CASE/limit7.d/9999999999_099.000"
+: > "$CASE/burn.d/b_253402300799_000001000000_099.000_0000"
+printf '1000000\t41.2\t1015900\n' > "$BURN_FILE"
+cp "$BURN_FILE" "$CASE/legacy.before"
+CORALLINE_NO_SAMPLE=1; state_prepare
+cmp -s "$BURN_FILE" "$CASE/legacy.before" && ok 'no-sample preserves legacy bytes' || bad 'no-sample preserves legacy bytes' changed
+true_case 'no-sample preserves burn sentinel' test -f "$CASE/burn.d/b_253402300799_000001000000_099.000_0000"
+true_case 'no-sample preserves 5h sentinel' test -d "$CASE/limit5.d/9999999999_099.000"
+true_case 'no-sample preserves 7d sentinel' test -d "$CASE/limit7.d/9999999999_099.000"
+CASE2="$TMPD/no-sample-missing"; reset_state_case "$CASE2"; CORALLINE_NO_SAMPLE=1; state_prepare
+true_case 'no-sample never creates missing burn root' test ! -e "$CASE2/burn.d"
+true_case 'no-sample never creates missing limit root' test ! -e "$CASE2/limit5.d"
+
+# Mutation-enabled complete snapshots may remove only exact strict sentinels;
+# malformed entries and flat legacy limit files remain untouched.
+CASE="$TMPD/gc-sentinel"; reset_state_case "$CASE"
+mkdir -p "$CASE/burn.d" "$CASE/limit5.d/9999999999_099.000" "$CASE/limit5.d/not-state"
+: > "$CASE/burn.d/b_253402300799_000001000000_099.000_0000"
+: > "$CASE/burn.d/not-state"
+printf 'flat-canary' > "$RL5H_FILE"
+printf '1000000\t99\t99999999\n' > "$BURN_FILE"
+state_prepare
+true_case 'strict burn sentinel GCed' test ! -e "$CASE/burn.d/b_253402300799_000001000000_099.000_0000"
+true_case 'malformed burn entry preserved' test -f "$CASE/burn.d/not-state"
+true_case 'strict limit sentinel GCed' test ! -e "$CASE/limit5.d/9999999999_099.000"
+true_case 'malformed limit entry preserved' test -d "$CASE/limit5.d/not-state"
+eq 'flat limit file preserved' "$(LC_ALL=C tr -d '\n' < "$RL5H_FILE")" flat-canary
+cmp -s "$BURN_FILE" <(printf '1000000\t99\t99999999\n') && ok 'legacy sentinel row preserved physically' || bad 'legacy sentinel row preserved physically' changed
+
+# GC is snapshot-bound: an exact newer publication created after enumeration is
+# absent from the candidate set and survives this round.
+CASE="$TMPD/barrier"; reset_state_case "$CASE"; mkdir -p "$CASE/burn.d"
+: > "$CASE/burn.d/b_253402300799_000001000000_099.000_0000"
+_SB_NAMES=(); _SB_PATHS=(); _SB_RSTS=(); _SB_SAMPS=(); _SB_PCTS=(); _SB_PLAUS=(); _SB_RAW=0
+_SL5_NAMES=(); _SL5_PATHS=(); _SL5_RSTS=(); _SL5_PCTS=(); _SL5_PLAUS=(); _SL5_RAW=0
+_SL7_NAMES=(); _SL7_PATHS=(); _SL7_RSTS=(); _SL7_PCTS=(); _SL7_PLAUS=(); _SL7_RAW=0
+_SB_ROOT="$CASE/burn.d"; _SB_BASE="$CASE/burn.tsv"; _STATE_FIND_ARGS=("$_SB_ROOT/.")
+_STATE_LEGACY_READ=0; _STATE_BURN_GATE=1; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0
+_SB_DIR_PREOK=1; _SL5_DIR_PREOK=0; _SL7_DIR_PREOK=0; _LEG_PREOK=1
+_SB_DIR_COMPLETE=0; _SL5_COMPLETE=0; _SL7_COMPLETE=0; _LEG_COMPLETE=0
+state_snapshot; _SB_COMPLETE=1; state_burn_retention
+_NEW="$CASE/burn.d/b_000001015900_000001000001_042.000_0000"; : > "$_NEW"
+_STATE_MUTATE=1; _SL5_CAND_PATHS=(); _SL5_CAND_TOTAL=0; _SL7_CAND_PATHS=(); _SL7_CAND_TOTAL=0
+state_gc
+true_case 'post-snapshot writer survives current GC' test -f "$_NEW"
+
+# Bounded retention deletes at most 128 per render and blocks publication until
+# every strict retention candidate from the complete snapshot is gone.
+CASE="$TMPD/retention"; reset_state_case "$CASE"; BURN_TRIM=1; mkdir -p "$CASE/burn.d"
+i=0
+while [ "$i" -lt 130 ]; do
+  sample=$(( NOW - 130 + i )); printf -v name 'b_%012d_%012d_%03d.%03d_%04d' 1015900 "$sample" 10 0 0
+  : > "$CASE/burn.d/$name"; i=$((i + 1))
+done
+state_prepare; count_entries "$CASE/burn.d"; eq 'first retention round removes at most 128' "$_COUNT" 2
+true_case 'publication blocked while candidate remains' test ! -e "$CASE/burn.d/b_000001015900_000001000000_041.200_0000"
+state_prepare; count_entries "$CASE/burn.d"; eq 'second maintenance converges then publishes once' "$_COUNT" 2
+
+# The default retained set is a normal steady state, not an adversarial input.
+# Descending creation order exercises the O(n log n) in-shell merge sort.
+CASE="$TMPD/steady1500"; reset_state_case "$CASE"; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0; BURN_TRIM=1500
+mkdir -p "$CASE/burn.d"; i=0
+while [ "$i" -lt 1500 ]; do
+  sample=$(( NOW - i - 1 )); printf -v name 'b_%012d_%012d_010.000_0000' 1015900 "$sample"
+  : > "$CASE/burn.d/$name"; i=$(( i + 1 ))
+done
+_START=$SECONDS; state_prepare; _ELAPSED=$(( SECONDS - _START ))
+[ "$_ELAPSED" -lt 5 ] && ok '1500-entry steady render completes under 5s' || bad '1500-entry steady render completes under 5s' "seconds=$_ELAPSED"
+eq '1500-entry steady sort first sample' "${_SB_REP_SAMPS[0]}" 998500
+eq '1500-entry steady sort last sample' "${_SB_REP_SAMPS[1499]}" 999999
+count_entries "$CASE/burn.d"; eq '1500-entry steady render publishes once' "$_COUNT" 1501
+
+# Raw snapshot and publication watermarks: malformed names consume capacity but
+# are never deletion targets.
+make_files() { local dir="$1" n="$2" i=0; mkdir -p "$dir"; while [ "$i" -lt "$n" ]; do printf -v _N 'x%04d' "$i"; : > "$dir/$_N"; i=$((i + 1)); done; }
+CASE="$TMPD/watermark3967"; reset_state_case "$CASE"; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0; make_files "$CASE/burn.d" 3967
+state_prepare; count_entries "$CASE/burn.d"; eq 'burn raw 3967 may publish one' "$_COUNT" 3968
+CASE="$TMPD/watermark3968"; reset_state_case "$CASE"; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0; make_files "$CASE/burn.d" 3968
+state_prepare; count_entries "$CASE/burn.d"; eq 'burn raw 3968 never publishes' "$_COUNT" 3968
+CASE="$TMPD/overcap"; reset_state_case "$CASE"; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0; make_files "$CASE/burn.d" 4097
+state_prepare; count_entries "$CASE/burn.d"; eq 'burn cap+1 freezes store' "$_COUNT" 4097
+eq 'burn cap+1 returns warming' "$_B5_STATE" warming
+
+make_dirs() { local dir="$1" n="$2" i=0 paths=(); mkdir -p "$dir"; while [ "$i" -lt "$n" ]; do printf -v _N 'x%04d' "$i"; paths[${#paths[@]}]="$dir/$_N"; i=$((i + 1)); done; mkdir -p "${paths[@]}"; }
+CASE="$TMPD/limit383"; reset_state_case "$CASE"; _STATE_BURN_GATE=0; _STATE_RL7_GATE=0; make_dirs "$CASE/limit5.d" 383
+state_prepare; count_entries "$CASE/limit5.d"; eq 'limit raw 383 may publish one' "$_COUNT" 384
+CASE="$TMPD/limit384"; reset_state_case "$CASE"; _STATE_BURN_GATE=0; _STATE_RL7_GATE=0; make_dirs "$CASE/limit5.d" 384
+state_prepare; count_entries "$CASE/limit5.d"; eq 'limit raw 384 never publishes' "$_COUNT" 384
+CASE="$TMPD/limit513"; reset_state_case "$CASE"; _STATE_BURN_GATE=0; _STATE_RL7_GATE=0; make_dirs "$CASE/limit5.d" 513
+state_prepare; count_entries "$CASE/limit5.d"; eq 'limit cap+1 freezes store' "$_COUNT" 513
+
+# Legacy byte/row/record caps and newest-512 valid-row ring.
+CASE="$TMPD/legacy-bounds"; reset_state_case "$CASE"; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0; CORALLINE_NO_SAMPLE=1
+LC_ALL=C awk 'BEGIN { for (i=0;i<4096;i++) { for(j=0;j<255;j++) printf "x"; printf "\n" } }' > "$BURN_FILE"
+state_prepare; eq 'exact 1MiB bounded legacy completes' "$_SB_COMPLETE" 1
+printf x >> "$BURN_FILE"; state_prepare; eq 'legacy cap+1 is incomplete' "$_SB_COMPLETE" 0
+: > "$BURN_FILE"; i=1
+while [ "$i" -le 600 ]; do printf '%d\t1.2345\t1015900\n' "$i" >> "$BURN_FILE"; i=$((i + 1)); done
+state_prepare; eq 'legacy ring retains 512 valid rows' "${#_LEG_RSTS[@]}" 512
+eq 'legacy ring drops oldest valid rows' "${_LEG_SAMPS[0]}" 89
+LC_ALL=C awk 'BEGIN { for(i=0;i<4097;i++) print "bad" }' > "$BURN_FILE"
+state_prepare; eq 'legacy 4097 physical rows incomplete' "$_SB_COMPLETE" 0
+LC_ALL=C awk 'BEGIN { for(i=0;i<4097;i++) printf "1"; printf "\n" }' > "$BURN_FILE"
+state_prepare; eq 'legacy 4097-byte record incomplete' "$_SB_COMPLETE" 0
+printf '1000000\t1\t1015900\0\n' > "$BURN_FILE"
+state_prepare; eq 'legacy NUL row ignored after bounded read' "${#_LEG_RSTS[@]}" 0
+
+# Controller failures discard partial data and forbid mutation.
+CASE="$TMPD/controller-fail"; reset_state_case "$CASE"; mkdir -p "$CASE/burn.d"; : > "$CASE/burn.d/not-state"
+REAL_FIND=$(command -v find); REAL_OD=$(command -v od); REAL_AWK=$(command -v awk)
+mkdir -p "$CASE/bin"
+printf '%s\n' '#!/bin/bash' 'printf "%s/./partial\0" "$WIN02_ROOT"' 'exit 7' > "$CASE/bin/find"; chmod +x "$CASE/bin/find"
+printf '%s\n' '#!/bin/bash' 'exec "$WIN02_REAL_OD" "$@"' > "$CASE/bin/od"; chmod +x "$CASE/bin/od"
+printf '%s\n' '#!/bin/bash' 'exec "$WIN02_REAL_AWK" "$@"' > "$CASE/bin/awk"; chmod +x "$CASE/bin/awk"
+OLD_PATH=$PATH; export WIN02_ROOT="$CASE/burn.d" WIN02_REAL_OD="$REAL_OD" WIN02_REAL_AWK="$REAL_AWK"; PATH="$CASE/bin:$PATH"
+state_prepare
+PATH=$OLD_PATH
+eq 'partial find failure marks burn incomplete' "$_SB_COMPLETE" 0
+count_entries "$CASE/burn.d"; eq 'partial find failure performs no publication or GC' "$_COUNT" 1
+
+CASE="$TMPD/legacy-fail"; reset_state_case "$CASE"; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0; printf '1000000\t1\t1015900\n' > "$BURN_FILE"
+mkdir -p "$CASE/bin"
+printf '%s\n' '#!/bin/bash' 'exec "$WIN02_REAL_FIND" "$@"' > "$CASE/bin/find"; chmod +x "$CASE/bin/find"
+printf '%s\n' '#!/bin/bash' 'printf "49 48 48 48 48 48 48 9 49 9 49 48 49 53 57 48 48 10\n"' 'exit 7' > "$CASE/bin/od"; chmod +x "$CASE/bin/od"
+printf '%s\n' '#!/bin/bash' 'exec "$WIN02_REAL_AWK" "$@"' > "$CASE/bin/awk"; chmod +x "$CASE/bin/awk"
+export WIN02_REAL_FIND="$REAL_FIND" WIN02_REAL_AWK="$REAL_AWK"; PATH="$CASE/bin:$OLD_PATH"
+state_prepare
+PATH=$OLD_PATH
+eq 'partial od failure marks legacy incomplete' "$_SB_COMPLETE" 0
+eq 'partial od failure discards buffered rows' "${#_LEG_RSTS[@]}" 0
+true_case 'partial od failure publishes nothing' test ! -e "$CASE/burn.d"
+
+# Symlink stores and ancestors fail closed without touching their targets. Git
+# Bash's default ln -s emulation copies directories, so create a real Windows
+# reparse point there; native links are visible to Git Bash's -L predicate.
+CASE="$TMPD/symlink"; reset_state_case "$CASE"; mkdir -p "$CASE/target"; : > "$CASE/target/canary"
+case "$(uname -s)" in
+  (MINGW*|MSYS*)
+    _LINK_WIN=$(cygpath -w "$CASE/burn.d"); _TARGET_WIN=$(cygpath -w "$CASE/target")
+    MSYS2_ARG_CONV_EXCL='*' cmd.exe /d /c mklink /J "$_LINK_WIN" "$_TARGET_WIN" >/dev/null 2>&1
+    _LINK_OK=$? ;;
+  (*) ln -s "$CASE/target" "$CASE/burn.d"; _LINK_OK=$? ;;
+esac
+true_case 'native symlink fixture created' test "$_LINK_OK" -eq 0
+state_prepare
+eq 'symlink store makes snapshot incomplete' "$_SB_COMPLETE" 0
+true_case 'symlink target canary survives' test -f "$CASE/target/canary"
+count_entries "$CASE/target"; eq 'symlink target receives no publication' "$_COUNT" 1
+
+# Full-runtime gate and process budget. Wrappers exec the real tools in-place, so
+# each trace line is one external state child; add one for the controller.
+if command -v jq >/dev/null 2>&1; then
+  make_payload() {
+    local path="$1" now reset
+    now=$(date +%s); reset=$((now + 10800))
+    jq --arg r "$reset" '.rate_limits.five_hour.resets_at=$r | .rate_limits.seven_day.resets_at=$r' "$HERE/sample-input.json" > "$path"
+  }
+  trace_wrappers() {
+    local dir="$1" tool real
+    mkdir -p "$dir"
+    for tool in find od awk rm mkdir; do
+      real=$(command -v "$tool")
+      {
+        printf '%s\n' '#!/bin/bash'
+        printf 'printf "%%s\\n" %q >> "$WIN02_TRACE"\n' "$tool"
+        printf 'exec %q "$@"\n' "$real"
+      } > "$dir/$tool"
+      chmod +x "$dir/$tool"
+    done
+  }
+  CASE="$TMPD/process"; mkdir -p "$CASE"; make_payload "$CASE/input"; trace_wrappers "$CASE/bin"
+  printf '%s\n' 'VL_SEGMENTS=dir' 'VL_CLOCK=off' > "$CASE/disabled.conf"
+  : > "$CASE/disabled.log"
+  WIN02_TRACE="$CASE/disabled.log" CORALLINE_CONFIG="$CASE/disabled.conf" PATH="$CASE/bin:$PATH" bash "$SCRIPT" < "$CASE/input" >/dev/null 2> "$CASE/disabled.err"
+  _TRACE=0; while IFS= read -r _; do _TRACE=$((_TRACE + 1)); done < "$CASE/disabled.log"
+  eq 'disabled state adds zero children' "$_TRACE" 0
+  eq 'disabled state stderr empty' "$(wc -c < "$CASE/disabled.err" | tr -d ' ')" 0
+
+  mkdir -p "$CASE/state/burn.d"; printf '1\t1\t2\n' > "$CASE/state/burn.tsv"
+  printf '%s\n' 'VL_SEGMENTS=burn' 'VL_CLOCK=off' "BURN_FILE=$CASE/state/burn.tsv" > "$CASE/read.conf"
+  : > "$CASE/read.log"
+  WIN02_TRACE="$CASE/read.log" CORALLINE_CONFIG="$CASE/read.conf" CORALLINE_NO_SAMPLE=1 PATH="$CASE/bin:$PATH" bash "$SCRIPT" < "$CASE/input" >/dev/null 2> "$CASE/read.err"
+  _TRACE=1; while IFS= read -r _; do _TRACE=$((_TRACE + 1)); done < "$CASE/read.log"
+  [ "$_TRACE" -le 4 ] && ok 'no-sample descendant ceiling <=4' || bad 'no-sample descendant ceiling <=4' "count=$_TRACE"
+  eq 'no-sample process trace stderr empty' "$(wc -c < "$CASE/read.err" | tr -d ' ')" 0
+
+  rm -rf "$CASE/state"; mkdir -p "$CASE/state/burn.d"
+  now=$(date +%s); old=$((now - 10)); reset=$((now + 10800)); printf -v oldname 'b_%012d_%012d_010.000_0000' "$reset" "$old"; : > "$CASE/state/burn.d/$oldname"
+  old=$((now - 9)); printf -v oldname 'b_%012d_%012d_011.000_0000' "$reset" "$old"; : > "$CASE/state/burn.d/$oldname"
+  printf '1\t1\t2\n' > "$CASE/state/burn.tsv"
+  printf '%s\n' 'VL_SEGMENTS=burn\ limit5h\ limit7d' 'VL_LIMIT_SYNC=1' 'VL_CLOCK=off' "BURN_FILE=$CASE/state/burn.tsv" "RL5H_FILE=$CASE/state/limit5.tsv" "RL7D_FILE=$CASE/state/limit7.tsv" 'BURN_TRIM=1' > "$CASE/full.conf"
+  : > "$CASE/full.log"
+  WIN02_TRACE="$CASE/full.log" CORALLINE_CONFIG="$CASE/full.conf" PATH="$CASE/bin:$PATH" bash "$SCRIPT" < "$CASE/input" >/dev/null 2> "$CASE/full.err"
+  _TRACE=1; while IFS= read -r _; do _TRACE=$((_TRACE + 1)); done < "$CASE/full.log"
+  [ "$_TRACE" -le 6 ] && ok 'fully enabled descendant ceiling <=6' || bad 'fully enabled descendant ceiling <=6' "count=$_TRACE"
+  eq 'fully enabled process trace stderr empty' "$(wc -c < "$CASE/full.err" | tr -d ' ')" 0
+
+  printf '%s\n' 'VL_SEGMENTS=dir' 'VL_CLOCK=off' "BURN_FILE=$CASE/gated/burn.tsv" > "$CASE/gate.conf"
+  CORALLINE_CONFIG="$CASE/gate.conf" bash "$SCRIPT" < "$CASE/input" >/dev/null 2>/dev/null
+  true_case 'burn absent never creates state root' test ! -e "$CASE/gated/burn.d"
+else
+  ok 'full-runtime gate and process budget skipped without jq'
+fi
+
+printf 'SUMMARY pass=%s fail=%s\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1
+printf 'ALL PASS\n'

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -289,6 +289,23 @@ state_prepare; count_entries "$CASE/limit5.d"; eq 'limit raw 384 never publishes
 CASE="$TMPD/limit513"; reset_state_case "$CASE"; _STATE_BURN_GATE=0; _STATE_RL7_GATE=0; make_dirs "$CASE/limit5.d" 513
 state_prepare; count_entries "$CASE/limit5.d"; eq 'limit cap+1 freezes store' "$_COUNT" 513
 
+# Limit entries are immutable empty directories. The controller streams one
+# bounded child layer so a poisoned canonical name cannot become stored state
+# or force Bash to materialize an unbounded glob.
+CASE="$TMPD/limit-nonempty"; reset_state_case "$CASE"; _STATE_BURN_GATE=0; _STATE_RL7_GATE=0
+mkdir -p "$CASE/limit5.d/0001015900_041.200"; : > "$CASE/limit5.d/0001015900_041.200/canary"
+state_prepare
+eq 'nonempty limit directory is not stored state' "$_SL5_STORED_VALID" 0
+eq 'nonempty limit directory blocks publication' "$_SL5_CLEAN" 0
+true_case 'nonempty limit directory is preserved' test -f "$CASE/limit5.d/0001015900_041.200/canary"
+
+CASE="$TMPD/limit-child-cap"; reset_state_case "$CASE"; _STATE_BURN_GATE=0; _STATE_RL7_GATE=0
+mkdir -p "$CASE/limit5.d/0001015900_041.200"; i=0
+while [ "$i" -lt 513 ]; do printf -v _N 'child%04d' "$i"; : > "$CASE/limit5.d/0001015900_041.200/$_N"; i=$((i + 1)); done
+state_prepare
+eq 'limit child cap+1 freezes store' "$_SL5_COMPLETE" 0
+true_case 'limit child cap+1 preserves poisoned directory' test -f "$CASE/limit5.d/0001015900_041.200/child0512"
+
 # Legacy byte/row/record caps and newest-512 valid-row ring.
 CASE="$TMPD/legacy-bounds"; reset_state_case "$CASE"; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0; CORALLINE_NO_SAMPLE=1
 LC_ALL=C awk 'BEGIN { for (i=0;i<4096;i++) { for(j=0;j<255;j++) printf "x"; printf "\n" } }' > "$BURN_FILE"

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -1,0 +1,117 @@
+<#
+  Regression tests for statusline.ps1 (issue #8: native PowerShell support
+  without Git Bash). Mirrors the check()-per-assertion convention the bash
+  tests in this directory use, translated to PowerShell.
+
+  Run:
+    powershell -NoProfile -File test/test-statusline-ps1.ps1
+
+  Needs: git.exe on PATH (already required by statusline.sh's own git
+  segment). No jq, no bash.
+#>
+
+$ErrorActionPreference = 'Continue'
+$Here = Split-Path -Path $MyInvocation.MyCommand.Path -Parent
+$Repo = Split-Path -Path $Here -Parent
+$Script = Join-Path $Repo 'statusline.ps1'
+$SampleInput = Join-Path $Here 'sample-input.json'
+
+$script:fail = 0
+function Check([string]$Name, [bool]$Cond) {
+    if ($Cond) { Write-Output "ok    $Name" }
+    else { Write-Output "FAIL  $Name"; $script:fail = 1 }
+}
+
+function Invoke-Statusline([string]$Json, [string]$ConfigPath, [string]$Cwd) {
+    $prevConfig = $env:CORALLINE_CONFIG
+    if ($ConfigPath) { $env:CORALLINE_CONFIG = $ConfigPath } else { Remove-Item Env:\CORALLINE_CONFIG -ErrorAction SilentlyContinue }
+    $prevLoc = Get-Location
+    if ($Cwd) { Set-Location -LiteralPath $Cwd }
+    try {
+        $out = $Json | & powershell -NoProfile -File $Script 2>&1
+        return @{ Output = ($out -join "`n"); ExitCode = $LASTEXITCODE }
+    } finally {
+        Set-Location $prevLoc
+        if ($prevConfig) { $env:CORALLINE_CONFIG = $prevConfig } else { Remove-Item Env:\CORALLINE_CONFIG -ErrorAction SilentlyContinue }
+    }
+}
+
+# --- Case 1: default segments render from the shared sample-input.json -----
+$sampleJson = Get-Content -LiteralPath $SampleInput -Raw
+$r1 = Invoke-Statusline $sampleJson '' ''
+Check 'exits 0 on the shared sample input' ($r1.ExitCode -eq 0)
+Check 'dir segment shows the sample cwd' ($r1.Output -like '*projects/coralline*')
+Check 'model segment shows the display name' ($r1.Output -like '*Fable 5*')
+Check 'ctx segment shows the used percentage' ($r1.Output -like '*62%*')
+Check '5h limit segment renders' ($r1.Output -like '*5h*')
+Check '7d limit segment renders' ($r1.Output -like '*7d*')
+Check 'cost segment renders' ($r1.Output -like '*$1.23*')
+Check 'no PowerShell errors on stderr (git/jq/bash-free path)' ($r1.Output -notmatch 'Split-Path|ParameterBindingException|CommandNotFoundException')
+
+# --- Case 2: VL_ASCII=1 swaps the gauge fill/empty glyphs, no crash --------
+$h2 = Join-Path ([System.IO.Path]::GetTempPath()) ("coralline-ps1-$([guid]::NewGuid())")
+New-Item -ItemType Directory -Path $h2 | Out-Null
+$asciiConf = Join-Path $h2 'coralline.conf'
+Set-Content -LiteralPath $asciiConf -Value @('VL_ASCII="1"', 'VL_SEGMENTS="ctx limit5h"') -Encoding UTF8
+$r2 = Invoke-Statusline $sampleJson $asciiConf ''
+Check 'ASCII mode exits 0' ($r2.ExitCode -eq 0)
+Check 'ASCII mode uses # for the filled gauge' ($r2.Output -like '*#*')
+Check 'ASCII mode uses - for the empty gauge' ($r2.Output -like '*-*')
+Remove-Item -Recurse -Force $h2
+
+# --- Case 3: missing config file falls back to the built-in defaults -------
+$missingConf = Join-Path ([System.IO.Path]::GetTempPath()) ("coralline-ps1-missing-$([guid]::NewGuid()).conf")
+$r3 = Invoke-Statusline $sampleJson $missingConf ''
+Check 'missing config file does not error' ($r3.ExitCode -eq 0)
+Check 'missing config file still renders the default segments' ($r3.Output -like '*Fable 5*')
+
+# --- Case 4: malformed / empty stdin degrades to a clock-only render -------
+$r4 = Invoke-Statusline '' '' ''
+Check 'empty stdin exits 0' ($r4.ExitCode -eq 0)
+$r5 = Invoke-Statusline 'not json {{{' '' ''
+Check 'malformed stdin exits 0' ($r5.ExitCode -eq 0)
+
+# --- Case 5: theme include (`. "path"`) resolves without a config-format
+# change — same coralline.conf a bash install already wrote works here -----
+$h5 = Join-Path ([System.IO.Path]::GetTempPath()) ("coralline-ps1-$([guid]::NewGuid())")
+New-Item -ItemType Directory -Path $h5 | Out-Null
+$themeConf = Join-Path $h5 'coralline.conf'
+$draculaTheme = Join-Path $Repo 'themes\dracula.conf'
+Set-Content -LiteralPath $themeConf -Value @(". `"$draculaTheme`"", 'VL_SEGMENTS="model"') -Encoding UTF8
+$r6 = Invoke-Statusline $sampleJson $themeConf ''
+Check 'theme include resolves and its color reaches the render' ($r6.Output -like '*38;2;189;147;249*')
+
+Remove-Item -Recurse -Force $h5
+
+# --- Case 6: git segment reflects a real repo (branch + dirty marker) ------
+$h6 = Join-Path ([System.IO.Path]::GetTempPath()) ("coralline-ps1-git-$([guid]::NewGuid())")
+New-Item -ItemType Directory -Path $h6 | Out-Null
+Push-Location $h6
+try {
+    git init -q -b main .
+    git config user.email test@example.com
+    git config user.name test
+    'one' | Set-Content -LiteralPath (Join-Path $h6 'a.txt')
+    git add a.txt
+    git commit -q -m 'init'
+    $gitConf = Join-Path $h6 'coralline.conf'
+    Set-Content -LiteralPath $gitConf -Value 'VL_SEGMENTS="git"' -Encoding UTF8
+    # statusline.ps1 (like statusline.sh) reads cwd from the session JSON, not
+    # from this process's own working directory, so the fixture repo must be
+    # named there explicitly.
+    $gitCwd = ($h6 -replace '\\', '/')
+    $gitJson = "{`"cwd`":`"$gitCwd`"}"
+    $rClean = Invoke-Statusline $gitJson $gitConf $h6
+    Check 'git segment shows the branch name on a clean repo' ($rClean.Output -like '*main*')
+
+    'two' | Add-Content -LiteralPath (Join-Path $h6 'a.txt')
+    $rDirty = Invoke-Statusline $gitJson $gitConf $h6
+    Check 'git segment marks a modified working tree' ($rDirty.Output -like '*main!*')
+} finally {
+    Pop-Location
+    Remove-Item -Recurse -Force $h6
+}
+
+if ($script:fail -eq 0) { Write-Output 'ALL PASS'; exit 0 }
+Write-Output 'SOME FAILED'
+exit 1

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 5.1
 <#
-  WIN-01 regression and differential tests for statusline.ps1.
+  WIN-01 plus WIN-02 state regression and differential tests for statusline.ps1.
 
   Run on native Windows PowerShell 5.1. Git Bash is test-only and supplies the
   statusline.sh oracle plus real configure.sh printf %q fixtures.
@@ -12,6 +12,8 @@ $Here = Split-Path -Path $MyInvocation.MyCommand.Path -Parent
 $Repo = Split-Path -Path $Here -Parent
 $Script = Join-Path $Repo 'statusline.ps1'
 $BashScript = Join-Path $Repo 'statusline.sh'
+$script:StateScript = $Script
+$script:StateBashScript = $BashScript
 $Configure = Join-Path $Repo 'configure.sh'
 $PowerShellExe = (Get-Process -Id $PID).Path
 $Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
@@ -115,10 +117,55 @@ function Invoke-CapturedProcess(
     }
 }
 
+function Start-CapturedProcessAsync(
+    [string]$FileName,
+    [string]$Arguments,
+    [string]$InputText,
+    [hashtable]$Environment,
+    [string]$WorkingDirectory
+) {
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $FileName
+    $psi.Arguments = $Arguments
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardInput = $true
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.CreateNoWindow = $true
+    if (-not [string]::IsNullOrEmpty($WorkingDirectory)) { $psi.WorkingDirectory = $WorkingDirectory }
+    foreach ($key in $Environment.Keys) {
+        if ($null -eq $Environment[$key]) { [void]$psi.EnvironmentVariables.Remove($key) }
+        else { $psi.EnvironmentVariables[$key] = [string]$Environment[$key] }
+    }
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo = $psi
+    if (-not $process.Start()) { throw 'async process did not start' }
+    $stdout = New-Object System.IO.MemoryStream
+    $stderr = New-Object System.IO.MemoryStream
+    $outTask = $process.StandardOutput.BaseStream.CopyToAsync($stdout)
+    $errTask = $process.StandardError.BaseStream.CopyToAsync($stderr)
+    $inputBytes = $Utf8NoBom.GetBytes($InputText)
+    if ($inputBytes.Length -gt 0) { $process.StandardInput.BaseStream.Write($inputBytes, 0, $inputBytes.Length) }
+    $process.StandardInput.Close()
+    return [pscustomobject]@{ Process=$process; Stdout=$stdout; Stderr=$stderr; OutTask=$outTask; ErrTask=$errTask }
+}
+
+function Wait-CapturedProcessAsync($Handle, [int]$TimeoutMs) {
+    $timedOut = -not $Handle.Process.WaitForExit($TimeoutMs)
+    if ($timedOut) { try { $Handle.Process.Kill() } catch { }; [void]$Handle.Process.WaitForExit(2000) }
+    [void]$Handle.OutTask.Wait(2000); [void]$Handle.ErrTask.Wait(2000)
+    $exitCode = -1
+    if (-not $timedOut -and $Handle.Process.HasExited) { $exitCode = $Handle.Process.ExitCode }
+    $result = [pscustomobject]@{ ExitCode=$exitCode; TimedOut=$timedOut; StdoutBytes=$Handle.Stdout.ToArray(); StderrBytes=$Handle.Stderr.ToArray() }
+    $Handle.Process.Dispose(); $Handle.Stdout.Dispose(); $Handle.Stderr.Dispose()
+    return $result
+}
+
 function Runtime-Environment([string]$ConfigPath, [hashtable]$Extra) {
     $environment = @{
         CORALLINE_CONFIG = $null
         CORALLINE_NO_SAMPLE = '1'
+        CORALLINE_TEST_NOW = $null
         REMORA_ACTIVE = $null
         VIRTUAL_ENV = $null
         CONDA_DEFAULT_ENV = $null
@@ -135,14 +182,18 @@ function Invoke-Statusline(
     [string]$Arguments,
     [int]$TimeoutMs
 ) {
-    $psArgs = '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + $Script + '"'
+    $runtimeScript = $Script
+    if ($ExtraEnvironment.ContainsKey('CORALLINE_TEST_NOW') -and $null -ne $ExtraEnvironment.CORALLINE_TEST_NOW) { $runtimeScript = $script:StateScript }
+    $psArgs = '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + $runtimeScript + '"'
     if (-not [string]::IsNullOrEmpty($Arguments)) { $psArgs += ' ' + $Arguments }
     return Invoke-CapturedProcess $PowerShellExe $psArgs $Json (Runtime-Environment $ConfigPath $ExtraEnvironment) $Repo $TimeoutMs
 }
 
 function Invoke-BashStatusline([string]$Json, [string]$ConfigPath, [hashtable]$ExtraEnvironment) {
     $environment = Runtime-Environment $ConfigPath $ExtraEnvironment
-    $args = '--noprofile --norc "' + (Forward-Path $BashScript) + '"'
+    $runtimeScript = $BashScript
+    if ($ExtraEnvironment.ContainsKey('CORALLINE_TEST_NOW') -and $null -ne $ExtraEnvironment.CORALLINE_TEST_NOW) { $runtimeScript = $script:StateBashScript }
+    $args = '--noprofile --norc "' + (Forward-Path $runtimeScript) + '"'
     return Invoke-CapturedProcess $script:BashExe $args $Json $environment $Repo 10000
 }
 
@@ -151,6 +202,9 @@ function Check-Run([string]$Name, $Run) {
     Check "$Name exit 0" ($Run.ExitCode -eq 0)
     Check "$Name stderr empty" ($Run.StderrBytes.Length -eq 0)
     Check "$Name strict UTF-8 stdout" ($null -ne $Run.Stdout)
+    if ($Run.TimedOut -or $Run.ExitCode -ne 0 -or $Run.StderrBytes.Length -ne 0) {
+        [Console]::Out.WriteLine('DIAG  ' + $Name + ' stderr=' + [Convert]::ToBase64String($Run.StderrBytes))
+    }
 }
 
 function Plain([string]$Text) {
@@ -248,6 +302,36 @@ function Snapshot-Ads([string]$Carrier, [string]$StreamName) {
     return "$($item.Length)|$hash"
 }
 
+function Snapshot-StateTree([string]$Root) {
+    if (-not (Test-Path -LiteralPath $Root)) { return '<missing>' }
+    $lines = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($item in @(Get-ChildItem -LiteralPath $Root -Recurse -Force | Sort-Object FullName)) {
+        $relative = $item.FullName.Substring($Root.Length).Replace('\','/')
+        $length = 0L
+        if (-not $item.PSIsContainer) { $length = $item.Length }
+        [void]$lines.Add(('{0}|{1}|{2}|{3}|{4}|{5}' -f $relative,$item.Attributes,$length,$item.CreationTimeUtc.Ticks,$item.LastWriteTimeUtc.Ticks,$item.LastAccessTimeUtc.Ticks))
+    }
+    return $lines -join "`n"
+}
+
+function Get-ImmediateNames([string]$Root) {
+    if (-not [IO.Directory]::Exists($Root)) { return ,([string[]]@()) }
+    return ,([string[]]@([IO.Directory]::EnumerateFileSystemEntries($Root) | ForEach-Object { [IO.Path]::GetFileName($_) } | Sort-Object))
+}
+
+function Wait-StateBarrier([string]$Barrier, [int]$Count, [int]$TimeoutMs) {
+    $watch = [Diagnostics.Stopwatch]::StartNew()
+    $dir = [IO.Path]::GetDirectoryName($Barrier)
+    $pattern = [IO.Path]::GetFileName($Barrier) + '.*.ready'
+    while ($watch.ElapsedMilliseconds -lt $TimeoutMs) {
+        $ready = 0
+        foreach ($unused in [IO.Directory]::EnumerateFiles($dir, $pattern)) { $ready++ }
+        if ($ready -ge $Count) { return $true }
+        [Threading.Thread]::Sleep(10)
+    }
+    return $false
+}
+
 function Run-Git([string]$WorkingDirectory, [string]$Arguments) {
     $run = Invoke-CapturedProcess $script:GitExe $Arguments '' @{} $WorkingDirectory 10000
     if ($run.TimedOut -or $run.ExitCode -ne 0) { throw "git failed: $Arguments`n$($run.Stderr)" }
@@ -277,6 +361,118 @@ try {
     $source = [System.IO.File]::ReadAllText($Script, $StrictUtf8)
     $bashSource = [System.IO.File]::ReadAllText($BashScript, $StrictUtf8)
 
+    # Deterministic clock, state capture, and snapshot barriers live only in test
+    # copies. Production has no hidden environment-controlled time or I/O hooks.
+    $script:StateScript = Join-Path $TempRoot 'statusline-state-test.ps1'
+    $psClock = '$Now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()'
+    $psClockHook = @'
+$Now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+$testNowValue = 0L
+if ([string]$env:CORALLINE_TEST_STRICT -eq '1') { $ErrorActionPreference = 'Stop' }
+if ([string]$env:CORALLINE_TEST_NOW -match '\A(?:0|[1-9][0-9]{0,11})\z' -and [long]::TryParse([string]$env:CORALLINE_TEST_NOW, $IntegerStyle, $Invariant, [ref]$testNowValue) -and $testNowValue -le 253402300799L) { $Now = $testNowValue }
+'@
+    $psBarrierMarker = '    $burnRetention = [pscustomobject]@{ Candidates=@(); Representatives=@() }'
+    $psBarrierHook = @'
+    if (-not [string]::IsNullOrEmpty([string]$env:CORALLINE_TEST_BARRIER)) {
+        [IO.File]::WriteAllBytes(([string]$env:CORALLINE_TEST_BARRIER + '.' + [string]$PID + '.ready'), [byte[]]@())
+        while (-not [IO.File]::Exists([string]$env:CORALLINE_TEST_BARRIER)) { Start-Sleep -Milliseconds 10 }
+    }
+    $burnRetention = [pscustomobject]@{ Candidates=@(); Representatives=@() }
+'@
+    $psDumpMarker = '    $State = Get-CorallineState $BurnStateGate $Limit5StateGate $Limit7StateGate'
+    $psDumpHook = @'
+    $State = Get-CorallineState $BurnStateGate $Limit5StateGate $Limit7StateGate
+    if (-not [string]::IsNullOrEmpty([string]$env:CORALLINE_TEST_STATE_DUMP)) {
+        $capture = [ordered]@{
+            BurnState=$State.Burn.State; BurnLabel=$State.Burn.Label; BurnEta=$State.Burn.Eta; BurnRate=$State.Burn.Rate; BurnTtr=$State.Burn.Ttr
+            FiveState=$State.Five.State; FiveEta=$State.Five.Eta; FiveRate=$State.Five.Rate; FiveTtr=$State.Five.Ttr
+            SevenEta=$State.Seven.Eta; SevenRate=$State.Seven.Rate; SevenTtr=$State.Seven.Ttr
+            Limit5Valid=$State.Limit5.Valid; Limit5Reset=$State.Limit5.Reset; Limit5Pct=$State.Limit5.Pct
+            Limit7Valid=$State.Limit7.Valid; Limit7Reset=$State.Limit7.Reset; Limit7Pct=$State.Limit7.Pct
+            BurnSnapshotComplete=$State.BurnSnapshotComplete; Limit5SnapshotComplete=$State.Limit5SnapshotComplete; Limit7SnapshotComplete=$State.Limit7SnapshotComplete
+        }
+        [IO.File]::WriteAllText([string]$env:CORALLINE_TEST_STATE_DUMP, ($capture | ConvertTo-Json -Compress), $Utf8NoBom)
+    }
+'@
+    $psAfterCreateMarker = "            `$stream.Dispose()`n            return `$true"
+    $psAfterCreateHook = @'
+            $stream.Dispose()
+            if (-not [string]::IsNullOrEmpty([string]$env:CORALLINE_TEST_AFTER_CREATE)) {
+                [IO.File]::WriteAllBytes(([string]$env:CORALLINE_TEST_AFTER_CREATE + '.' + [string]$PID + '.ready'), [byte[]]@())
+                while (-not [IO.File]::Exists([string]$env:CORALLINE_TEST_AFTER_CREATE)) { Start-Sleep -Milliseconds 10 }
+            }
+            return $true
+'@
+    $psMathMarker = 'function Format-StatePct([int]$Milli) {'
+    $psMathHook = @'
+if (-not [string]::IsNullOrEmpty([string]$env:CORALLINE_TEST_MATH_DUMP)) {
+    $values = @(
+        (Get-RoundEvenInt64 5L 2L),
+        (Get-RoundEvenInt64 7L 2L),
+        (Get-RoundEvenInt64 4L 3L),
+        (Get-RoundEvenInt64 5L 3L),
+        (Format-StateRate 10000000000L 3L),
+        (Format-StateRate 19999999999L 2L),
+        (Get-RoundEvenInt64 8639913600L 1000L)
+    )
+    [IO.File]::WriteAllText([string]$env:CORALLINE_TEST_MATH_DUMP, ($values -join '|'), $Utf8NoBom)
+    [Environment]::Exit(0)
+}
+function Format-StatePct([int]$Milli) {
+'@
+    if (-not $source.Contains($psClock) -or -not $source.Contains($psBarrierMarker) -or -not $source.Contains($psDumpMarker) -or -not $source.Contains($psAfterCreateMarker) -or -not $source.Contains($psMathMarker)) { throw 'PowerShell state test marker missing' }
+    $statePsSource = $source.Replace($psClock, $psClockHook.TrimEnd()).Replace($psBarrierMarker, $psBarrierHook.TrimEnd()).Replace($psDumpMarker, $psDumpHook.TrimEnd()).Replace($psAfterCreateMarker, $psAfterCreateHook.TrimEnd()).Replace($psMathMarker, $psMathHook.TrimEnd())
+    Write-Utf8 $script:StateScript $statePsSource
+
+    $script:StateBashScript = Join-Path $TempRoot 'statusline-state-test.sh'
+    $bashClock = 'printf -v NOW ''%(%s)T'' -1 2>/dev/null || NOW=$(date +%s)'
+    $bashClockHook = @'
+printf -v NOW '%(%s)T' -1 2>/dev/null || NOW=$(date +%s)
+case "${CORALLINE_TEST_NOW:-}" in
+  (0|[1-9][0-9]*)
+    if [ "${#CORALLINE_TEST_NOW}" -le 12 ]; then
+      _TEST_NOW=$(( 10#$CORALLINE_TEST_NOW ))
+      [ "$_TEST_NOW" -le 253402300799 ] && NOW=$_TEST_NOW
+    fi ;;
+esac
+'@
+    $bashBarrierMarker = '  state_snapshot' + "`n" + '  if [ "$_STATE_BURN_GATE" = 1 ]; then'
+    $bashBarrierHook = @'
+  state_snapshot
+  if [ -n "${CORALLINE_TEST_BARRIER:-}" ]; then
+    set -C
+    { : > "${CORALLINE_TEST_BARRIER}.$$.ready"; } 2>/dev/null || true
+    set +C
+    while [ ! -e "$CORALLINE_TEST_BARRIER" ]; do sleep 0.01; done
+  fi
+  if [ "$_STATE_BURN_GATE" = 1 ]; then
+'@
+    $bashDumpMarker = "  state_prepare`nfi`n`n# Defensive ANSI stripper"
+    $bashDumpHook = @'
+  state_prepare
+  if [ -n "${CORALLINE_TEST_STATE_DUMP:-}" ]; then
+    printf '%s\n' "BurnState=$_BURN_STATE BurnLabel=$_BURN_LABEL BurnEta=$_BURN_ETA BurnRate=$_BURN_RATE BurnTtr=$_BURN_TTR FiveState=$_B5_STATE FiveEta=$_B5_ETA FiveRate=$_B5_RATE FiveTtr=$_B5_TTR SevenEta=$_B7_ETA SevenRate=$_B7_RATE SevenTtr=$_B7_TTR Limit5Valid=$_STATE_RL5_VALID Limit5Reset=$_STATE_RL5_RST Limit5Pct=$_STATE_RL5_PCT Limit7Valid=$_STATE_RL7_VALID Limit7Reset=$_STATE_RL7_RST Limit7Pct=$_STATE_RL7_PCT" > "$CORALLINE_TEST_STATE_DUMP"
+  fi
+fi
+
+# Defensive ANSI stripper
+'@
+    $bashAfterCreateMarker = '      if { : > "$path"; } 2>/dev/null; then _PUB_BURN_PATH="$path"; break; fi'
+    $bashAfterCreateHook = @'
+      if { : > "$path"; } 2>/dev/null; then
+        _PUB_BURN_PATH="$path"
+        if [ -n "${CORALLINE_TEST_AFTER_CREATE:-}" ]; then
+          { : > "${CORALLINE_TEST_AFTER_CREATE}.$$.ready"; } 2>/dev/null || true
+          while [ ! -e "$CORALLINE_TEST_AFTER_CREATE" ]; do sleep 0.01; done
+        fi
+        break
+      fi
+'@
+    if (-not $bashSource.Contains($bashClock) -or -not $bashSource.Contains($bashBarrierMarker) -or -not $bashSource.Contains($bashDumpMarker) -or -not $bashSource.Contains($bashAfterCreateMarker)) { throw 'Bash state test marker missing' }
+    $stateBashSource = $bashSource.Replace($bashClock, $bashClockHook.TrimEnd()).Replace($bashBarrierMarker, $bashBarrierHook.TrimEnd()).Replace($bashDumpMarker, $bashDumpHook.TrimEnd()).Replace($bashAfterCreateMarker, $bashAfterCreateHook.TrimEnd())
+    Write-Utf8 $script:StateBashScript $stateBashSource
+
+    Check 'static source has no production deterministic-clock hook' (-not $source.Contains('CORALLINE_TEST_NOW') -and -not $bashSource.Contains('CORALLINE_TEST_NOW'))
     Check 'static source has no mojibake double question token' (-not $source.Contains(('?' + '?')))
     Check 'static source has no dangling handoff reference' (-not $source.Contains('handoff/'))
     Check 'static source forbids Invoke-Expression' (-not $source.Contains('Invoke-Expression'))
@@ -286,12 +482,12 @@ try {
     Check 'reparse validation precedes config read' ($source.IndexOf('Test-SafeRegularFile $Path') -lt $source.IndexOf('Read-StrictUtf8File $Path'))
     Check 'Bash oracle main extraction contains central scrub' ($bashSource.Contains('] | map(scrub) | join('))
 
-    $expectedRegistry = @('clock','cost','ctx','dir','duration','effort','git','limit5h','limit7d','lines','model','node','project','python','stash','style')
+    $expectedRegistry = @('burn','clock','cost','ctx','dir','duration','effort','git','limit5h','limit7d','lines','model','node','project','python','stash','style')
     $builderBlock = [regex]::Match($source, '(?s)\$SegmentBuilders = \[ordered\]@\{(.*?)\n\}').Groups[1].Value
     $actualRegistry = @([regex]::Matches($builderBlock, '(?m)^    ([A-Za-z0-9]+) =') | ForEach-Object { $_.Groups[1].Value } | Sort-Object)
-    Check 'closed PowerShell registry equals WIN-01 inventory' (($actualRegistry -join ' ') -eq (($expectedRegistry | Sort-Object) -join ' '))
-    $bashSegments = @([regex]::Matches($bashSource, '(?m)^seg_([A-Za-z0-9_]+)\(\)') | ForEach-Object { $_.Groups[1].Value } | Where-Object { $_ -ne 'len' -and $_ -ne 'limit' -and $_ -ne 'burn' } | Sort-Object -Unique)
-    Check 'Bash public registry minus burn equals WIN-01 inventory' (($bashSegments -join ' ') -eq (($expectedRegistry | Sort-Object) -join ' '))
+    Check 'closed PowerShell registry equals WIN-02 inventory' (($actualRegistry -join ' ') -eq (($expectedRegistry | Sort-Object) -join ' '))
+    $bashSegments = @([regex]::Matches($bashSource, '(?m)^seg_([A-Za-z0-9_]+)\(\)') | ForEach-Object { $_.Groups[1].Value } | Where-Object { $_ -ne 'len' -and $_ -ne 'limit' } | Sort-Object -Unique)
+    Check 'Bash public registry equals WIN-02 inventory' (($bashSegments -join ' ') -eq (($expectedRegistry | Sort-Object) -join ' '))
 
     $script:BashExe = $env:CORALLINE_TEST_BASH
     if ([string]::IsNullOrEmpty($script:BashExe)) { $script:BashExe = 'C:\Program Files\Git\bin\bash.exe' }
@@ -592,7 +788,13 @@ fi
     [void](Run-ModelColor 'inactive includes consume no shared budget' $inactiveBudget '91' @{ REMORA_ACTIVE='0' })
 
     $baseConfigLines = @('VL_CLOCK=off')
+    $burnPayload = Clone-Object $basePayload
+    $burnPayload.rate_limits.five_hour.used_percentage = $null
+    $burnPayload.rate_limits.five_hour.resets_at = $null
+    $burnPayload.rate_limits.seven_day.used_percentage = '30'
+    $burnPayload.rate_limits.seven_day.resets_at = '1345600'
     $segmentCases = [ordered]@{
+        burn = [pscustomobject]@{ Show=@('VL_SEGMENTS=burn','VL_CLOCK=off'); Needle=((Glyph 0x2197) + ' 7d ' + (Glyph 0x21E2)); Payload=$burnPayload; Environment=@{CORALLINE_TEST_NOW='1000000'}; Suppress={ param($p) $p.rate_limits.five_hour.used_percentage=$null; $p.rate_limits.seven_day.used_percentage=$null; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=burn' }
         clock = [pscustomobject]@{ Show=@('VL_SEGMENTS=clock','VL_CLOCK=24h','VL_CLOCK_SECONDS=0'); Needle=(Glyph 0x2299); Suppress={ param($p) $p }; SuppressConfig=@('VL_SEGMENTS=clock','VL_CLOCK=off') }
         cost = [pscustomobject]@{ Show=@('VL_SEGMENTS=cost','VL_CLOCK=off'); Needle='$1.23'; Suppress={ param($p) $p.cost.total_cost_usd=0; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=cost' }
         ctx = [pscustomobject]@{ Show=@('VL_SEGMENTS=ctx','VL_CLOCK=off'); Needle='62%'; Suppress={ param($p) $p.context_window.used_percentage=$null; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=ctx' }
@@ -613,14 +815,18 @@ fi
 
     foreach ($name in $expectedRegistry) {
         $case = $segmentCases[$name]
+        $showPayload = $basePayload
+        if ($null -ne $case.PSObject.Properties['Payload']) { $showPayload = $case.Payload }
+        $caseEnvironment = @{}
+        if ($null -ne $case.PSObject.Properties['Environment']) { $caseEnvironment = $case.Environment }
         $showConfig = New-Config ("segment-$name-show") $case.Show
-        $show = Invoke-Statusline (Json $basePayload) $showConfig @{} '' 5000
+        $show = Invoke-Statusline (Json $showPayload) $showConfig $caseEnvironment '' 5000
         Check-Run "$name show" $show
         Check "$name show/value" ((Plain $show.Stdout).Contains([string]$case.Needle))
-        $suppressedPayload = Clone-Object $basePayload
+        $suppressedPayload = Clone-Object $showPayload
         $suppressedPayload = & $case.Suppress $suppressedPayload
         $suppressConfig = New-Config ("segment-$name-suppress") $case.SuppressConfig
-        $suppress = Invoke-Statusline (Json $suppressedPayload) $suppressConfig @{} '' 5000
+        $suppress = Invoke-Statusline (Json $suppressedPayload) $suppressConfig $caseEnvironment '' 5000
         Check-Run "$name suppress" $suppress
         Check "$name suppresses without an empty pill" ([string]::IsNullOrEmpty($suppress.Stdout))
     }
@@ -789,6 +995,720 @@ fi
     Check-Run 'codepage 437 raw I/O' $codepageRun
     Check 'stdout is UTF-8 without BOM' ($codepageRun.StdoutBytes.Length -ge 3 -and -not ($codepageRun.StdoutBytes[0] -eq 0xEF -and $codepageRun.StdoutBytes[1] -eq 0xBB -and $codepageRun.StdoutBytes[2] -eq 0xBF) -and $codepageRun.Stdout.Contains((Glyph 0x96EA)))
     Check 'stdout uses LF without CR' (-not ($codepageRun.StdoutBytes -contains [byte]13) -and $codepageRun.StdoutBytes[$codepageRun.StdoutBytes.Length - 1] -eq 10)
+
+    # WIN-02 immutable state, estimator parity, mixed writers, and path boundaries.
+    $stateRoot = Join-Path $TempRoot 'win02-state'
+    [void][IO.Directory]::CreateDirectory($stateRoot)
+    $fixedNow = 1000000L
+    $reset5 = 1015900L
+    $reset7 = 1345600L
+    $statePayload = Clone-Object $basePayload
+    $statePayload.rate_limits.five_hour.used_percentage = '41.2'
+    $statePayload.rate_limits.five_hour.resets_at = [string]$reset5
+    $statePayload.rate_limits.seven_day.used_percentage = '30'
+    $statePayload.rate_limits.seven_day.resets_at = [string]$reset7
+    $stateEnvWrite = @{ CORALLINE_NO_SAMPLE=$null; CORALLINE_TEST_NOW=[string]$fixedNow }
+    $stateEnvRead = @{ CORALLINE_NO_SAMPLE='1'; CORALLINE_TEST_NOW=[string]$fixedNow }
+
+    $mathDump = Join-Path $stateRoot 'math.txt'
+    $mathArgs = '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + $script:StateScript + '"'
+    $mathRun = Invoke-CapturedProcess $PowerShellExe $mathArgs '' (Runtime-Environment '' @{ CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_MATH_DUMP=$mathDump }) $Repo 10000
+    Check-Run 'WIN-02 PowerShell exact rational helper vectors' $mathRun
+    Check 'WIN-02 exact midpoint/rate/carry/max arithmetic' ([IO.File]::ReadAllText($mathDump, $StrictUtf8) -ceq '2|4|1|2|0.3333333333|1.0000000000|8639914')
+
+    function New-StateConfig([string]$Name, [string]$Root, [string]$Segments, [bool]$Sync) {
+        [void][IO.Directory]::CreateDirectory($Root)
+        $burn = Forward-Path (Join-Path $Root 'burn.tsv')
+        $limit5 = Forward-Path (Join-Path $Root 'limit5.tsv')
+        $limit7 = Forward-Path (Join-Path $Root 'limit7.tsv')
+        $lines = @(
+            ('VL_SEGMENTS=' + (Quote-FromConfigure $Segments)),
+            'VL_CLOCK=off',
+            ("BURN_FILE='$burn'"),
+            ("RL5H_FILE='$limit5'"),
+            ("RL7D_FILE='$limit7'")
+        )
+        if ($Sync) { $lines += 'VL_LIMIT_SYNC=1' }
+        return New-Config $Name $lines
+    }
+
+    $sequentialRoot = Join-Path $stateRoot 'sequential'
+    $sequentialConfig = New-StateConfig 'win02-sequential' $sequentialRoot 'burn limit5h limit7d' $true
+    $psWrite = Invoke-Statusline (Json $statePayload) $sequentialConfig $stateEnvWrite '' 10000
+    Check-Run 'WIN-02 PowerShell first writer' $psWrite
+    $burnStore = Join-Path $sequentialRoot 'burn.d'
+    $limit5Store = Join-Path $sequentialRoot 'limit5.d'
+    $limit7Store = Join-Path $sequentialRoot 'limit7.d'
+    $burnNames = Get-ImmediateNames $burnStore
+    Check 'WIN-02 PowerShell canonical burn name' ($burnNames.Count -eq 1 -and $burnNames[0] -ceq 'b_000001015900_000001000000_041.200_0000')
+    Check 'WIN-02 PowerShell canonical 5h directory' ([IO.Directory]::Exists((Join-Path $limit5Store '0001015900_041.200')))
+    Check 'WIN-02 PowerShell canonical 7d directory' ([IO.Directory]::Exists((Join-Path $limit7Store '0001345600_030.000')))
+    Check 'WIN-02 PowerShell writer leaves legacy TSV absent' (-not [IO.File]::Exists((Join-Path $sequentialRoot 'burn.tsv')))
+
+    $bashRead = Invoke-BashStatusline (Json $statePayload) $sequentialConfig $stateEnvRead
+    Check-Run 'WIN-02 Bash reads PowerShell state' $bashRead
+    Check-Exact 'WIN-02 Bash reader matches PowerShell fixed-pill output' $bashRead $psWrite
+    Remove-Item -LiteralPath $burnStore,$limit5Store,$limit7Store -Recurse -Force
+    $bashWrite = Invoke-BashStatusline (Json $statePayload) $sequentialConfig $stateEnvWrite
+    Check-Run 'WIN-02 Bash first writer' $bashWrite
+    $burnNames = Get-ImmediateNames $burnStore
+    Check 'WIN-02 Bash canonical burn name' ($burnNames.Count -eq 1 -and $burnNames[0] -ceq 'b_000001015900_000001000000_041.200_0000')
+    $psRead = Invoke-Statusline (Json $statePayload) $sequentialConfig $stateEnvRead '' 10000
+    Check-Run 'WIN-02 PowerShell reads Bash state' $psRead
+    Check-Exact 'WIN-02 PowerShell reader matches Bash fixed-pill output' $psRead $bashWrite
+
+    # C:\, C:/, and /c/ spellings must resolve to the same physical store.
+    $identityRoot = Join-Path $stateRoot 'identity'
+    [void][IO.Directory]::CreateDirectory($identityRoot)
+    $identityNative = Join-Path $identityRoot 'burn.tsv'
+    $identityForward = Forward-Path $identityNative
+    $identityMsys = '/' + $identityForward.Substring(0,1).ToLowerInvariant() + $identityForward.Substring(2)
+    $identityForms = @($identityNative, $identityForward, $identityMsys)
+    for ($i=0; $i -lt $identityForms.Count; $i++) {
+        $config = New-Config ("win02-identity-$i") @('VL_SEGMENTS=burn','VL_CLOCK=off',("BURN_FILE='" + $identityForms[$i] + "'"))
+        $payload = Clone-Object $statePayload
+        $payload.rate_limits.five_hour.used_percentage = [string](10 + $i)
+        $identityDump = Join-Path $identityRoot ("state-$i.txt")
+        $identityEnv = @{ CORALLINE_NO_SAMPLE=$null; CORALLINE_TEST_NOW=[string]($fixedNow + $i); CORALLINE_TEST_STATE_DUMP=(Forward-Path $identityDump) }
+        if ($i -eq 2) { $identityEnv.CORALLINE_TEST_STRICT='1' }
+        if (($i % 2) -eq 0) { $run = Invoke-Statusline (Json $payload) $config $identityEnv '' 10000 }
+        else { $run = Invoke-BashStatusline (Json $payload) $config $identityEnv }
+        Check-Run "WIN-02 path identity writer $i" $run
+    }
+    $identityNames = Get-ImmediateNames (Join-Path $identityRoot 'burn.d')
+    if ($identityNames.Count -ne 3) {
+        [Console]::Out.WriteLine('DIAG  WIN-02 identity names=' + ($identityNames -join ','))
+        foreach ($dump in @(Get-ChildItem -LiteralPath $identityRoot -Filter 'state-*.txt' -File | Sort-Object Name)) { [Console]::Out.WriteLine('DIAG  ' + $dump.Name + '=' + [IO.File]::ReadAllText($dump.FullName, $StrictUtf8)) }
+    }
+    Check 'WIN-02 C native/forward/MSYS forms share one store' ($identityNames.Count -eq 3)
+
+    # Exact decimal vectors are checked through committed filenames in both runtimes.
+    $pctVectors = @(
+        [pscustomobject]@{Raw='1.2345'; Canon='001.234'; Valid=$true},
+        [pscustomobject]@{Raw='1.2355'; Canon='001.236'; Valid=$true},
+        [pscustomobject]@{Raw='99.9995'; Canon='100.000'; Valid=$true},
+        [pscustomobject]@{Raw='100.000001'; Canon=''; Valid=$false},
+        [pscustomobject]@{Raw='-0'; Canon=''; Valid=$false},
+        [pscustomobject]@{Raw='1e2'; Canon=''; Valid=$false},
+        [pscustomobject]@{Raw='1,2'; Canon=''; Valid=$false}
+    )
+    for ($i=0; $i -lt $pctVectors.Count; $i++) {
+        $vectorRoot = Join-Path $stateRoot ("pct-$i")
+        $config = New-StateConfig ("win02-pct-$i") $vectorRoot 'burn' $false
+        $payload = Clone-Object $statePayload
+        $payload.rate_limits.five_hour.used_percentage = $pctVectors[$i].Raw
+        if (($i % 2) -eq 0) { $run = Invoke-Statusline (Json $payload) $config $stateEnvWrite '' 10000 }
+        else { $run = Invoke-BashStatusline (Json $payload) $config $stateEnvWrite }
+        Check-Run "WIN-02 canonical pct writer $i" $run
+        $names = Get-ImmediateNames (Join-Path $vectorRoot 'burn.d')
+        if ($pctVectors[$i].Valid) { Check "WIN-02 canonical pct $($pctVectors[$i].Raw)" ($names.Count -eq 1 -and $names[0].Contains('_' + $pctVectors[$i].Canon + '_')) }
+        else { Check "WIN-02 rejects pct $($pctVectors[$i].Raw)" ($names.Count -eq 0) }
+    }
+
+    # Store-only estimator vector: exact same-second reduction, rate-derived ETA,
+    # reset isolation, and raw fixed-pill output must agree.
+    $estimateRoot = Join-Path $stateRoot 'estimate'
+    $estimateConfig = New-StateConfig 'win02-estimate' $estimateRoot 'burn' $false
+    $estimateStore = Join-Path $estimateRoot 'burn.d'
+    [void][IO.Directory]::CreateDirectory($estimateStore)
+    foreach ($name in @(
+        'b_000001015900_000000999640_006.000_0000',
+        'b_000001015900_000000999700_007.000_0000',
+        'b_000001015900_000000999700_006.500_0001',
+        'b_000001015900_000000999940_008.000_0000',
+        'b_000001015900_000001000000_008.000_0000',
+        'b_000001010000_000000999900_051.000_0000'
+    )) { [IO.File]::WriteAllBytes((Join-Path $estimateStore $name), [byte[]]@()) }
+    $estimatePayload = Clone-Object $statePayload
+    $estimatePayload.rate_limits.five_hour.used_percentage = '8'
+    $estimatePsDump = Join-Path $estimateRoot 'ps-state.json'
+    $estimateBashDump = Join-Path $estimateRoot 'bash-state.txt'
+    $estimatePsEnv = @{ CORALLINE_NO_SAMPLE='1'; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_STATE_DUMP=$estimatePsDump }
+    $estimateBashEnv = @{ CORALLINE_NO_SAMPLE='1'; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_STATE_DUMP=(Forward-Path $estimateBashDump) }
+    $estimatePs = Invoke-Statusline (Json $estimatePayload) $estimateConfig $estimatePsEnv '' 10000
+    $estimateBash = Invoke-BashStatusline (Json $estimatePayload) $estimateConfig $estimateBashEnv
+    Check-Run 'WIN-02 PowerShell estimator vector' $estimatePs
+    Check-Run 'WIN-02 Bash estimator vector' $estimateBash
+    $estimatePsState = [IO.File]::ReadAllText($estimatePsDump, $StrictUtf8) | ConvertFrom-Json
+    $estimateBashState = [IO.File]::ReadAllText($estimateBashDump, $StrictUtf8).Trim()
+    Check 'WIN-02 PowerShell exact estimator semantics' ($estimatePsState.FiveState -eq 'active' -and [string]$estimatePsState.FiveEta -eq '22080' -and $estimatePsState.FiveRate -eq '0.0041666667' -and [string]$estimatePsState.FiveTtr -eq '15900' -and $estimatePsState.BurnLabel -eq '5h')
+    Check 'WIN-02 same-second maximum preserves synthetic slope' ($estimatePsState.FiveEta -eq 22080 -and $estimatePsState.FiveRate -eq '0.0041666667')
+    Check 'WIN-02 Bash exact estimator semantics' ($estimateBashState.Contains('FiveState=active FiveEta=22080 FiveRate=0.0041666667 FiveTtr=15900') -and $estimateBashState.Contains('BurnState=active BurnLabel=5h BurnEta=22080'))
+    if (-not ($estimatePsState.FiveState -eq 'active')) { [Console]::Out.WriteLine('DIAG  WIN-02 PowerShell state=' + ([IO.File]::ReadAllText($estimatePsDump, $StrictUtf8))) }
+    Check-Exact 'WIN-02 estimator fixed-pill differential' $estimatePs $estimateBash
+    Check 'WIN-02 estimator exact ETA visible' ((Plain $estimatePs.Stdout).Contains((Glyph 0x2197) + ' ' + (Glyph 0x2713)))
+
+    # 7d rational vectors straddle an exact .5 ETA without binary floating point.
+    # The exact midpoint has an even quotient and stays down; one milli-percent
+    # below/above it lands on opposite sides. Both runtimes expose the same state.
+    foreach ($vector in @(
+        [pscustomobject]@{Pct='39.999'; Eta='5'; Rate=''},
+        [pscustomobject]@{Pct='40'; Eta='4'; Rate='13.3333333333'},
+        [pscustomobject]@{Pct='40.001'; Eta='4'; Rate=''}
+    )) {
+        $rationalRoot = Join-Path $stateRoot ('rational-' + $vector.Pct.Replace('.','-'))
+        $rationalConfig = New-StateConfig ('win02-rational-' + $vector.Pct.Replace('.','-')) $rationalRoot 'burn' $false
+        $rationalPayload = Clone-Object $statePayload
+        $rationalPayload.rate_limits.five_hour.used_percentage = $null
+        $rationalPayload.rate_limits.five_hour.resets_at = $null
+        $rationalPayload.rate_limits.seven_day.used_percentage = $vector.Pct
+        $rationalPayload.rate_limits.seven_day.resets_at = [string]($fixedNow + 604797L)
+        $psDump = Join-Path $rationalRoot 'ps.json'
+        $bashDump = Join-Path $rationalRoot 'bash.txt'
+        $psEnv = @{ CORALLINE_NO_SAMPLE='1'; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_STATE_DUMP=$psDump }
+        $bashEnv = @{ CORALLINE_NO_SAMPLE='1'; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_STATE_DUMP=(Forward-Path $bashDump) }
+        $psRun = Invoke-Statusline (Json $rationalPayload) $rationalConfig $psEnv '' 10000
+        $bashRun = Invoke-BashStatusline (Json $rationalPayload) $rationalConfig $bashEnv
+        Check-Run ('WIN-02 PowerShell rational pct ' + $vector.Pct) $psRun
+        Check-Run ('WIN-02 Bash rational pct ' + $vector.Pct) $bashRun
+        Check-Exact ('WIN-02 rational fixed-pill differential ' + $vector.Pct) $psRun $bashRun
+        $psState = [IO.File]::ReadAllText($psDump, $StrictUtf8) | ConvertFrom-Json
+        $bashState = [IO.File]::ReadAllText($bashDump, $StrictUtf8).Trim()
+        Check ('WIN-02 rational ETA ' + $vector.Pct) ([string]$psState.SevenEta -eq $vector.Eta -and $bashState.Contains('SevenEta=' + $vector.Eta + ' '))
+        if (-not [string]::IsNullOrEmpty($vector.Rate)) { Check 'WIN-02 rational non-divisible 7d rate' ($psState.SevenRate -eq $vector.Rate -and $bashState.Contains('SevenRate=' + $vector.Rate + ' ')) }
+        Check ('WIN-02 rational no-sample root absent ' + $vector.Pct) (-not [IO.Directory]::Exists((Join-Path $rationalRoot 'burn.d')))
+    }
+
+    # Deterministic controls distinguish unchanged usage, truly idle history, and
+    # reset rollover. No live Claude quota movement is used as correctness evidence.
+    foreach ($control in @(
+        [pscustomobject]@{
+            Name='unchanged'; Expected='warming'; Pct='10';
+            Entries=@(
+                'b_000001015900_000000999500_010.000_0000',
+                'b_000001015900_000000999700_010.000_0000',
+                'b_000001015900_000000999900_010.000_0000'
+            )
+        },
+        [pscustomobject]@{
+            Name='idle'; Expected='idle'; Pct='6';
+            Entries=@(
+                'b_000001015900_000000999000_005.000_0000',
+                'b_000001015900_000000999100_006.000_0000',
+                'b_000001015900_000000999900_006.000_0000'
+            )
+        },
+        [pscustomobject]@{
+            Name='reset-rollover'; Expected='warming'; Pct='2';
+            Entries=@(
+                'b_000001010000_000000999500_005.000_0000',
+                'b_000001010000_000000999700_006.000_0000',
+                'b_000001010000_000000999900_007.000_0000',
+                'b_000001015900_000000999950_002.000_0000'
+            )
+        }
+    )) {
+        $controlRoot = Join-Path $stateRoot ('estimator-' + $control.Name)
+        $controlConfig = New-StateConfig ('win02-estimator-' + $control.Name) $controlRoot 'burn' $false
+        $controlStore = Join-Path $controlRoot 'burn.d'
+        [void][IO.Directory]::CreateDirectory($controlStore)
+        foreach ($name in $control.Entries) { [IO.File]::WriteAllBytes((Join-Path $controlStore $name), [byte[]]@()) }
+        $controlPayload = Clone-Object $statePayload
+        $controlPayload.rate_limits.five_hour.used_percentage = $control.Pct
+        $controlPayload.rate_limits.seven_day.used_percentage = $null
+        $controlPayload.rate_limits.seven_day.resets_at = $null
+        $psDump = Join-Path $controlRoot 'ps.json'
+        $bashDump = Join-Path $controlRoot 'bash.txt'
+        $psEnv = @{ CORALLINE_NO_SAMPLE='1'; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_STATE_DUMP=$psDump }
+        $bashEnv = @{ CORALLINE_NO_SAMPLE='1'; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_STATE_DUMP=(Forward-Path $bashDump) }
+        $psRun = Invoke-Statusline (Json $controlPayload) $controlConfig $psEnv '' 10000
+        $bashRun = Invoke-BashStatusline (Json $controlPayload) $controlConfig $bashEnv
+        Check-Run ('WIN-02 PowerShell estimator control ' + $control.Name) $psRun
+        Check-Run ('WIN-02 Bash estimator control ' + $control.Name) $bashRun
+        Check-Exact ('WIN-02 estimator control differential ' + $control.Name) $psRun $bashRun
+        $psState = [IO.File]::ReadAllText($psDump, $StrictUtf8) | ConvertFrom-Json
+        $bashState = [IO.File]::ReadAllText($bashDump, $StrictUtf8).Trim()
+        Check ('WIN-02 deterministic estimator state ' + $control.Name) ($psState.FiveState -eq $control.Expected -and $bashState.Contains('FiveState=' + $control.Expected + ' '))
+    }
+
+    # Legacy is bounded, permanently read-only, deduplicated in memory, and never
+    # imported as l_* state.
+    $legacyRoot = Join-Path $stateRoot 'legacy'
+    $legacyConfig = New-StateConfig 'win02-legacy' $legacyRoot 'burn' $false
+    $legacyPath = Join-Path $legacyRoot 'burn.tsv'
+    Write-Utf8 $legacyPath "999640`t6`t1015900`n999700`t7`t1015900`n999940`t8`t1015900`n1000000`t8`t1015900`n9999999`t99`t99999999`n"
+    $legacyBefore = Snapshot-File $legacyPath
+    $legacyPayload = Clone-Object $statePayload
+    $legacyPayload.rate_limits.five_hour.used_percentage = '8'
+    $legacyPs = Invoke-Statusline (Json $legacyPayload) $legacyConfig $stateEnvWrite '' 10000
+    $legacyBash = Invoke-BashStatusline (Json $legacyPayload) $legacyConfig $stateEnvWrite
+    Check-Run 'WIN-02 PowerShell legacy read' $legacyPs
+    Check-Run 'WIN-02 Bash legacy read' $legacyBash
+    Check 'WIN-02 legacy bytes/timestamp/hash unchanged' ((Snapshot-File $legacyPath) -eq $legacyBefore)
+    $legacyNames = Get-ImmediateNames (Join-Path $legacyRoot 'burn.d')
+    Check 'WIN-02 no runtime creates l_*' (@($legacyNames | Where-Object { $_ -like 'l_*' }).Count -eq 0)
+
+    # Simulate a downgrade runtime appending the permanent legacy TSV after the
+    # immutable store already exists. New readers must reread those rows without
+    # importing, rewriting, or changing either source.
+    [IO.File]::AppendAllText($legacyPath, "999500`t10`t1016000`n999700`t11`t1016000`n999940`t12`t1016000`n", $Utf8NoBom)
+    $downgradeLegacyBefore = Snapshot-File $legacyPath
+    [void](Snapshot-StateTree (Join-Path $legacyRoot 'burn.d'))
+    $downgradeStoreBefore = Snapshot-StateTree (Join-Path $legacyRoot 'burn.d')
+    $downgradePsDump = Join-Path $legacyRoot 'downgrade-ps.json'
+    $downgradeBashDump = Join-Path $legacyRoot 'downgrade-bash.txt'
+    $downgradePsEnv = @{ CORALLINE_NO_SAMPLE='1'; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_STATE_DUMP=$downgradePsDump }
+    $downgradeBashEnv = @{ CORALLINE_NO_SAMPLE='1'; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_STATE_DUMP=(Forward-Path $downgradeBashDump) }
+    $downgradePs = Invoke-Statusline (Json $legacyPayload) $legacyConfig $downgradePsEnv '' 10000
+    $downgradeBash = Invoke-BashStatusline (Json $legacyPayload) $legacyConfig $downgradeBashEnv
+    Check-Run 'WIN-02 PowerShell post-downgrade legacy reread' $downgradePs
+    Check-Run 'WIN-02 Bash post-downgrade legacy reread' $downgradeBash
+    Check-Exact 'WIN-02 post-downgrade reader differential' $downgradePs $downgradeBash
+    $downgradeState = [IO.File]::ReadAllText($downgradePsDump, $StrictUtf8) | ConvertFrom-Json
+    Check 'WIN-02 post-downgrade rows drive latest synthetic reset' ($downgradeState.FiveState -eq 'active' -and [string]$downgradeState.FiveEta -eq '21120' -and [string]$downgradeState.FiveTtr -eq '16000')
+    Check 'WIN-02 post-downgrade legacy remains byte exact during reread' ((Snapshot-File $legacyPath) -eq $downgradeLegacyBefore)
+    Check 'WIN-02 post-downgrade store remains unchanged during reread' ((Snapshot-StateTree (Join-Path $legacyRoot 'burn.d')) -ceq $downgradeStoreBefore)
+    Check 'WIN-02 post-downgrade reread creates no l_*' (@((Get-ImmediateNames (Join-Path $legacyRoot 'burn.d')) | Where-Object { $_ -like 'l_*' }).Count -eq 0)
+
+    # CORALLINE_NO_SAMPLE preserves all roots, strict sentinels, malformed entries,
+    # legacy bytes, and missing roots under both readers.
+    $readonlyRoot = Join-Path $stateRoot 'readonly'
+    $readonlyConfig = New-StateConfig 'win02-readonly' $readonlyRoot 'burn limit5h limit7d' $true
+    [void][IO.Directory]::CreateDirectory((Join-Path $readonlyRoot 'burn.d'))
+    [void][IO.Directory]::CreateDirectory((Join-Path $readonlyRoot 'limit5.d\9999999999_099.000'))
+    [void][IO.Directory]::CreateDirectory((Join-Path $readonlyRoot 'limit7.d\9999999999_099.000'))
+    [IO.File]::WriteAllBytes((Join-Path $readonlyRoot 'burn.d\b_253402300799_000001000000_099.000_0000'), [byte[]]@())
+    [IO.File]::WriteAllText((Join-Path $readonlyRoot 'burn.d\malformed'), 'x', $Utf8NoBom)
+    Write-Utf8 (Join-Path $readonlyRoot 'burn.tsv') "1000000`t41.2`t1015900`n"
+    [void](Snapshot-StateTree $readonlyRoot)
+    $readonlyBefore = Snapshot-StateTree $readonlyRoot
+    $readonlyPs = Invoke-Statusline (Json $statePayload) $readonlyConfig $stateEnvRead '' 10000
+    $readonlyBash = Invoke-BashStatusline (Json $statePayload) $readonlyConfig $stateEnvRead
+    Check-Run 'WIN-02 PowerShell no-sample' $readonlyPs
+    Check-Run 'WIN-02 Bash no-sample' $readonlyBash
+    Check 'WIN-02 no-sample tree metadata unchanged' ((Snapshot-StateTree $readonlyRoot) -ceq $readonlyBefore)
+    $missingReadonlyRoot = Join-Path $stateRoot 'readonly-missing'
+    $missingReadonlyConfig = New-StateConfig 'win02-readonly-missing' $missingReadonlyRoot 'burn limit5h limit7d' $true
+    [void](Invoke-Statusline (Json $statePayload) $missingReadonlyConfig $stateEnvRead '' 10000)
+    [void](Invoke-BashStatusline (Json $statePayload) $missingReadonlyConfig $stateEnvRead)
+    Check 'WIN-02 no-sample leaves missing roots absent' (-not [IO.Directory]::Exists((Join-Path $missingReadonlyRoot 'burn.d')) -and -not [IO.Directory]::Exists((Join-Path $missingReadonlyRoot 'limit5.d')))
+
+    # Over-cap stores are incomplete, bounded by watchdog, and frozen.
+    $overRoot = Join-Path $stateRoot 'overcap'
+    $overConfig = New-StateConfig 'win02-overcap' $overRoot 'burn limit5h' $true
+    $overBurn = Join-Path $overRoot 'burn.d'
+    [void][IO.Directory]::CreateDirectory($overBurn)
+    for ($i=0; $i -lt 4097; $i++) { [IO.File]::WriteAllBytes((Join-Path $overBurn ('x' + $i.ToString('D4'))), [byte[]]@()) }
+    $overPs = Invoke-Statusline (Json $statePayload) $overConfig $stateEnvWrite '' 20000
+    Check-Run 'WIN-02 PowerShell burn cap+1 watchdog' $overPs
+    Check 'WIN-02 PowerShell burn cap+1 frozen' ((Get-ImmediateNames $overBurn).Count -eq 4097)
+    $overLimit = Join-Path $overRoot 'limit5.d'
+    if ([IO.Directory]::Exists($overLimit)) { [IO.Directory]::Delete($overLimit, $true) }
+    [void][IO.Directory]::CreateDirectory($overLimit)
+    for ($i=0; $i -lt 513; $i++) { [void][IO.Directory]::CreateDirectory((Join-Path $overLimit ('x' + $i.ToString('D3')))) }
+    $overPs2 = Invoke-Statusline (Json $statePayload) $overConfig $stateEnvWrite '' 20000
+    Check-Run 'WIN-02 PowerShell limit cap+1 watchdog' $overPs2
+    Check 'WIN-02 PowerShell limit cap+1 frozen' ((Get-ImmediateNames $overLimit).Count -eq 513)
+
+    # Publication watermarks and complete scan caps are distinct boundaries.
+    foreach ($rawCount in @(3967,3968,4096)) {
+        $boundaryRoot = Join-Path $stateRoot ("burn-boundary-$rawCount")
+        $boundaryConfig = New-StateConfig ("win02-burn-boundary-$rawCount") $boundaryRoot 'burn' $false
+        $boundaryStore = Join-Path $boundaryRoot 'burn.d'
+        [void][IO.Directory]::CreateDirectory($boundaryStore)
+        for ($i=0; $i -lt $rawCount; $i++) { [IO.File]::WriteAllBytes((Join-Path $boundaryStore ('x' + $i.ToString('D4'))), [byte[]]@()) }
+        $boundaryRun = Invoke-Statusline (Json $statePayload) $boundaryConfig $stateEnvWrite '' 30000
+        Check-Run "WIN-02 PowerShell burn raw boundary $rawCount" $boundaryRun
+        $expectedCount = $rawCount
+        if ($rawCount -eq 3967) { $expectedCount++ }
+        Check "WIN-02 burn raw boundary $rawCount publication" ((Get-ImmediateNames $boundaryStore).Count -eq $expectedCount)
+    }
+    foreach ($rawCount in @(383,384,512)) {
+        $boundaryRoot = Join-Path $stateRoot ("limit-boundary-$rawCount")
+        $boundaryConfig = New-StateConfig ("win02-limit-boundary-$rawCount") $boundaryRoot 'limit5h' $true
+        $boundaryStore = Join-Path $boundaryRoot 'limit5.d'
+        [void][IO.Directory]::CreateDirectory($boundaryStore)
+        for ($i=0; $i -lt $rawCount; $i++) { [void][IO.Directory]::CreateDirectory((Join-Path $boundaryStore ('x' + $i.ToString('D3')))) }
+        $boundaryRun = Invoke-Statusline (Json $statePayload) $boundaryConfig $stateEnvWrite '' 30000
+        Check-Run "WIN-02 PowerShell limit raw boundary $rawCount" $boundaryRun
+        $expectedCount = $rawCount
+        if ($rawCount -eq 383) { $expectedCount++ }
+        Check "WIN-02 limit raw boundary $rawCount publication" ((Get-ImmediateNames $boundaryStore).Count -eq $expectedCount)
+    }
+
+    # The default 1500-entry retained set must remain usable on the prompt path.
+    # Every filename is canonical so this exercises the real native sort path.
+    $steadyRoot = Join-Path $stateRoot 'steady-1500'
+    $steadyConfig = New-StateConfig 'win02-steady-1500' $steadyRoot 'burn' $false
+    $steadyStore = Join-Path $steadyRoot 'burn.d'
+    [void][IO.Directory]::CreateDirectory($steadyStore)
+    for ($i=0; $i -lt 1500; $i++) {
+        $sample = $fixedNow - $i - 1L
+        $name = 'b_' + $reset5.ToString('D12', $Invariant) + '_' + $sample.ToString('D12', $Invariant) + '_010.000_0000'
+        [IO.File]::WriteAllBytes((Join-Path $steadyStore $name), [byte[]]@())
+    }
+    $steadyPs = Invoke-Statusline (Json $statePayload) $steadyConfig $stateEnvWrite '' 5000
+    Check-Run 'WIN-02 PowerShell 1500-entry steady render' $steadyPs
+    Check 'WIN-02 PowerShell 1500-entry steady render under 3s' ($steadyPs.ElapsedMs -lt 3000)
+    Check 'WIN-02 PowerShell 1500-entry steady publication' ((Get-ImmediateNames $steadyStore).Count -eq 1501)
+    $steadyBash = Invoke-BashStatusline (Json $statePayload) $steadyConfig $stateEnvRead
+    Check-Run 'WIN-02 Bash 1500-entry steady render' $steadyBash
+    Check 'WIN-02 Bash 1500-entry steady render under 3s' ($steadyBash.ElapsedMs -lt 3000)
+
+    # PowerShell legacy reads enforce the same byte/row/record bounds and keep the
+    # physical TSV untouched. Exact-cap input is complete; cap+1 and late bounds
+    # freeze publication instead of using partial rows.
+    $legacyExactRoot = Join-Path $stateRoot 'legacy-exact-cap'
+    $legacyExactConfig = New-StateConfig 'win02-legacy-exact-cap' $legacyExactRoot 'burn' $false
+    $legacyExactPath = Join-Path $legacyExactRoot 'burn.tsv'
+    $legacyRecord = New-Object byte[] 4096
+    for ($i=0; $i -lt 4095; $i++) { $legacyRecord[$i] = 120 }
+    $legacyRecord[4095] = 10
+    $legacyExactBytes = New-Object byte[] 1048576
+    for ($offset=0; $offset -lt $legacyExactBytes.Length; $offset += $legacyRecord.Length) { [Array]::Copy($legacyRecord, 0, $legacyExactBytes, $offset, $legacyRecord.Length) }
+    [IO.File]::WriteAllBytes($legacyExactPath, $legacyExactBytes)
+    $legacyExactBefore = Snapshot-File $legacyExactPath
+    $legacyExactRun = Invoke-Statusline (Json $statePayload) $legacyExactConfig $stateEnvWrite '' 30000
+    Check-Run 'WIN-02 PowerShell exact 1MiB legacy' $legacyExactRun
+    Check 'WIN-02 exact 1MiB legacy completes and publishes' ((Get-ImmediateNames (Join-Path $legacyExactRoot 'burn.d')).Count -eq 1)
+    Check 'WIN-02 exact 1MiB legacy remains byte exact' ((Snapshot-File $legacyExactPath) -eq $legacyExactBefore)
+
+    $legacyOverRoot = Join-Path $stateRoot 'legacy-cap-plus-one'
+    $legacyOverConfig = New-StateConfig 'win02-legacy-cap-plus-one' $legacyOverRoot 'burn' $false
+    $legacyOverPath = Join-Path $legacyOverRoot 'burn.tsv'
+    $legacyOverBytes = New-Object byte[] 1048577
+    [Array]::Copy($legacyExactBytes, $legacyOverBytes, $legacyExactBytes.Length)
+    $legacyOverBytes[1048576] = 120
+    [IO.File]::WriteAllBytes($legacyOverPath, $legacyOverBytes)
+    $legacyOverBefore = Snapshot-File $legacyOverPath
+    $legacyOverRun = Invoke-Statusline (Json $statePayload) $legacyOverConfig $stateEnvWrite '' 30000
+    Check-Run 'WIN-02 PowerShell legacy cap+1 watchdog' $legacyOverRun
+    Check 'WIN-02 legacy cap+1 freezes publication' (-not [IO.Directory]::Exists((Join-Path $legacyOverRoot 'burn.d')))
+    Check 'WIN-02 legacy cap+1 remains byte exact' ((Snapshot-File $legacyOverPath) -eq $legacyOverBefore)
+
+    foreach ($legacyCase in @(
+        [pscustomobject]@{Name='row-cap-plus-one'; Bytes=([byte[]](,10 * 4097))},
+        [pscustomobject]@{Name='record-cap-plus-one'; Bytes=([Text.Encoding]::ASCII.GetBytes(('1' * 4097)))},
+        [pscustomobject]@{Name='nul-row'; Bytes=([byte[]](49,48,48,48,48,48,48,9,49,9,49,48,49,53,57,48,48,10,49,0,9,49,9,49,10))}
+    )) {
+        $caseRoot = Join-Path $stateRoot ('legacy-' + $legacyCase.Name)
+        $caseConfig = New-StateConfig ('win02-legacy-' + $legacyCase.Name) $caseRoot 'burn' $false
+        $casePath = Join-Path $caseRoot 'burn.tsv'
+        [IO.File]::WriteAllBytes($casePath, $legacyCase.Bytes)
+        $caseBefore = Snapshot-File $casePath
+        $caseRun = Invoke-Statusline (Json $statePayload) $caseConfig $stateEnvWrite '' 10000
+        Check-Run ('WIN-02 PowerShell legacy ' + $legacyCase.Name) $caseRun
+        $casePublished = [IO.Directory]::Exists((Join-Path $caseRoot 'burn.d'))
+        if ($legacyCase.Name -eq 'nul-row') { Check 'WIN-02 bounded NUL row is ignored without poisoning snapshot' $casePublished }
+        else { Check ('WIN-02 ' + $legacyCase.Name + ' freezes publication') (-not $casePublished) }
+        Check ('WIN-02 ' + $legacyCase.Name + ' remains byte exact') ((Snapshot-File $casePath) -eq $caseBefore)
+    }
+
+    # Fixed-clock limit edges are strict for both stores. Only NOW+1 and NOW+max
+    # are plausible and publishable; expired/far-future strict sentinels are
+    # preserved read-only, then removed only from a complete mutation snapshot.
+    foreach ($limitSpec in @(
+        [pscustomobject]@{Name='5h'; Segment='limit5h'; RootName='limit5.d'; Max=21600L; Field='five_hour'},
+        [pscustomobject]@{Name='7d'; Segment='limit7d'; RootName='limit7.d'; Max=691200L; Field='seven_day'}
+    )) {
+        foreach ($offset in @(0L,1L,$limitSpec.Max,($limitSpec.Max + 1L))) {
+            $edgeRoot = Join-Path $stateRoot ("edge-$($limitSpec.Name)-$offset")
+            $edgeConfig = New-StateConfig ("win02-edge-$($limitSpec.Name)-$offset") $edgeRoot $limitSpec.Segment $true
+            $edgePayload = Clone-Object $statePayload
+            $edgePayload.rate_limits.five_hour.used_percentage = $null
+            $edgePayload.rate_limits.five_hour.resets_at = $null
+            $edgePayload.rate_limits.seven_day.used_percentage = $null
+            $edgePayload.rate_limits.seven_day.resets_at = $null
+            $edgePayload.rate_limits.($limitSpec.Field).used_percentage = '33.333'
+            $edgePayload.rate_limits.($limitSpec.Field).resets_at = [string]($fixedNow + $offset)
+            $edgeRun = Invoke-Statusline (Json $edgePayload) $edgeConfig $stateEnvWrite '' 10000
+            Check-Run ("WIN-02 $($limitSpec.Name) reset edge $offset") $edgeRun
+            $validEdge = $offset -eq 1L -or $offset -eq $limitSpec.Max
+            $edgeStore = Join-Path $edgeRoot $limitSpec.RootName
+            $edgeNames = Get-ImmediateNames $edgeStore
+            Check ("WIN-02 $($limitSpec.Name) reset edge $offset publication") (($validEdge -and $edgeNames.Count -eq 1) -or (-not $validEdge -and $edgeNames.Count -eq 0))
+        }
+
+        $sentinelRoot = Join-Path $stateRoot ('sentinel-' + $limitSpec.Name)
+        $sentinelConfig = New-StateConfig ('win02-sentinel-' + $limitSpec.Name) $sentinelRoot $limitSpec.Segment $true
+        $sentinelStore = Join-Path $sentinelRoot $limitSpec.RootName
+        [void][IO.Directory]::CreateDirectory($sentinelStore)
+        $expiredName = $fixedNow.ToString('D10', $Invariant) + '_099.000'
+        $futureName = ($fixedNow + $limitSpec.Max + 1L).ToString('D10', $Invariant) + '_099.000'
+        [void][IO.Directory]::CreateDirectory((Join-Path $sentinelStore $expiredName))
+        [void][IO.Directory]::CreateDirectory((Join-Path $sentinelStore $futureName))
+        $sentinelPayload = Clone-Object $statePayload
+        $sentinelPayload.rate_limits.five_hour.used_percentage = $null
+        $sentinelPayload.rate_limits.five_hour.resets_at = $null
+        $sentinelPayload.rate_limits.seven_day.used_percentage = $null
+        $sentinelPayload.rate_limits.seven_day.resets_at = $null
+        $sentinelPayload.rate_limits.($limitSpec.Field).used_percentage = '20'
+        $sentinelPayload.rate_limits.($limitSpec.Field).resets_at = [string]($fixedNow + 1L)
+        $sentinelRead = Invoke-Statusline (Json $sentinelPayload) $sentinelConfig $stateEnvRead '' 10000
+        Check-Run ("WIN-02 $($limitSpec.Name) sentinel no-sample") $sentinelRead
+        Check ("WIN-02 $($limitSpec.Name) no-sample preserves reset sentinels") ((Get-ImmediateNames $sentinelStore).Count -eq 2)
+        $sentinelWrite = Invoke-Statusline (Json $sentinelPayload) $sentinelConfig $stateEnvWrite '' 10000
+        Check-Run ("WIN-02 $($limitSpec.Name) sentinel mutation") $sentinelWrite
+        $sentinelNames = Get-ImmediateNames $sentinelStore
+        $expectedName = ($fixedNow + 1L).ToString('D10', $Invariant) + '_020.000'
+        Check ("WIN-02 $($limitSpec.Name) complete GC removes only sentinels") ($sentinelNames.Count -eq 1 -and $sentinelNames[0] -ceq $expectedName)
+    }
+
+    # Limit high-water is reset-first, then pct within that reset. A rollover to a
+    # greater reset cannot be shadowed by an older 90% value, and a lower current
+    # payload cannot regress a stored 20% high-water.
+    foreach ($limitSpec in @(
+        [pscustomobject]@{Name='5h'; Segment='limit5h'; RootName='limit5.d'; Field='five_hour'},
+        [pscustomobject]@{Name='7d'; Segment='limit7d'; RootName='limit7.d'; Field='seven_day'}
+    )) {
+        $highRoot = Join-Path $stateRoot ('highwater-' + $limitSpec.Name)
+        $highConfig = New-StateConfig ('win02-highwater-' + $limitSpec.Name) $highRoot $limitSpec.Segment $true
+        $highStore = Join-Path $highRoot $limitSpec.RootName
+        [void][IO.Directory]::CreateDirectory($highStore)
+        foreach ($name in @(
+            (($fixedNow + 100L).ToString('D10', $Invariant) + '_090.000'),
+            (($fixedNow + 200L).ToString('D10', $Invariant) + '_010.000'),
+            (($fixedNow + 200L).ToString('D10', $Invariant) + '_020.000')
+        )) { [void][IO.Directory]::CreateDirectory((Join-Path $highStore $name)) }
+        $highPayload = Clone-Object $statePayload
+        $highPayload.rate_limits.five_hour.used_percentage = $null
+        $highPayload.rate_limits.five_hour.resets_at = $null
+        $highPayload.rate_limits.seven_day.used_percentage = $null
+        $highPayload.rate_limits.seven_day.resets_at = $null
+        $highPayload.rate_limits.($limitSpec.Field).used_percentage = '15'
+        $highPayload.rate_limits.($limitSpec.Field).resets_at = [string]($fixedNow + 200L)
+        $psDump = Join-Path $highRoot 'ps.json'
+        $bashDump = Join-Path $highRoot 'bash.txt'
+        $psEnv = @{ CORALLINE_NO_SAMPLE='1'; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_STATE_DUMP=$psDump }
+        $bashEnv = @{ CORALLINE_NO_SAMPLE='1'; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_STATE_DUMP=(Forward-Path $bashDump) }
+        $psRun = Invoke-Statusline (Json $highPayload) $highConfig $psEnv '' 10000
+        $bashRun = Invoke-BashStatusline (Json $highPayload) $highConfig $bashEnv
+        Check-Run ('WIN-02 PowerShell high-water ' + $limitSpec.Name) $psRun
+        Check-Run ('WIN-02 Bash high-water ' + $limitSpec.Name) $bashRun
+        Check-Exact ('WIN-02 high-water differential ' + $limitSpec.Name) $psRun $bashRun
+        $psState = [IO.File]::ReadAllText($psDump, $StrictUtf8) | ConvertFrom-Json
+        $bashState = [IO.File]::ReadAllText($bashDump, $StrictUtf8).Trim()
+        $prefix = 'Limit5'
+        if ($limitSpec.Name -eq '7d') { $prefix = 'Limit7' }
+        $psPct = $psState.($prefix + 'Pct')
+        $psReset = $psState.($prefix + 'Reset')
+        Check ('WIN-02 reset-first stored high-water ' + $limitSpec.Name) ([string]$psPct -eq '20000' -and [string]$psReset -eq [string]($fixedNow + 200L) -and $bashState.Contains($prefix + 'Pct=20000'))
+
+        $highPayload.rate_limits.($limitSpec.Field).used_percentage = '25'
+        $writeRun = Invoke-Statusline (Json $highPayload) $highConfig $stateEnvWrite '' 10000
+        Check-Run ('WIN-02 PowerShell high-water advance ' + $limitSpec.Name) $writeRun
+        $highNames = Get-ImmediateNames $highStore
+        $expectedHigh = ($fixedNow + 200L).ToString('D10', $Invariant) + '_025.000'
+        Check ('WIN-02 high-water advances without regression ' + $limitSpec.Name) ($highNames -contains $expectedHigh)
+        $maintenanceRun = Invoke-Statusline (Json $highPayload) $highConfig $stateEnvWrite '' 10000
+        Check-Run ('WIN-02 PowerShell high-water maintenance ' + $limitSpec.Name) $maintenanceRun
+        $highNames = Get-ImmediateNames $highStore
+        Check ('WIN-02 high-water maintenance converges ' + $limitSpec.Name) ($highNames.Count -eq 1 -and $highNames[0] -ceq $expectedHigh)
+    }
+
+    # Concurrent mixed-runtime cohorts use unique canonical pct values so every
+    # successful writer has one observable immutable commit.
+    foreach ($count in @(1,2,4,8,128)) {
+        $cohortRoot = Join-Path $stateRoot ("cohort-$count")
+        $cohortConfig = New-StateConfig ("win02-cohort-$count") $cohortRoot 'burn' $false
+        $handles = New-Object 'System.Collections.Generic.List[object]'
+        for ($i=0; $i -lt $count; $i++) {
+            $payload = Clone-Object $statePayload
+            $payload.rate_limits.five_hour.used_percentage = [string]::Format($Invariant, '10.{0:000}', $i)
+            $writerEnv = @{ CORALLINE_NO_SAMPLE=$null; CORALLINE_TEST_NOW=[string]($fixedNow + $i) }
+            $environment = Runtime-Environment $cohortConfig $writerEnv
+            if (($i % 2) -eq 0) {
+                $args = '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + $script:StateScript + '"'
+                [void]$handles.Add((Start-CapturedProcessAsync $PowerShellExe $args (Json $payload) $environment $Repo))
+            } else {
+                $args = '--noprofile --norc "' + (Forward-Path $script:StateBashScript) + '"'
+                [void]$handles.Add((Start-CapturedProcessAsync $script:BashExe $args (Json $payload) $environment $Repo))
+            }
+        }
+        $cohortOk = $true
+        $cohortErrors = New-Object 'System.Collections.Generic.List[string]'
+        $writerIndex = 0
+        foreach ($handle in $handles) {
+            $result = Wait-CapturedProcessAsync $handle 120000
+            if ($result.TimedOut -or $result.ExitCode -ne 0 -or $result.StderrBytes.Length -ne 0) {
+                $cohortOk = $false
+                [void]$cohortErrors.Add(("writer=$writerIndex timeout=$($result.TimedOut) exit=$($result.ExitCode) stderr=" + $Utf8NoBom.GetString($result.StderrBytes)))
+            }
+            $writerIndex++
+        }
+        $cohortNames = Get-ImmediateNames (Join-Path $cohortRoot 'burn.d')
+        if (-not $cohortOk -or $cohortNames.Count -ne $count) { [Console]::Out.WriteLine("DIAG  WIN-02 cohort N=$count names=$($cohortNames.Count) errors=" + ($cohortErrors -join ';')) }
+        Check "WIN-02 mixed cohort N=$count writers succeed" ($cohortOk -and $cohortNames.Count -eq $count)
+    }
+
+    # Every mixed writer snapshots before the parent injects occupied live slots.
+    # The occupied names are therefore post-snapshot commits and cannot enter this
+    # GC round; writers must collide through them and exclusively claim later slots.
+    $raceRoot = Join-Path $stateRoot 'same-name-race'
+    $raceConfig = New-StateConfig 'win02-same-name-race' $raceRoot 'burn' $false
+    $raceBarrier = Join-Path $raceRoot 'release'
+    $racePayload = Clone-Object $statePayload
+    $racePayload.rate_limits.five_hour.used_percentage = '42.345'
+    $raceHandles = New-Object 'System.Collections.Generic.List[object]'
+    for ($i=0; $i -lt 8; $i++) {
+        $raceEnv = Runtime-Environment $raceConfig @{ CORALLINE_NO_SAMPLE=$null; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_BARRIER=(Forward-Path $raceBarrier) }
+        if (($i % 2) -eq 0) {
+            $raceArgs = '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + $script:StateScript + '"'
+            [void]$raceHandles.Add((Start-CapturedProcessAsync $PowerShellExe $raceArgs (Json $racePayload) $raceEnv $Repo))
+        } else {
+            $raceArgs = '--noprofile --norc "' + (Forward-Path $script:StateBashScript) + '"'
+            [void]$raceHandles.Add((Start-CapturedProcessAsync $script:BashExe $raceArgs (Json $racePayload) $raceEnv $Repo))
+        }
+    }
+    $raceReady = Wait-StateBarrier $raceBarrier 8 120000
+    Check 'WIN-02 mixed same-name writers reach complete-snapshot barrier' $raceReady
+    $raceStore = Join-Path $raceRoot 'burn.d'
+    if ($raceReady) {
+        [void][IO.Directory]::CreateDirectory($raceStore)
+        for ($slot=0; $slot -lt 4; $slot++) {
+            $name = 'b_000001015900_000001000000_042.345_' + $slot.ToString('D4', $Invariant)
+            [IO.File]::WriteAllBytes((Join-Path $raceStore $name), [byte[]]@())
+        }
+        [IO.File]::WriteAllBytes($raceBarrier, [byte[]]@())
+    }
+    $raceOk = $raceReady
+    foreach ($handle in $raceHandles) {
+        $result = Wait-CapturedProcessAsync $handle 120000
+        if ($result.TimedOut -or $result.ExitCode -ne 0 -or $result.StderrBytes.Length -ne 0) { $raceOk=$false }
+    }
+    $raceNames = Get-ImmediateNames $raceStore
+    $expectedRaceNames = @()
+    for ($slot=0; $slot -lt 12; $slot++) { $expectedRaceNames += 'b_000001015900_000001000000_042.345_' + $slot.ToString('D4', $Invariant) }
+    Check 'WIN-02 preoccupied slots and eight mixed commits are exact' ($raceOk -and ($raceNames -join "`n") -ceq ($expectedRaceNames -join "`n"))
+    Check 'WIN-02 post-snapshot occupied entries survive current GC' (@($raceNames | Where-Object { $_ -like '*_0000' -or $_ -like '*_0001' -or $_ -like '*_0002' -or $_ -like '*_0003' }).Count -eq 4)
+
+    # Crash before the commit point leaves no entry. Crash after exclusive create
+    # leaves one complete zero-byte entry and no partial grammar-valid artifact.
+    $beforeCrashRoot = Join-Path $stateRoot 'crash-before-create'
+    $beforeCrashConfig = New-StateConfig 'win02-crash-before-create' $beforeCrashRoot 'burn' $false
+    $beforeBarrier = Join-Path $beforeCrashRoot 'release'
+    $beforeEnv = Runtime-Environment $beforeCrashConfig @{ CORALLINE_NO_SAMPLE=$null; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_BARRIER=(Forward-Path $beforeBarrier) }
+    $beforeArgs = '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + $script:StateScript + '"'
+    $beforeHandle = Start-CapturedProcessAsync $PowerShellExe $beforeArgs (Json $statePayload) $beforeEnv $Repo
+    $beforeReady = Wait-StateBarrier $beforeBarrier 1 30000
+    Check 'WIN-02 crash-before-create reaches complete snapshot' $beforeReady
+    if ($beforeReady) { try { $beforeHandle.Process.Kill() } catch { } }
+    [void](Wait-CapturedProcessAsync $beforeHandle 30000)
+    Check 'WIN-02 crash-before-create leaves no committed entry' ((Get-ImmediateNames (Join-Path $beforeCrashRoot 'burn.d')).Count -eq 0)
+
+    $afterCrashRoot = Join-Path $stateRoot 'crash-after-create'
+    $afterCrashConfig = New-StateConfig 'win02-crash-after-create' $afterCrashRoot 'burn' $false
+    $afterBarrier = Join-Path $afterCrashRoot 'release'
+    $afterEnv = Runtime-Environment $afterCrashConfig @{ CORALLINE_NO_SAMPLE=$null; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_AFTER_CREATE=(Forward-Path $afterBarrier) }
+    $afterArgs = '--noprofile --norc "' + (Forward-Path $script:StateBashScript) + '"'
+    $afterHandle = Start-CapturedProcessAsync $script:BashExe $afterArgs (Json $statePayload) $afterEnv $Repo
+    $afterReady = Wait-StateBarrier $afterBarrier 1 30000
+    Check 'WIN-02 crash-after-create reaches committed barrier' $afterReady
+    $afterStore = Join-Path $afterCrashRoot 'burn.d'
+    $afterNames = Get-ImmediateNames $afterStore
+    $afterComplete = $afterNames.Count -eq 1 -and [IO.File]::Exists((Join-Path $afterStore $afterNames[0])) -and (New-Object IO.FileInfo((Join-Path $afterStore $afterNames[0]))).Length -eq 0
+    if ($afterReady) { try { $afterHandle.Process.Kill() } catch { } }
+    [void](Wait-CapturedProcessAsync $afterHandle 30000)
+    Check 'WIN-02 crash-after-create preserves complete commit' ($afterComplete -and (Get-ImmediateNames $afterStore).Count -eq 1)
+
+    # Culture cannot change canonical decimal filenames or output.
+    $cultureRoot = Join-Path $stateRoot 'culture'
+    $cultureConfig = New-StateConfig 'win02-culture' $cultureRoot 'burn' $false
+    $culturePayload = Clone-Object $statePayload
+    $culturePayload.rate_limits.five_hour.used_percentage = '1.2355'
+    $cultureCommand = '[Threading.Thread]::CurrentThread.CurrentCulture=[Globalization.CultureInfo]::GetCultureInfo(''de-DE''); & ''' + $script:StateScript + ''''
+    $cultureArgs = '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "' + $cultureCommand.Replace('"','\"') + '"'
+    $cultureRun = Invoke-CapturedProcess $PowerShellExe $cultureArgs (Json $culturePayload) (Runtime-Environment $cultureConfig $stateEnvWrite) $Repo 10000
+    Check-Run 'WIN-02 comma-decimal PowerShell culture' $cultureRun
+    $cultureNames = Get-ImmediateNames (Join-Path $cultureRoot 'burn.d')
+    Check 'WIN-02 culture keeps invariant decimal filename' ($cultureNames.Count -eq 1 -and $cultureNames[0].Contains('_001.236_'))
+
+    # State path positive controls plus ADS, junction, symlink, UNC, and device
+    # negatives. Required NTFS capabilities are failures, never BLOCKED.
+    $pathRoot = Join-Path $stateRoot 'paths'
+    $pathPositive = New-StateConfig 'win02-path-positive' (Join-Path $pathRoot 'positive') 'burn' $false
+    $pathPositiveRun = Invoke-Statusline (Json $statePayload) $pathPositive $stateEnvWrite '' 10000
+    Check-Run 'WIN-02 state path positive control' $pathPositiveRun
+    $positiveStore = Join-Path $pathRoot 'positive\burn.d'
+    Check 'WIN-02 state path positive control reaches write' ([IO.Directory]::Exists($positiveStore))
+    $positiveSentinel = Join-Path $positiveStore 'b_253402300799_000001000000_099.000_0000'
+    [IO.File]::WriteAllBytes($positiveSentinel, [byte[]]@())
+    $pathPositiveGc = Invoke-Statusline (Json $statePayload) $pathPositive $stateEnvWrite '' 10000
+    Check-Run 'WIN-02 state path positive GC control' $pathPositiveGc
+    Check 'WIN-02 state path positive control reaches exact GC' (-not [IO.File]::Exists($positiveSentinel))
+
+    $adsCarrier = Join-Path $pathRoot 'ads-carrier'
+    [void][IO.Directory]::CreateDirectory($pathRoot)
+    [IO.File]::WriteAllText($adsCarrier, 'primary', $Utf8NoBom)
+    $adsReady = $true
+    try { Set-Content -LiteralPath $adsCarrier -Stream canary -Value 'stream' -NoNewline -ErrorAction Stop } catch { $adsReady=$false }
+    Check 'WIN-02 NTFS ADS capability available' $adsReady
+    if ($adsReady) {
+        $adsBefore = Snapshot-Ads $adsCarrier canary
+        $adsConfig = New-Config 'win02-path-ads' @('VL_SEGMENTS=burn','VL_CLOCK=off',("BURN_FILE='" + (Forward-Path $adsCarrier) + ":burn.tsv'"))
+        $adsRun = Invoke-Statusline (Json $statePayload) $adsConfig $stateEnvWrite '' 10000
+        Check-Run 'WIN-02 ADS state rejection' $adsRun
+        Check 'WIN-02 ADS state canary unchanged' ((Snapshot-Ads $adsCarrier canary) -eq $adsBefore)
+    }
+
+    $junctionTarget = Join-Path $pathRoot 'junction-target'
+    $junctionLink = Join-Path $pathRoot 'junction-link'
+    [void][IO.Directory]::CreateDirectory($junctionTarget)
+    $mkJunction = Invoke-CapturedProcess $env:ComSpec ('/d /s /c "mklink /J ""' + $junctionLink + '"" ""' + $junctionTarget + '"""') '' @{} $Repo 5000
+    $junctionReady = $mkJunction.ExitCode -eq 0 -and [IO.Directory]::Exists($junctionLink)
+    Check 'WIN-02 NTFS junction capability available' $junctionReady
+    if ($junctionReady) {
+        $junctionTargetStore = Join-Path $junctionTarget 'burn.d'
+        [void][IO.Directory]::CreateDirectory($junctionTargetStore)
+        $junctionSentinel = Join-Path $junctionTargetStore 'b_253402300799_000001000000_099.000_0000'
+        [IO.File]::WriteAllBytes($junctionSentinel, [byte[]]@())
+        $junctionConfig = New-Config 'win02-path-junction' @('VL_SEGMENTS=burn','VL_CLOCK=off',("BURN_FILE='" + (Forward-Path (Join-Path $junctionLink 'burn.tsv')) + "'"))
+        $junctionRun = Invoke-Statusline (Json $statePayload) $junctionConfig $stateEnvWrite '' 10000
+        Check-Run 'WIN-02 junction state rejection' $junctionRun
+        Check 'WIN-02 junction target receives no publication or GC' ([IO.File]::Exists($junctionSentinel) -and (Get-ImmediateNames $junctionTargetStore).Count -eq 1)
+    }
+
+    $symlinkTarget = Join-Path $pathRoot 'symlink-target'
+    $symlinkLink = Join-Path $pathRoot 'symlink-link'
+    [void][IO.Directory]::CreateDirectory($symlinkTarget)
+    $mkSymlink = Invoke-CapturedProcess $env:ComSpec ('/d /s /c "mklink /D ""' + $symlinkLink + '"" ""' + $symlinkTarget + '"""') '' @{} $Repo 5000
+    $symlinkReady = $mkSymlink.ExitCode -eq 0 -and [IO.Directory]::Exists($symlinkLink)
+    Check 'WIN-02 NTFS directory symlink capability available' $symlinkReady
+    if ($symlinkReady) {
+        $symlinkTargetStore = Join-Path $symlinkTarget 'burn.d'
+        [void][IO.Directory]::CreateDirectory($symlinkTargetStore)
+        $symlinkSentinel = Join-Path $symlinkTargetStore 'b_253402300799_000001000000_099.000_0000'
+        [IO.File]::WriteAllBytes($symlinkSentinel, [byte[]]@())
+        $symlinkConfig = New-Config 'win02-path-symlink' @('VL_SEGMENTS=burn','VL_CLOCK=off',("BURN_FILE='" + (Forward-Path (Join-Path $symlinkLink 'burn.tsv')) + "'"))
+        $symlinkRun = Invoke-Statusline (Json $statePayload) $symlinkConfig $stateEnvWrite '' 10000
+        Check-Run 'WIN-02 directory symlink state rejection' $symlinkRun
+        Check 'WIN-02 directory symlink target receives no publication or GC' ([IO.File]::Exists($symlinkSentinel) -and (Get-ImmediateNames $symlinkTargetStore).Count -eq 1)
+    }
+
+    $fileTarget = Join-Path $pathRoot 'legacy-target.tsv'
+    $fileLink = Join-Path $pathRoot 'legacy-link.tsv'
+    Write-Utf8 $fileTarget "1000000`t1`t1015900`n"
+    $mkFileLink = Invoke-CapturedProcess $env:ComSpec ('/d /s /c "mklink ""' + $fileLink + '"" ""' + $fileTarget + '"""') '' @{} $Repo 5000
+    $fileLinkReady = $mkFileLink.ExitCode -eq 0 -and [IO.File]::Exists($fileLink)
+    Check 'WIN-02 NTFS file symlink capability available' $fileLinkReady
+    if ($fileLinkReady) {
+        $fileBefore = Snapshot-File $fileTarget
+        $fileLinkConfig = New-Config 'win02-path-file-link' @('VL_SEGMENTS=burn','VL_CLOCK=off',("BURN_FILE='" + (Forward-Path $fileLink) + "'"))
+        $fileLinkRun = Invoke-Statusline (Json $statePayload) $fileLinkConfig $stateEnvWrite '' 10000
+        Check-Run 'WIN-02 file symlink state rejection' $fileLinkRun
+        Check 'WIN-02 file symlink target unchanged' ((Snapshot-File $fileTarget) -eq $fileBefore)
+    }
+
+    $localStateBase = Join-Path $pathRoot 'unc-local\burn.tsv'
+    [void][IO.Directory]::CreateDirectory([IO.Path]::GetDirectoryName($localStateBase))
+    $driveRoot = [IO.Path]::GetPathRoot($localStateBase)
+    $uncStateBase = '\\localhost\' + $driveRoot.Substring(0,1) + '$\' + $localStateBase.Substring($driveRoot.Length)
+    $uncProbe = Invoke-CapturedProcess $PowerShellExe ('-NoProfile -Command "[IO.File]::WriteAllText(''' + $uncStateBase + ''',''probe''); [IO.File]::Delete(''' + $uncStateBase + ''')"') '' @{} $Repo 5000
+    $uncReady = $uncProbe.ExitCode -eq 0 -and -not $uncProbe.TimedOut
+    Check 'WIN-02 loopback UNC capability available' $uncReady
+    if ($uncReady) {
+        $uncConfig = New-Config 'win02-path-unc' @('VL_SEGMENTS=burn','VL_CLOCK=off',("BURN_FILE='" + $uncStateBase + "'"))
+        $uncRun = Invoke-Statusline (Json $statePayload) $uncConfig $stateEnvWrite '' 5000
+        Check-Run 'WIN-02 UNC state rejection' $uncRun
+        Check 'WIN-02 UNC state rejection is pre-I/O' (-not [IO.Directory]::Exists((Join-Path ([IO.Path]::GetDirectoryName($localStateBase)) 'burn.d')))
+    }
+
+    foreach ($deviceBase in @('\\?\' + $localStateBase, '\\.\' + $localStateBase)) {
+        $deviceConfig = New-Config ('win02-path-device-' + [Math]::Abs($deviceBase.GetHashCode())) @('VL_SEGMENTS=burn','VL_CLOCK=off',("BURN_FILE='" + $deviceBase + "'"))
+        $deviceRun = Invoke-Statusline (Json $statePayload) $deviceConfig $stateEnvWrite '' 5000
+        Check-Run 'WIN-02 device namespace state rejection' $deviceRun
+        Check 'WIN-02 device namespace creates no store' (-not [IO.Directory]::Exists((Join-Path ([IO.Path]::GetDirectoryName($localStateBase)) 'burn.d')))
+    }
 
     $subagentRun = Invoke-Statusline '' '\\localhost\never\touch.conf' @{} '--subagent' 5000
     Check-Run 'literal subagent early route' $subagentRun

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -19,7 +19,7 @@ $PowerShellExe = (Get-Process -Id $PID).Path
 $Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
 $StrictUtf8 = New-Object System.Text.UTF8Encoding($false, $true)
 $Invariant = [System.Globalization.CultureInfo]::InvariantCulture
-$TempRoot = Join-Path $Repo ('.win01-test-' + [guid]::NewGuid().ToString('N'))
+$TempRoot = Join-Path ([IO.Path]::GetTempPath()) ('coralline-win01-test-' + [guid]::NewGuid().ToString('N'))
 $script:Fail = 0
 $script:Pass = 0
 $script:Blocked = 0
@@ -156,13 +156,20 @@ function Wait-CapturedProcessAsync($Handle, [int]$TimeoutMs) {
     [void]$Handle.OutTask.Wait(2000); [void]$Handle.ErrTask.Wait(2000)
     $exitCode = -1
     if (-not $timedOut -and $Handle.Process.HasExited) { $exitCode = $Handle.Process.ExitCode }
-    $result = [pscustomobject]@{ ExitCode=$exitCode; TimedOut=$timedOut; StdoutBytes=$Handle.Stdout.ToArray(); StderrBytes=$Handle.Stderr.ToArray() }
+    $stdoutBytes = $Handle.Stdout.ToArray()
+    $stderrBytes = $Handle.Stderr.ToArray()
+    try { $stdoutText = $StrictUtf8.GetString($stdoutBytes) } catch { $stdoutText = $null }
+    try { $stderrText = $StrictUtf8.GetString($stderrBytes) } catch { $stderrText = $null }
+    $result = [pscustomobject]@{ ExitCode=$exitCode; TimedOut=$timedOut; StdoutBytes=$stdoutBytes; StderrBytes=$stderrBytes; Stdout=$stdoutText; Stderr=$stderrText }
     $Handle.Process.Dispose(); $Handle.Stdout.Dispose(); $Handle.Stderr.Dispose()
     return $result
 }
 
 function Runtime-Environment([string]$ConfigPath, [hashtable]$Extra) {
+    $runtimeHome = Join-Path $TempRoot 'runtime-home'
     $environment = @{
+        HOME = Forward-Path $runtimeHome
+        USERPROFILE = $runtimeHome
         CORALLINE_CONFIG = $null
         CORALLINE_NO_SAMPLE = '1'
         CORALLINE_TEST_NOW = $null
@@ -183,7 +190,9 @@ function Invoke-Statusline(
     [int]$TimeoutMs
 ) {
     $runtimeScript = $Script
-    if ($ExtraEnvironment.ContainsKey('CORALLINE_TEST_NOW') -and $null -ne $ExtraEnvironment.CORALLINE_TEST_NOW) { $runtimeScript = $script:StateScript }
+    if ($ExtraEnvironment.ContainsKey('CORALLINE_TEST_WIDTH_SCRIPT') -and $null -ne $ExtraEnvironment.CORALLINE_TEST_WIDTH_SCRIPT) { $runtimeScript = $script:WidthScript }
+    elseif ($ExtraEnvironment.ContainsKey('CORALLINE_TEST_FLOAT_SCRIPT') -and $null -ne $ExtraEnvironment.CORALLINE_TEST_FLOAT_SCRIPT) { $runtimeScript = $script:FloatScript }
+    elseif ($ExtraEnvironment.ContainsKey('CORALLINE_TEST_NOW') -and $null -ne $ExtraEnvironment.CORALLINE_TEST_NOW) { $runtimeScript = $script:StateScript }
     $psArgs = '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + $runtimeScript + '"'
     if (-not [string]::IsNullOrEmpty($Arguments)) { $psArgs += ' ' + $Arguments }
     return Invoke-CapturedProcess $PowerShellExe $psArgs $Json (Runtime-Environment $ConfigPath $ExtraEnvironment) $Repo $TimeoutMs
@@ -355,6 +364,41 @@ function Assert-NoUnexpectedResidue([string]$Root, [string]$Name) {
     Check "$Name no runtime residue" ($bad.Count -eq 0)
 }
 
+function New-FloatConfig([string]$Name, [string]$Target, [string]$Segments, [string]$Separator, [string[]]$Extra) {
+    $lines = @(('VL_SEGMENTS=' + (Quote-FromConfigure 'model ctx cost')), 'VL_CLOCK=off', 'VL_FLOAT=1', ('VL_FLOAT_SEGMENTS=' + (Quote-FromConfigure $Segments)), ('VL_FLOAT_FILE=' + (Quote-FromConfigure $Target)), ('VL_FLOAT_SEP=' + (Quote-FromConfigure $Separator)))
+    if ($null -ne $Extra) { $lines += $Extra }
+    return New-Config $Name $lines
+}
+
+function Invoke-Float([string]$Json, [string]$ConfigPath, [hashtable]$Extra) {
+    return Invoke-Statusline $Json $ConfigPath $Extra '' 10000
+}
+
+function Wait-Ready([string]$Barrier, [int]$TimeoutMs) {
+    $watch = [Diagnostics.Stopwatch]::StartNew()
+    while ($watch.ElapsedMilliseconds -lt $TimeoutMs) {
+        if (@([IO.Directory]::GetFiles([IO.Path]::GetDirectoryName($Barrier), ([IO.Path]::GetFileName($Barrier) + '.*.ready'))).Count -gt 0) { return $true }
+        Start-Sleep -Milliseconds 10
+    }
+    return $false
+}
+
+function Float-Bytes([string]$Path) {
+    if (-not [IO.File]::Exists($Path)) { return $null }
+    return [IO.File]::ReadAllBytes($Path)
+}
+
+function Bytes-Same([byte[]]$Left, [byte[]]$Right) {
+    if ($null -eq $Left -or $null -eq $Right -or $Left.Length -ne $Right.Length) { return $false }
+    for ($i=0; $i -lt $Left.Length; $i++) { if ($Left[$i] -ne $Right[$i]) { return $false } }
+    return $true
+}
+
+function Start-FloatAsync([string]$Json, [string]$ConfigPath, [hashtable]$Extra) {
+    $psArgs = '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + $script:FloatScript + '"'
+    return Start-CapturedProcessAsync $PowerShellExe $psArgs $Json (Runtime-Environment $ConfigPath $Extra) $Repo
+}
+
 [void][System.IO.Directory]::CreateDirectory($TempRoot)
 $cleanupOk = $false
 try {
@@ -423,6 +467,32 @@ function Format-StatePct([int]$Milli) {
     if (-not $source.Contains($psClock) -or -not $source.Contains($psBarrierMarker) -or -not $source.Contains($psDumpMarker) -or -not $source.Contains($psAfterCreateMarker) -or -not $source.Contains($psMathMarker)) { throw 'PowerShell state test marker missing' }
     $statePsSource = $source.Replace($psClock, $psClockHook.TrimEnd()).Replace($psBarrierMarker, $psBarrierHook.TrimEnd()).Replace($psDumpMarker, $psDumpHook.TrimEnd()).Replace($psAfterCreateMarker, $psAfterCreateHook.TrimEnd()).Replace($psMathMarker, $psMathHook.TrimEnd())
     Write-Utf8 $script:StateScript $statePsSource
+
+    $script:FloatScript = Join-Path $TempRoot 'statusline-float-test.ps1'
+    $floatBeforeParentMarker = '        # WIN03_TEST_BEFORE_PARENT_CREATE'
+    $floatAfterParentMarker = '    # WIN03_TEST_AFTER_PARENT_CREATE'
+    $floatAfterTempMarker = '                # WIN03_TEST_AFTER_TEMP_CLOSE'
+    $floatBeforeParentHook = @'
+        if (-not [string]::IsNullOrEmpty([string]$env:CORALLINE_TEST_FLOAT_BEFORE_PARENT)) {
+            [IO.File]::WriteAllBytes(([string]$env:CORALLINE_TEST_FLOAT_BEFORE_PARENT + '.' + [string]$PID + '.ready'), [byte[]]@())
+            while (-not [IO.File]::Exists([string]$env:CORALLINE_TEST_FLOAT_BEFORE_PARENT)) { Start-Sleep -Milliseconds 10 }
+        }
+'@
+    $floatAfterParentHook = @'
+    if (-not [string]::IsNullOrEmpty([string]$env:CORALLINE_TEST_FLOAT_AFTER_PARENT)) {
+        [IO.File]::WriteAllBytes(([string]$env:CORALLINE_TEST_FLOAT_AFTER_PARENT + '.' + [string]$PID + '.ready'), [byte[]]@())
+        while (-not [IO.File]::Exists([string]$env:CORALLINE_TEST_FLOAT_AFTER_PARENT)) { Start-Sleep -Milliseconds 10 }
+    }
+'@
+    $floatAfterTempHook = @'
+                if (-not [string]::IsNullOrEmpty([string]$env:CORALLINE_TEST_FLOAT_AFTER_TEMP)) {
+                    [IO.File]::WriteAllBytes(([string]$env:CORALLINE_TEST_FLOAT_AFTER_TEMP + '.' + [string]$PID + '.ready'), [byte[]]@())
+                    while (-not [IO.File]::Exists([string]$env:CORALLINE_TEST_FLOAT_AFTER_TEMP)) { Start-Sleep -Milliseconds 10 }
+                }
+'@
+    if (-not $source.Contains($floatBeforeParentMarker) -or -not $source.Contains($floatAfterParentMarker) -or -not $source.Contains($floatAfterTempMarker)) { throw 'WIN-03 float barrier marker missing' }
+    $floatSource = $source.Replace($floatBeforeParentMarker, $floatBeforeParentHook.TrimEnd()).Replace($floatAfterParentMarker, $floatAfterParentHook.TrimEnd()).Replace($floatAfterTempMarker, $floatAfterTempHook.TrimEnd())
+    Write-Utf8 $script:FloatScript $floatSource
 
     $script:StateBashScript = Join-Path $TempRoot 'statusline-state-test.sh'
     $bashClock = 'printf -v NOW ''%(%s)T'' -1 2>/dev/null || NOW=$(date +%s)'
@@ -851,6 +921,23 @@ fi
     Check-Run 'Bash full stateless oracle' $bashOrder
     Check-Exact 'full fixed-pill differential is byte exact' $orderRun $bashOrder
     if (-not ($orderRun.Stdout -ceq $bashOrder.Stdout)) { [Console]::Out.WriteLine('DIAG  order-config=' + [Convert]::ToBase64String([System.IO.File]::ReadAllBytes($orderConfig))) }
+
+    $crossListRoot = Join-Path $TempRoot 'fixed-cross-list-no-repo'
+    [void][IO.Directory]::CreateDirectory($crossListRoot)
+    $crossListGitProbe = Invoke-CapturedProcess $script:GitExe 'rev-parse --show-toplevel' '' @{} $crossListRoot 5000
+    Check 'WIN-03 fixed cross-list fixture has no enclosing Git repository' (-not $crossListGitProbe.TimedOut -and $crossListGitProbe.ExitCode -ne 0)
+    $crossListPath = Forward-Path $crossListRoot
+    $crossListPayload = Clone-Object $basePayload
+    $crossListPayload.cwd = $crossListPath
+    $crossListPayload.workspace.current_dir = $crossListPath
+    $crossListConfig = New-Config 'fixed-cross-list-project-dir' @('VL_LAYOUT=fixed','VL_SEGMENTS=project','VL_SEGMENTS2=dir','VL_CLOCK=off')
+    $crossListPs = Invoke-Statusline (Json $crossListPayload) $crossListConfig @{} '' 5000
+    $crossListBash = Invoke-BashStatusline (Json $crossListPayload) $crossListConfig @{}
+    Check-Run 'WIN-03 PowerShell fixed cross-list project dir' $crossListPs
+    Check-Run 'WIN-03 Bash fixed cross-list project dir' $crossListBash
+    Check-Exact 'WIN-03 fixed cross-list project dir differential' $crossListPs $crossListBash
+    $crossListRows = @($crossListPs.Stdout.Split([char]"`n") | Where-Object { $_.Length -gt 0 })
+    Check 'WIN-03 fixed cross-list project dir emits one row' ($crossListRows.Count -eq 1)
 
     $themePs = Invoke-Statusline (Json $basePayload) $themeConfig @{} '' 5000
     $themeBash = Invoke-BashStatusline (Json $basePayload) $themeConfig @{}
@@ -1730,7 +1817,8 @@ fi
     Check 'SEC-INC-01 completes within five seconds' ($run01.ElapsedMs -lt 5000)
     Assert-NoUnexpectedResidue $secRoot 'SEC-INC-01'
 
-    $uncCanary = '\\localhost\C$\tmp\' + [System.IO.Path]::GetFileName($Repo) + '\' + [System.IO.Path]::GetFileName($TempRoot) + '\security\outside\evil.conf'
+    $uncCanaryRoot = [IO.Path]::GetPathRoot($evil)
+    $uncCanary = '\\localhost\' + $uncCanaryRoot.Substring(0,1) + '$\' + $evil.Substring($uncCanaryRoot.Length)
     $probeCommand = "try { [IO.File]::ReadAllText('$uncCanary') | Out-Null; exit 0 } catch { exit 2 }"
     $uncProbe = Invoke-CapturedProcess $PowerShellExe ('-NoLogo -NoProfile -NonInteractive -Command "' + $probeCommand + '"') '' @{} $Repo 3000
     $staticUnc = $source.IndexOf("StartsWith('\\'") -ge 0 -and $source.IndexOf("StartsWith('\\'") -lt $source.IndexOf('GetFullPath($p)')
@@ -1790,6 +1878,241 @@ fi
         Blocked 'SEC-INC-05' 'junction creation capability unavailable'
     }
     Assert-NoUnexpectedResidue $secRoot 'SEC-INC matrix'
+
+    # WIN-03 style/layout/float producer matrix.
+    $win03Root = Join-Path $TempRoot 'win03'
+    [void][IO.Directory]::CreateDirectory($win03Root)
+    $styleCases = @(
+        [pscustomobject]@{ Name='pill'; Lines=@('VL_STYLE=pill') },
+        [pscustomobject]@{ Name='lean'; Lines=@('VL_STYLE=lean',('VL_LEAN_SEP=' + (Quote-FromConfigure '|'))) },
+        [pscustomobject]@{ Name='classic'; Lines=@('VL_STYLE=classic') },
+        [pscustomobject]@{ Name='ascii'; Lines=@('VL_ASCII=1') },
+        [pscustomobject]@{ Name='classic-ascii'; Lines=@('VL_STYLE=classic','VL_ASCII=1') },
+        [pscustomobject]@{ Name='lean-bar'; Lines=@('VL_STYLE=lean','VL_LEAN_BG=238','VL_LEAN_FG=231',('VL_LEAN_CAP_L=' + (Quote-FromConfigure '<')),('VL_LEAN_CAP_R=' + (Quote-FromConfigure '>')),('VL_LEAN_SEP=' + (Quote-FromConfigure '|'))) }
+    )
+    foreach ($case in $styleCases) {
+        $styleConfig = New-Config ('win03-style-' + $case.Name) (@('VL_SEGMENTS=model\ ctx\ cost','VL_CLOCK=off') + $case.Lines)
+        $psStyle = Invoke-Statusline (Json $basePayload) $styleConfig @{} '' 10000
+        $bashStyle = Invoke-BashStatusline (Json $basePayload) $styleConfig @{}
+        Check-Run ('WIN-03 PowerShell style ' + $case.Name) $psStyle
+        Check-Run ('WIN-03 Bash style ' + $case.Name) $bashStyle
+        Check-Exact ('WIN-03 style differential ' + $case.Name) $psStyle $bashStyle
+    }
+    $invalidColorConfig = New-Config 'win03-invalid-lean-color' @('VL_SEGMENTS=model','VL_CLOCK=off','VL_STYLE=lean','VL_LEAN_BG=2J','VL_LEAN_FG=999999')
+    $invalidColorRun = Invoke-Statusline (Json $basePayload) $invalidColorConfig @{} '' 10000
+    Check-Run 'WIN-03 invalid lean color' $invalidColorRun
+    Check 'WIN-03 invalid lean color cannot inject CSI' (-not $invalidColorRun.Stdout.Contains(([string][char]27 + '[2J')))
+
+    foreach ($columns in @('1','20','40','32767','0','bad','999999999999')) {
+        $autoConfig = New-Config ('win03-auto-' + $columns) @('VL_SEGMENTS=model\ ctx\ cost\ lines','VL_CLOCK=off','VL_LAYOUT=auto','VL_MAX_LINES=3','VL_WRAP_MARGIN=0')
+        $env = @{ COLUMNS=$columns }
+        $psAuto = Invoke-Statusline (Json $basePayload) $autoConfig $env '' 10000
+        $bashAuto = Invoke-BashStatusline (Json $basePayload) $autoConfig $env
+        Check-Run ('WIN-03 PowerShell auto width ' + $columns) $psAuto
+        Check-Run ('WIN-03 Bash auto width ' + $columns) $bashAuto
+        Check-Exact ('WIN-03 auto width differential ' + $columns) $psAuto $bashAuto
+    }
+    $unicodePayload = Clone-Object $basePayload
+    $unicodePayload.model.display_name = 'Claude ' + (Glyph 0x1F600) + (Glyph 0x0301) + (Glyph 0xFF21)
+    $unicodeConfig = New-Config 'win03-auto-unicode' @('VL_SEGMENTS=model\ ctx\ cost','VL_CLOCK=off','VL_LAYOUT=auto','VL_MAX_LINES=2','VL_WRAP_MARGIN=0')
+    $unicodePs = Invoke-Statusline (Json $unicodePayload) $unicodeConfig @{ COLUMNS='24' } '' 10000
+    $unicodeBash = Invoke-BashStatusline (Json $unicodePayload) $unicodeConfig @{ COLUMNS='24' }
+    Check-Run 'WIN-03 Unicode width PowerShell' $unicodePs
+    Check-Run 'WIN-03 Unicode width Bash' $unicodeBash
+    Check-Exact 'WIN-03 Unicode width differential' $unicodePs $unicodeBash
+
+    $fixedWidthSource = $source.Replace('function Get-DisplayWidth([string]$Value) {', 'function Get-DisplayWidth([string]$Value) { throw ''fixed layout entered width helper''')
+    $script:WidthScript = Join-Path $TempRoot 'statusline-width-test.ps1'
+    Write-Utf8 $script:WidthScript $fixedWidthSource
+    $fixedWidthConfig = New-Config 'win03-fixed-no-width-scan' @('VL_SEGMENTS=model','VL_CLOCK=off','VL_LAYOUT=fixed')
+    $fixedWidthRun = Invoke-Statusline (Json $basePayload) $fixedWidthConfig @{ CORALLINE_TEST_WIDTH_SCRIPT='1'; COLUMNS='1' } '' 10000
+    Check-Run 'WIN-03 fixed layout skips width helper' $fixedWidthRun
+    Check 'WIN-03 fixed layout source has no width test hook' (-not $source.Contains('CORALLINE_TEST_WIDTH_SCRIPT'))
+    Check 'WIN-03 RawUI width is ConsoleHost-only' $source.Contains("if (`$Host.Name -ne 'ConsoleHost') { return 0 }")
+
+    $floatTarget = Join-Path $win03Root 'float output\float.txt'
+    $floatConfig = New-FloatConfig 'win03-float-standard' $floatTarget 'model ctx cost' '  |  ' @()
+    $floatPs = Invoke-Float (Json $basePayload) $floatConfig @{}
+    Check-Run 'WIN-03 standard float PowerShell' $floatPs
+    $floatPsBytes = Float-Bytes $floatTarget
+    Check 'WIN-03 float creates UTF-8 no-BOM LF file' ($null -ne $floatPsBytes -and $floatPsBytes.Length -gt 0 -and $floatPsBytes[0] -ne 0xEF -and $floatPsBytes[$floatPsBytes.Length - 1] -eq 10 -and -not ($floatPsBytes -contains [byte]13))
+    Check 'WIN-03 float has one trailing LF and no ESC' ($floatPsBytes.Length -eq 0 -or ($floatPsBytes[$floatPsBytes.Length - 1] -eq 10 -and -not ($floatPsBytes[0..($floatPsBytes.Length - 1)] -contains [byte]27)))
+    $floatOld = [byte[]]@(0x6f,0x6c,0x64,0x0a)
+    [IO.File]::WriteAllBytes($floatTarget, $floatOld)
+    $floatReplace = Invoke-Float (Json $basePayload) $floatConfig @{}
+    Check-Run 'WIN-03 existing float replacement' $floatReplace
+    $replacedBytes = Float-Bytes $floatTarget
+    Check 'WIN-03 local File.Replace changes complete destination' ((-not (Bytes-Same $replacedBytes $floatOld)) -and $replacedBytes.Length -gt 1 -and $replacedBytes[$replacedBytes.Length - 1] -eq 10)
+    Check 'WIN-03 float leaves no temp artifact' (@(Get-ChildItem -LiteralPath (Split-Path $floatTarget -Parent) -Force -ErrorAction SilentlyContinue | Where-Object { $_.Name -like '.float.tmp.*' }).Count -eq 0)
+
+    $readonlyTarget = Join-Path $win03Root 'readonly.txt'
+    [IO.File]::WriteAllBytes($readonlyTarget, $floatOld)
+    $readonlyInfo = Get-Item -LiteralPath $readonlyTarget -Force
+    $readonlyInfo.Attributes = $readonlyInfo.Attributes -bor [IO.FileAttributes]::ReadOnly
+    $readonlyBefore = Snapshot-File $readonlyTarget
+    $readonlyAttrBefore = (Get-Item -LiteralPath $readonlyTarget -Force).Attributes
+    $readonlyRun = Invoke-Float (Json $basePayload) (New-FloatConfig 'win03-float-readonly' $readonlyTarget 'model' '|' @()) @{}
+    Check-Run 'WIN-03 read-only float target' $readonlyRun
+    Check 'WIN-03 read-only target remains unchanged' ((Snapshot-File $readonlyTarget) -eq $readonlyBefore -and (Get-Item -LiteralPath $readonlyTarget -Force).Attributes -eq $readonlyAttrBefore)
+    $readonlyInfo.Attributes = $readonlyInfo.Attributes -band (-bnot [IO.FileAttributes]::ReadOnly)
+
+    $observerTarget = Join-Path $win03Root 'observer.txt'
+    [IO.File]::WriteAllBytes($observerTarget, $floatOld)
+    $observerBarrier = Join-Path $win03Root 'observer-release'
+    $observerConfig = New-FloatConfig 'win03-float-observer' $observerTarget 'model ctx' '|' @()
+    $observerHandle = Start-FloatAsync (Json $basePayload) $observerConfig @{ CORALLINE_TEST_FLOAT_SCRIPT='1'; CORALLINE_TEST_FLOAT_AFTER_TEMP=$observerBarrier }
+    $observerReady = Wait-Ready $observerBarrier 5000
+    Check 'WIN-03 atomic observer reaches post-close barrier' $observerReady
+    $observerOnlyOld = $true
+    if ($observerReady) {
+        for ($i=0; $i -lt 20; $i++) { if (-not (Bytes-Same (Float-Bytes $observerTarget) $floatOld)) { $observerOnlyOld=$false; break }; Start-Sleep -Milliseconds 5 }
+    }
+    [IO.File]::WriteAllBytes($observerBarrier, [byte[]]@())
+    $observerResult = Wait-CapturedProcessAsync $observerHandle 15000
+    Check-Run 'WIN-03 atomic observer writer' $observerResult
+    Check 'WIN-03 atomic observer sees old then complete new' ($observerOnlyOld -and -not (Bytes-Same (Float-Bytes $observerTarget) $floatOld) -and (Float-Bytes $observerTarget)[(Float-Bytes $observerTarget).Length - 1] -eq 10)
+    Remove-Item -LiteralPath $observerBarrier -Force -ErrorAction SilentlyContinue
+
+    $junctionProbeRoot = Join-Path $win03Root 'junction-capability'
+    [void][IO.Directory]::CreateDirectory($junctionProbeRoot)
+    $junctionProbeTarget = Join-Path $junctionProbeRoot 'outside'
+    [void][IO.Directory]::CreateDirectory($junctionProbeTarget)
+    $junctionProbeLink = Join-Path $junctionProbeRoot 'link'
+    $junctionProbe = Invoke-CapturedProcess $env:ComSpec ('/d /s /c "mklink /J ""' + $junctionProbeLink + '"" ""' + $junctionProbeTarget + '"""') '' @{} $Repo 5000
+    $win03JunctionReady = $junctionProbe.ExitCode -eq 0 -and [IO.Directory]::Exists($junctionProbeLink)
+    Check 'WIN-03 required local junction capability' $win03JunctionReady
+    if ($win03JunctionReady) {
+        Remove-Item -LiteralPath $junctionProbeLink -Force -ErrorAction SilentlyContinue
+        foreach ($barrierCase in @('before-parent','after-parent','after-temp')) {
+            $caseRoot = Join-Path $win03Root ('reparse-' + $barrierCase)
+            $outside = Join-Path $caseRoot 'outside'
+            $parent = Join-Path $caseRoot 'parent'
+            $target = Join-Path $parent 'float.txt'
+            $link = Join-Path $caseRoot 'link-target'
+            $barrier = Join-Path $caseRoot 'release'
+            [void][IO.Directory]::CreateDirectory($outside)
+            $barrierExtra = @{ CORALLINE_TEST_FLOAT_SCRIPT='1' }
+            if ($barrierCase -eq 'before-parent') { $barrierExtra.CORALLINE_TEST_FLOAT_BEFORE_PARENT=$barrier }
+            elseif ($barrierCase -eq 'after-parent') { [void][IO.Directory]::CreateDirectory($parent); $barrierExtra.CORALLINE_TEST_FLOAT_AFTER_PARENT=$barrier }
+            else { [void][IO.Directory]::CreateDirectory($parent); $barrierExtra.CORALLINE_TEST_FLOAT_AFTER_TEMP=$barrier }
+            $caseConfig = New-FloatConfig ('win03-reparse-' + $barrierCase) $target 'model' '|' @()
+            $handle = $null
+            try {
+                $handle = Start-FloatAsync (Json $basePayload) $caseConfig $barrierExtra
+                $ready = Wait-Ready $barrier 5000
+                Check ('WIN-03 ' + $barrierCase + ' barrier reaches hook') $ready
+                if ($ready) {
+                    if ($barrierCase -eq 'before-parent') {
+                        $mk = Invoke-CapturedProcess $env:ComSpec ('/d /s /c "mklink /J ""' + $parent + '"" ""' + $outside + '"""') '' @{} $Repo 5000
+                    } elseif ($barrierCase -eq 'after-parent') {
+                        Remove-Item -LiteralPath $parent -Force -Recurse
+                        $mk = Invoke-CapturedProcess $env:ComSpec ('/d /s /c "mklink /J ""' + $parent + '"" ""' + $outside + '"""') '' @{} $Repo 5000
+                    } else {
+                        $backup = Join-Path $caseRoot 'parent-backup'
+                        [IO.Directory]::Move($parent, $backup)
+                        $mk = Invoke-CapturedProcess $env:ComSpec ('/d /s /c "mklink /J ""' + $parent + '"" ""' + $outside + '"""') '' @{} $Repo 5000
+                    }
+                    Check ('WIN-03 ' + $barrierCase + ' junction creation') ($mk.ExitCode -eq 0 -and [IO.Directory]::Exists($parent))
+                }
+                [IO.File]::WriteAllBytes($barrier, [byte[]]@())
+                $result = Wait-CapturedProcessAsync $handle 15000
+                $handle = $null
+                Check-Run ('WIN-03 ' + $barrierCase + ' reparse barrier run') $result
+                Check ('WIN-03 ' + $barrierCase + ' blocks target write') (-not [IO.File]::Exists($target) -and -not [IO.File]::Exists((Join-Path $outside 'float.txt')))
+            } finally {
+                if ($null -ne $handle) { [IO.File]::WriteAllBytes($barrier, [byte[]]@()); [void](Wait-CapturedProcessAsync $handle 15000) }
+                Remove-Item -LiteralPath $parent,$link,$barrier -Force -Recurse -ErrorAction SilentlyContinue
+                Remove-Item -LiteralPath (Join-Path $caseRoot 'parent-backup') -Force -Recurse -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    $floatBashRoot = Join-Path $win03Root 'float-bash'
+    [void][IO.Directory]::CreateDirectory($floatBashRoot)
+    $floatBashTarget = Join-Path $floatBashRoot 'float.txt'
+    $floatBashConfig = New-FloatConfig 'win03-float-bash' $floatBashTarget 'model ctx cost' '  |  ' @()
+    $floatBashPs = Invoke-Float (Json $basePayload) $floatBashConfig @{}
+    $floatBashPsBytes = Float-Bytes $floatBashTarget
+    Remove-Item -LiteralPath $floatBashTarget -Force
+    $floatBashRun = Invoke-BashStatusline (Json $basePayload) $floatBashConfig @{}
+    Check-Run 'WIN-03 Bash float oracle' $floatBashRun
+    $floatBashBytes = Float-Bytes $floatBashTarget
+    $floatSame = $null -ne $floatBashPsBytes -and $null -ne $floatBashBytes -and $floatBashPsBytes.Length -eq $floatBashBytes.Length
+    if ($floatSame) { for ($i=0; $i -lt $floatBashPsBytes.Length; $i++) { if ($floatBashPsBytes[$i] -ne $floatBashBytes[$i]) { $floatSame=$false; break } } }
+    Check 'WIN-03 float bytes match Bash producer' $floatSame
+
+    $emptyFloatTarget = Join-Path $win03Root 'empty-float.txt'
+    $emptyFloatConfig = New-FloatConfig 'win03-float-empty' $emptyFloatTarget '' '|' @()
+    $emptyFloatRun = Invoke-Float '{}' $emptyFloatConfig @{}
+    Check-Run 'WIN-03 empty float' $emptyFloatRun
+    $emptyFloatBytes = Float-Bytes $emptyFloatTarget
+    Check 'WIN-03 empty float is exactly LF' ($null -ne $emptyFloatBytes -and $emptyFloatBytes.Length -eq 1 -and $emptyFloatBytes[0] -eq 10)
+
+    # Authorization is depth/case sensitive while the default remains usable.
+    foreach ($kind in @('included-exact','included-mixed','root-mixed')) {
+        $homeCase = Join-Path $win03Root ('home-' + $kind)
+        [void][IO.Directory]::CreateDirectory($homeCase)
+        $targetA = Join-Path $win03Root ($kind + '-a.txt')
+        $targetB = Join-Path $win03Root ($kind + '-b.txt')
+        $include = Join-Path (Join-Path $TempRoot 'config') ($kind + '-include.conf')
+        $authLines = @('VL_SEGMENTS=model','VL_CLOCK=off','VL_FLOAT=1','VL_FLOAT_SEGMENTS=model')
+        if ($kind -eq 'included-exact') {
+            Write-Utf8 $include ('VL_FLOAT_FILE=' + (Quote-FromConfigure $targetB) + "`n")
+            $authLines += ('. ' + (Quote-FromConfigure $include))
+            $authLines += ('VL_FLOAT_FILE=' + (Quote-FromConfigure $targetA))
+        } elseif ($kind -eq 'included-mixed') {
+            Write-Utf8 $include ('vl_float_file=' + (Quote-FromConfigure $targetB) + "`n")
+            $authLines += ('. ' + (Quote-FromConfigure $include))
+            $authLines += ('VL_FLOAT_FILE=' + (Quote-FromConfigure $targetA))
+        } else {
+            $authLines += ('vl_float_file=' + (Quote-FromConfigure $targetB))
+        }
+        $authConfig = New-Config ('win03-auth-' + $kind) $authLines
+        $authRun = Invoke-Float (Json $basePayload) $authConfig @{ HOME=$homeCase; USERPROFILE=$homeCase }
+        Check-Run ('WIN-03 float authorization ' + $kind) $authRun
+        if ($kind -ne 'root-mixed') { Check ('WIN-03 ' + $kind + ' root target wins') ([IO.File]::Exists($targetA) -and -not [IO.File]::Exists($targetB)) }
+        else { Check ('WIN-03 root mixed key is no-op') (-not [IO.File]::Exists($targetB) -and [IO.File]::Exists((Join-Path $homeCase '.claude\coralline\float.txt'))) }
+    }
+    $invalidFloatCases = @(
+        [pscustomobject]@{ Name='empty'; Value="''" },
+        [pscustomobject]@{ Name='unc'; Value="'\\localhost\share\float.txt'" },
+        [pscustomobject]@{ Name='device'; Value="'\\?\C:\float.txt'" },
+        [pscustomobject]@{ Name='ads'; Value="'carrier.txt:float'" },
+        [pscustomobject]@{ Name='dos'; Value="'CON.txt'" },
+        [pscustomobject]@{ Name='trailing'; Value="'bad. '" }
+    )
+    foreach ($bad in $invalidFloatCases) {
+        $homeBad = Join-Path $win03Root ('home-bad-' + $bad.Name)
+        [void][IO.Directory]::CreateDirectory($homeBad)
+        $badConfig = New-Config ('win03-float-bad-' + $bad.Name) @('VL_SEGMENTS=model','VL_CLOCK=off','VL_FLOAT=1','VL_FLOAT_SEGMENTS=model',('VL_FLOAT_FILE=' + $bad.Value))
+        $badRun = Invoke-Float (Json $basePayload) $badConfig @{ HOME=$homeBad; USERPROFILE=$homeBad }
+        Check-Run ('WIN-03 invalid float path ' + $bad.Name) $badRun
+        Check ('WIN-03 invalid float path ' + $bad.Name + ' skips default write') (-not [IO.File]::Exists((Join-Path $homeBad '.claude\coralline\float.txt')))
+    }
+
+    $collisionRoot = Join-Path $win03Root 'dormant-collision'
+    [void][IO.Directory]::CreateDirectory($collisionRoot)
+    $collisionBase = Join-Path $collisionRoot 'burn.tsv'
+    $collisionConfig = New-Config 'win03-dormant-state-collision' @('VL_SEGMENTS=model','VL_CLOCK=off','VL_FLOAT=1','VL_FLOAT_SEGMENTS=model',('VL_FLOAT_FILE=' + (Quote-FromConfigure $collisionBase)),('BURN_FILE=' + (Quote-FromConfigure $collisionBase)))
+    $collisionRun = Invoke-Float (Json $basePayload) $collisionConfig @{}
+    Check-Run 'WIN-03 dormant state collision' $collisionRun
+    Check 'WIN-03 dormant state collision creates no float or state root' (-not [IO.File]::Exists($collisionBase) -and -not [IO.Directory]::Exists((Join-Path $collisionRoot 'burn.d')))
+
+    $longTarget = Join-Path $win03Root 'long.txt'
+    $longSegments = 'model ' + ('x' * 4091)
+    $longConfig = New-FloatConfig 'win03-float-segment-bound' $longTarget $longSegments '|' @()
+    $longRun = Invoke-Float (Json $basePayload) $longConfig @{}
+    Check-Run 'WIN-03 float segment bound' $longRun
+    Check 'WIN-03 overlong float segment list skips write' (-not [IO.File]::Exists($longTarget))
+    $sepTarget = Join-Path $win03Root 'sep.txt'
+    $sepConfig = New-FloatConfig 'win03-float-separator-bound' $sepTarget 'model' ('x' * 257) @()
+    $sepRun = Invoke-Float (Json $basePayload) $sepConfig @{}
+    Check-Run 'WIN-03 float separator bound' $sepRun
+    Check 'WIN-03 overlong float separator skips write' (-not [IO.File]::Exists($sepTarget))
+
+    Check 'WIN-03 source caches stash/node/python probes' ($source.Contains('$script:StashCacheSet') -and $source.Contains('$script:NodeCacheSet') -and $source.Contains('$script:PythonCacheSet'))
+    Check 'WIN-03 state collision derivation is outside state gates' ($source.IndexOf('$AllStatePaths') -lt $source.IndexOf('$BurnStateGate'))
+    Assert-NoUnexpectedResidue $win03Root 'WIN-03 float matrix'
 
 } finally {
     try { Remove-Item -LiteralPath $TempRoot -Recurse -Force -ErrorAction Stop } catch { }

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -712,6 +712,19 @@ shell_quote "$CORALLINE_Q_VALUE"
         'VL_BG_MODEL=44'
     )
     [void](Run-ModelColor 'single and double shell words' $wordConfig '44' @{})
+    $windowsPathConfig = New-Config 'double-quoted-windows-path' @(
+        'VL_SEGMENTS=model',
+        'VL_CLOCK=off',
+        'VL_BG_MODEL=45',
+        'VL_FLOAT_FILE="C:\Users\Jane\.claude\float.txt"'
+    )
+    $windowsPathPs = Invoke-Statusline (Json $basePayload) $windowsPathConfig @{} '' 5000
+    $windowsPathBash = Invoke-BashStatusline (Json $basePayload) $windowsPathConfig @{}
+    Check-Run 'PowerShell double-quoted Windows path' $windowsPathPs
+    Check-Run 'Bash double-quoted Windows path' $windowsPathBash
+    Check-Exact 'double-quoted ordinary backslashes are byte exact' $windowsPathPs $windowsPathBash
+    Check 'double-quoted Windows path keeps the root config active' ($windowsPathPs.Stdout.Contains('48;5;45m'))
+
     $bareConfig = New-Config 'bare-escape' @('VL_SEGMENTS=model\ ctx', 'VL_CLOCK=off')
     $bareRun = Invoke-Statusline (Json $basePayload) $bareConfig @{} '' 5000
     Check-Run 'bare backslash shell word' $bareRun

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -638,6 +638,30 @@ fi
     Check-Exact 'Unicode Git repository differential is byte exact' $unicodePs $unicodeBash
     Check 'Unicode Git keeps project and branch text' ((Plain $unicodePs.Stdout).Contains($unicodeLeaf) -and (Plain $unicodePs.Stdout).Contains($unicodeBranch))
 
+    $scalar = Glyph 0x1F600
+    $scalarRoot = Join-Path $TempRoot ($scalar + 'repo')
+    [void][System.IO.Directory]::CreateDirectory($scalarRoot)
+    Write-Utf8 (Join-Path $scalarRoot 'tracked.txt') "tracked`n"
+    [void](Run-Git $scalarRoot 'init -q')
+    [void](Run-Git $scalarRoot ('checkout -q -b ' + $scalar + 'branch'))
+    [void](Run-Git $scalarRoot 'config user.email test@example.com')
+    [void](Run-Git $scalarRoot 'config user.name test')
+    [void](Run-Git $scalarRoot 'add tracked.txt')
+    [void](Run-Git $scalarRoot 'commit -q -m init')
+    $scalarPayload = New-Payload (Forward-Path $scalarRoot)
+    $scalarOneConfig = New-Config 'unicode-scalar-max-one' @('VL_SEGMENTS=project\ git','VL_CLOCK=off','VL_NAME_MAX=1')
+    $scalarOnePs = Invoke-Statusline (Json $scalarPayload) $scalarOneConfig @{} '' 5000
+    Check-Run 'PowerShell Unicode scalar max one' $scalarOnePs
+    Check 'Unicode scalar max one preserves the complete scalar' ((Plain $scalarOnePs.Stdout).Contains($scalar))
+    Check 'Unicode scalar max one emits no replacement character' (-not $scalarOnePs.Stdout.Contains([char]0xFFFD))
+
+    [void](Run-Git $scalarRoot ('branch -m ' + 'ABCD' + $scalar + 'F'))
+    $scalarTailConfig = New-Config 'unicode-scalar-tail' @('VL_SEGMENTS=git','VL_CLOCK=off','VL_NAME_MAX=4')
+    $scalarTailPs = Invoke-Statusline (Json $scalarPayload) $scalarTailConfig @{} '' 5000
+    Check-Run 'PowerShell Unicode scalar tail boundary' $scalarTailPs
+    Check 'Unicode scalar tail keeps the complete suffix' ((Plain $scalarTailPs.Stdout).Contains('A' + (Glyph 0x2026) + $scalar + 'F'))
+    Check 'Unicode scalar tail emits no replacement character' (-not $scalarTailPs.Stdout.Contains([char]0xFFFD))
+
     $script:QuoteHelper = Join-Path $TempRoot 'configure-quote.sh'
     Write-Utf8 $script:QuoteHelper @'
 #!/usr/bin/env bash
@@ -651,6 +675,20 @@ shell_quote "$CORALLINE_Q_VALUE"
     Check-Run 'configure %q segment list' $quotedRun
     $quotedPlain = Plain $quotedRun.Stdout
     Check 'configure %q segment list renders every token' ($quotedPlain.Contains($repoLeaf) -and $quotedPlain.Contains('main') -and $quotedPlain.Contains('MODEL_SENTINEL') -and $quotedPlain.Contains('62%'))
+
+    $caseConfig = New-Config 'case-sensitive-keys' @(
+        'VL_SEGMENTS=model',
+        'vl_segments=clock',
+        'VL_CLOCK=off',
+        'VL_BG_MODEL=56',
+        'vl_bg_model=196'
+    )
+    $casePs = Invoke-Statusline (Json $basePayload) $caseConfig @{} '' 5000
+    $caseBash = Invoke-BashStatusline (Json $basePayload) $caseConfig @{}
+    Check-Run 'PowerShell case-sensitive config keys' $casePs
+    Check-Run 'Bash case-sensitive config keys' $caseBash
+    Check-Exact 'case-variant config keys cannot overwrite supported keys' $casePs $caseBash
+    Check 'case-sensitive config keeps the model segment' ((Plain $casePs.Stdout).Contains('MODEL_SENTINEL'))
 
     $paddedQuote = Quote-FromConfigure ' model '
     $paddedLine = 'VL_SEGMENTS=' + $paddedQuote
@@ -1788,6 +1826,16 @@ fi
         $uncRun = Invoke-Statusline (Json $statePayload) $uncConfig $stateEnvWrite '' 5000
         Check-Run 'WIN-02 UNC state rejection' $uncRun
         Check 'WIN-02 UNC state rejection is pre-I/O' (-not [IO.Directory]::Exists((Join-Path ([IO.Path]::GetDirectoryName($localStateBase)) 'burn.d')))
+
+        $uncGitRoot = '\\localhost\' + $driveRoot.Substring(0,1) + '$\' + $gitRoot.Substring($driveRoot.Length)
+        $uncPayload = New-Payload $uncGitRoot
+        $uncProbeConfig = New-Config 'win03-unc-read-probes' @('VL_SEGMENTS=git\ stash\ project\ node\ python','VL_CLOCK=off')
+        $uncProbeRun = Invoke-Statusline (Json $uncPayload) $uncProbeConfig @{} '' 10000
+        $uncProbePlain = Plain $uncProbeRun.Stdout
+        Check-Run 'WIN-03 UNC read-only workspace probes' $uncProbeRun
+        Check 'WIN-03 UNC git and project probes render' ($uncProbePlain.Contains('main') -and $uncProbePlain.Contains($repoLeaf))
+        Check 'WIN-03 UNC stash probe renders' ($uncProbePlain.Contains((Glyph 0x2691) + ' 1 '))
+        Check 'WIN-03 UNC runtime pin probes render' ($uncProbePlain.Contains('20.11.1') -and $uncProbePlain.Contains('3.12.2'))
     }
 
     foreach ($deviceBase in @('\\?\' + $localStateBase, '\\.\' + $localStateBase)) {

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -1,117 +1,882 @@
+#Requires -Version 5.1
 <#
-  Regression tests for statusline.ps1 (issue #8: native PowerShell support
-  without Git Bash). Mirrors the check()-per-assertion convention the bash
-  tests in this directory use, translated to PowerShell.
+  WIN-01 regression and differential tests for statusline.ps1.
 
-  Run:
-    powershell -NoProfile -File test/test-statusline-ps1.ps1
-
-  Needs: git.exe on PATH (already required by statusline.sh's own git
-  segment). No jq, no bash.
+  Run on native Windows PowerShell 5.1. Git Bash is test-only and supplies the
+  statusline.sh oracle plus real configure.sh printf %q fixtures.
 #>
 
-$ErrorActionPreference = 'Continue'
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
 $Here = Split-Path -Path $MyInvocation.MyCommand.Path -Parent
 $Repo = Split-Path -Path $Here -Parent
 $Script = Join-Path $Repo 'statusline.ps1'
-$SampleInput = Join-Path $Here 'sample-input.json'
+$BashScript = Join-Path $Repo 'statusline.sh'
+$Configure = Join-Path $Repo 'configure.sh'
+$PowerShellExe = (Get-Process -Id $PID).Path
+$Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+$StrictUtf8 = New-Object System.Text.UTF8Encoding($false, $true)
+$Invariant = [System.Globalization.CultureInfo]::InvariantCulture
+$TempRoot = Join-Path $Repo ('.win01-test-' + [guid]::NewGuid().ToString('N'))
+$script:Fail = 0
+$script:Pass = 0
+$script:Blocked = 0
 
-$script:fail = 0
-function Check([string]$Name, [bool]$Cond) {
-    if ($Cond) { Write-Output "ok    $Name" }
-    else { Write-Output "FAIL  $Name"; $script:fail = 1 }
+function Glyph([int]$Codepoint) { return [System.Char]::ConvertFromUtf32($Codepoint) }
+
+function Check([string]$Name, [bool]$Condition) {
+    if ($Condition) { [Console]::Out.WriteLine("PASS  $Name"); $script:Pass++ }
+    else { [Console]::Out.WriteLine("FAIL  $Name"); $script:Fail++ }
 }
 
-function Invoke-Statusline([string]$Json, [string]$ConfigPath, [string]$Cwd) {
-    $prevConfig = $env:CORALLINE_CONFIG
-    if ($ConfigPath) { $env:CORALLINE_CONFIG = $ConfigPath } else { Remove-Item Env:\CORALLINE_CONFIG -ErrorAction SilentlyContinue }
-    $prevLoc = Get-Location
-    if ($Cwd) { Set-Location -LiteralPath $Cwd }
+function Blocked([string]$Name, [string]$Reason) {
+    [Console]::Out.WriteLine("BLOCKED  ${Name}: $Reason")
+    $script:Blocked++
+}
+
+function Write-Utf8([string]$Path, [string]$Text) {
+    $dir = [System.IO.Path]::GetDirectoryName($Path)
+    if (-not [System.IO.Directory]::Exists($dir)) { [void][System.IO.Directory]::CreateDirectory($dir) }
+    [System.IO.File]::WriteAllText($Path, $Text, $Utf8NoBom)
+}
+
+function Forward-Path([string]$Path) { return $Path.Replace('\', '/') }
+
+function Invoke-CapturedProcess(
+    [string]$FileName,
+    [string]$Arguments,
+    [string]$InputText,
+    [hashtable]$Environment,
+    [string]$WorkingDirectory,
+    [int]$TimeoutMs
+) {
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $FileName
+    $psi.Arguments = $Arguments
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardInput = $true
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.CreateNoWindow = $true
+    if (-not [string]::IsNullOrEmpty($WorkingDirectory)) { $psi.WorkingDirectory = $WorkingDirectory }
+    foreach ($key in $Environment.Keys) {
+        if ($null -eq $Environment[$key]) { [void]$psi.EnvironmentVariables.Remove($key) }
+        else { $psi.EnvironmentVariables[$key] = [string]$Environment[$key] }
+    }
+
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo = $psi
+    $watch = [System.Diagnostics.Stopwatch]::StartNew()
     try {
-        $out = $Json | & powershell -NoProfile -File $Script 2>&1
-        return @{ Output = ($out -join "`n"); ExitCode = $LASTEXITCODE }
+        if (-not $process.Start()) { throw 'process did not start' }
+        $stdout = New-Object System.IO.MemoryStream
+        $stderr = New-Object System.IO.MemoryStream
+        $outTask = $process.StandardOutput.BaseStream.CopyToAsync($stdout)
+        $errTask = $process.StandardError.BaseStream.CopyToAsync($stderr)
+        $inputBytes = $Utf8NoBom.GetBytes($InputText)
+        if ($inputBytes.Length -gt 0) { $process.StandardInput.BaseStream.Write($inputBytes, 0, $inputBytes.Length) }
+        $process.StandardInput.Close()
+        $timedOut = -not $process.WaitForExit($TimeoutMs)
+        if ($timedOut) {
+            try { $process.Kill() } catch { }
+            [void]$process.WaitForExit(2000)
+        }
+        [void]$outTask.Wait(2000)
+        [void]$errTask.Wait(2000)
+        $watch.Stop()
+        $outBytes = $stdout.ToArray()
+        $errBytes = $stderr.ToArray()
+        try { $outText = $StrictUtf8.GetString($outBytes) } catch { $outText = $null }
+        try { $errText = $StrictUtf8.GetString($errBytes) } catch { $errText = $null }
+        $exitCode = -1
+        if (-not $timedOut -and $process.HasExited) { $exitCode = $process.ExitCode }
+        return [pscustomobject]@{
+            ExitCode = $exitCode
+            TimedOut = $timedOut
+            ElapsedMs = $watch.ElapsedMilliseconds
+            StdoutBytes = $outBytes
+            StderrBytes = $errBytes
+            Stdout = $outText
+            Stderr = $errText
+        }
+    } catch {
+        $watch.Stop()
+        return [pscustomobject]@{
+            ExitCode = -1
+            TimedOut = $false
+            ElapsedMs = $watch.ElapsedMilliseconds
+            StdoutBytes = [byte[]]@()
+            StderrBytes = $Utf8NoBom.GetBytes($_.Exception.Message)
+            Stdout = ''
+            Stderr = $_.Exception.Message
+        }
     } finally {
-        Set-Location $prevLoc
-        if ($prevConfig) { $env:CORALLINE_CONFIG = $prevConfig } else { Remove-Item Env:\CORALLINE_CONFIG -ErrorAction SilentlyContinue }
+        if ($null -ne $process) { $process.Dispose() }
     }
 }
 
-# --- Case 1: default segments render from the shared sample-input.json -----
-$sampleJson = Get-Content -LiteralPath $SampleInput -Raw
-$r1 = Invoke-Statusline $sampleJson '' ''
-Check 'exits 0 on the shared sample input' ($r1.ExitCode -eq 0)
-Check 'dir segment shows the sample cwd' ($r1.Output -like '*projects/coralline*')
-Check 'model segment shows the display name' ($r1.Output -like '*Fable 5*')
-Check 'ctx segment shows the used percentage' ($r1.Output -like '*62%*')
-Check '5h limit segment renders' ($r1.Output -like '*5h*')
-Check '7d limit segment renders' ($r1.Output -like '*7d*')
-Check 'cost segment renders' ($r1.Output -like '*$1.23*')
-Check 'no PowerShell errors on stderr (git/jq/bash-free path)' ($r1.Output -notmatch 'Split-Path|ParameterBindingException|CommandNotFoundException')
-
-# --- Case 2: VL_ASCII=1 swaps the gauge fill/empty glyphs, no crash --------
-$h2 = Join-Path ([System.IO.Path]::GetTempPath()) ("coralline-ps1-$([guid]::NewGuid())")
-New-Item -ItemType Directory -Path $h2 | Out-Null
-$asciiConf = Join-Path $h2 'coralline.conf'
-Set-Content -LiteralPath $asciiConf -Value @('VL_ASCII="1"', 'VL_SEGMENTS="ctx limit5h"') -Encoding UTF8
-$r2 = Invoke-Statusline $sampleJson $asciiConf ''
-Check 'ASCII mode exits 0' ($r2.ExitCode -eq 0)
-Check 'ASCII mode uses # for the filled gauge' ($r2.Output -like '*#*')
-Check 'ASCII mode uses - for the empty gauge' ($r2.Output -like '*-*')
-Remove-Item -Recurse -Force $h2
-
-# --- Case 3: missing config file falls back to the built-in defaults -------
-$missingConf = Join-Path ([System.IO.Path]::GetTempPath()) ("coralline-ps1-missing-$([guid]::NewGuid()).conf")
-$r3 = Invoke-Statusline $sampleJson $missingConf ''
-Check 'missing config file does not error' ($r3.ExitCode -eq 0)
-Check 'missing config file still renders the default segments' ($r3.Output -like '*Fable 5*')
-
-# --- Case 4: malformed / empty stdin degrades to a clock-only render -------
-$r4 = Invoke-Statusline '' '' ''
-Check 'empty stdin exits 0' ($r4.ExitCode -eq 0)
-$r5 = Invoke-Statusline 'not json {{{' '' ''
-Check 'malformed stdin exits 0' ($r5.ExitCode -eq 0)
-
-# --- Case 5: theme include (`. "path"`) resolves without a config-format
-# change — same coralline.conf a bash install already wrote works here -----
-$h5 = Join-Path ([System.IO.Path]::GetTempPath()) ("coralline-ps1-$([guid]::NewGuid())")
-New-Item -ItemType Directory -Path $h5 | Out-Null
-$themeConf = Join-Path $h5 'coralline.conf'
-$draculaTheme = Join-Path $Repo 'themes\dracula.conf'
-Set-Content -LiteralPath $themeConf -Value @(". `"$draculaTheme`"", 'VL_SEGMENTS="model"') -Encoding UTF8
-$r6 = Invoke-Statusline $sampleJson $themeConf ''
-Check 'theme include resolves and its color reaches the render' ($r6.Output -like '*38;2;189;147;249*')
-
-Remove-Item -Recurse -Force $h5
-
-# --- Case 6: git segment reflects a real repo (branch + dirty marker) ------
-$h6 = Join-Path ([System.IO.Path]::GetTempPath()) ("coralline-ps1-git-$([guid]::NewGuid())")
-New-Item -ItemType Directory -Path $h6 | Out-Null
-Push-Location $h6
-try {
-    git init -q -b main .
-    git config user.email test@example.com
-    git config user.name test
-    'one' | Set-Content -LiteralPath (Join-Path $h6 'a.txt')
-    git add a.txt
-    git commit -q -m 'init'
-    $gitConf = Join-Path $h6 'coralline.conf'
-    Set-Content -LiteralPath $gitConf -Value 'VL_SEGMENTS="git"' -Encoding UTF8
-    # statusline.ps1 (like statusline.sh) reads cwd from the session JSON, not
-    # from this process's own working directory, so the fixture repo must be
-    # named there explicitly.
-    $gitCwd = ($h6 -replace '\\', '/')
-    $gitJson = "{`"cwd`":`"$gitCwd`"}"
-    $rClean = Invoke-Statusline $gitJson $gitConf $h6
-    Check 'git segment shows the branch name on a clean repo' ($rClean.Output -like '*main*')
-
-    'two' | Add-Content -LiteralPath (Join-Path $h6 'a.txt')
-    $rDirty = Invoke-Statusline $gitJson $gitConf $h6
-    Check 'git segment marks a modified working tree' ($rDirty.Output -like '*main!*')
-} finally {
-    Pop-Location
-    Remove-Item -Recurse -Force $h6
+function Runtime-Environment([string]$ConfigPath, [hashtable]$Extra) {
+    $environment = @{
+        CORALLINE_CONFIG = $null
+        CORALLINE_NO_SAMPLE = '1'
+        REMORA_ACTIVE = $null
+        VIRTUAL_ENV = $null
+        CONDA_DEFAULT_ENV = $null
+    }
+    if (-not [string]::IsNullOrEmpty($ConfigPath)) { $environment.CORALLINE_CONFIG = Forward-Path $ConfigPath }
+    foreach ($key in $Extra.Keys) { $environment[$key] = $Extra[$key] }
+    return $environment
 }
 
-if ($script:fail -eq 0) { Write-Output 'ALL PASS'; exit 0 }
-Write-Output 'SOME FAILED'
-exit 1
+function Invoke-Statusline(
+    [string]$Json,
+    [string]$ConfigPath,
+    [hashtable]$ExtraEnvironment,
+    [string]$Arguments,
+    [int]$TimeoutMs
+) {
+    $psArgs = '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + $Script + '"'
+    if (-not [string]::IsNullOrEmpty($Arguments)) { $psArgs += ' ' + $Arguments }
+    return Invoke-CapturedProcess $PowerShellExe $psArgs $Json (Runtime-Environment $ConfigPath $ExtraEnvironment) $Repo $TimeoutMs
+}
+
+function Invoke-BashStatusline([string]$Json, [string]$ConfigPath, [hashtable]$ExtraEnvironment) {
+    $environment = Runtime-Environment $ConfigPath $ExtraEnvironment
+    $args = '--noprofile --norc "' + (Forward-Path $BashScript) + '"'
+    return Invoke-CapturedProcess $script:BashExe $args $Json $environment $Repo 10000
+}
+
+function Check-Run([string]$Name, $Run) {
+    Check "$Name no timeout" (-not $Run.TimedOut)
+    Check "$Name exit 0" ($Run.ExitCode -eq 0)
+    Check "$Name stderr empty" ($Run.StderrBytes.Length -eq 0)
+    Check "$Name strict UTF-8 stdout" ($null -ne $Run.Stdout)
+}
+
+function Plain([string]$Text) {
+    if ($null -eq $Text) { return '' }
+    return [regex]::Replace($Text, ([string][char]27 + '\[[0-9;]*m'), '')
+}
+
+function Check-Exact([string]$Name, $Actual, $Expected) {
+    $equal = $Actual.StdoutBytes.Length -eq $Expected.StdoutBytes.Length
+    if ($equal) {
+        for ($i=0; $i -lt $Actual.StdoutBytes.Length; $i++) {
+            if ($Actual.StdoutBytes[$i] -ne $Expected.StdoutBytes[$i]) { $equal = $false; break }
+        }
+    }
+    Check $Name $equal
+    if (-not $equal) {
+        [Console]::Out.WriteLine('DIAG  PowerShell=' + [Convert]::ToBase64String($Actual.StdoutBytes))
+        [Console]::Out.WriteLine('DIAG  Bash=' + [Convert]::ToBase64String($Expected.StdoutBytes))
+    }
+}
+
+function New-Config([string]$Name, [string[]]$Lines) {
+    $path = Join-Path $TempRoot ('config\' + $Name + '.conf')
+    Write-Utf8 $path (($Lines -join "`n") + "`n")
+    return $path
+}
+
+function New-Payload([string]$Cwd) {
+    $payload = [ordered]@{
+        cwd = $Cwd
+        workspace = [ordered]@{ current_dir = $Cwd }
+        model = [ordered]@{ display_name = 'Claude MODEL_SENTINEL' }
+        output_style = [ordered]@{ name = 'Explanatory' }
+        effort = [ordered]@{ level = 'high' }
+        context_window = [ordered]@{
+            used_percentage = 62.4
+            total_input_tokens = 1234567
+            total_output_tokens = 45678
+            current_usage = [ordered]@{
+                cache_read_input_tokens = 98765
+                cache_creation_input_tokens = 4321
+            }
+        }
+        rate_limits = [ordered]@{
+            five_hour = [ordered]@{ used_percentage = 41.2; resets_at = '' }
+            seven_day = [ordered]@{ used_percentage = 78.9; resets_at = '' }
+        }
+        cost = [ordered]@{
+            total_cost_usd = 1.2345
+            total_lines_added = 321
+            total_lines_removed = 87
+            total_duration_ms = 5432100
+        }
+    }
+    return $payload
+}
+
+function Json($Object) { return ($Object | ConvertTo-Json -Compress -Depth 12) }
+function Clone-Object($Object) { return ((Json $Object) | ConvertFrom-Json) }
+
+function Run-ModelColor([string]$Name, [string]$ConfigPath, [string]$ExpectedSpec, [hashtable]$Environment) {
+    $payload = New-Payload ''
+    $run = Invoke-Statusline (Json $payload) $ConfigPath $Environment '' 5000
+    Check-Run $Name $run
+    if ($ExpectedSpec.Contains(',')) {
+        $parts = $ExpectedSpec.Split(',')
+        $needle = "48;2;$($parts[0]);$($parts[1]);$($parts[2])m"
+    } else { $needle = "48;5;${ExpectedSpec}m" }
+    $hasColor = $run.Stdout.Contains($needle)
+    Check "$Name expected model color" $hasColor
+    if (-not $hasColor) {
+        [Console]::Out.WriteLine('DIAG  ' + $Name + '=' + [Convert]::ToBase64String($run.StdoutBytes))
+        [Console]::Out.WriteLine('DIAG  config=' + [Convert]::ToBase64String([System.IO.File]::ReadAllBytes($ConfigPath)))
+    }
+    return $run
+}
+
+function Snapshot-File([string]$Path) {
+    if (-not [System.IO.File]::Exists($Path)) { return $null }
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try { $hash = [BitConverter]::ToString($sha.ComputeHash([System.IO.File]::ReadAllBytes($Path))).Replace('-', '') }
+    finally { $sha.Dispose() }
+    $info = New-Object System.IO.FileInfo($Path)
+    return "$($info.Length)|$($info.LastWriteTimeUtc.Ticks)|$hash"
+}
+
+function Snapshot-Ads([string]$Carrier, [string]$StreamName) {
+    try {
+        $item = Get-Item -LiteralPath $Carrier -Stream $StreamName -ErrorAction Stop
+        $bytes = [byte[]]@(Get-Content -LiteralPath $Carrier -Stream $StreamName -Encoding Byte -ErrorAction Stop)
+    } catch { return $null }
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try { $hash = [BitConverter]::ToString($sha.ComputeHash($bytes)).Replace('-', '') }
+    finally { $sha.Dispose() }
+    return "$($item.Length)|$hash"
+}
+
+function Run-Git([string]$WorkingDirectory, [string]$Arguments) {
+    $run = Invoke-CapturedProcess $script:GitExe $Arguments '' @{} $WorkingDirectory 10000
+    if ($run.TimedOut -or $run.ExitCode -ne 0) { throw "git failed: $Arguments`n$($run.Stderr)" }
+    return $run
+}
+
+function Quote-FromConfigure([string]$Value) {
+    $environment = @{
+        CORALLINE_CONFIGURE = (Forward-Path $Configure)
+        CORALLINE_Q_VALUE = $Value
+    }
+    $run = Invoke-CapturedProcess $script:BashExe ('--noprofile --norc "' + (Forward-Path $script:QuoteHelper) + '"') '' $environment $Repo 5000
+    if ($run.ExitCode -ne 0 -or $run.TimedOut -or $run.StderrBytes.Length -ne 0) { throw 'configure.sh shell_quote fixture failed' }
+    return $run.Stdout
+}
+
+function Assert-NoUnexpectedResidue([string]$Root, [string]$Name) {
+    $bad = @(Get-ChildItem -LiteralPath $Root -Recurse -Force -ErrorAction SilentlyContinue | Where-Object {
+        $_.Name -like '*.tmp' -or $_.Name -like '*.lock' -or $_.Name -like 'burn-*.tsv' -or $_.Name -like 'limit-*.d'
+    })
+    Check "$Name no runtime residue" ($bad.Count -eq 0)
+}
+
+[void][System.IO.Directory]::CreateDirectory($TempRoot)
+$cleanupOk = $false
+try {
+    $source = [System.IO.File]::ReadAllText($Script, $StrictUtf8)
+    $bashSource = [System.IO.File]::ReadAllText($BashScript, $StrictUtf8)
+
+    Check 'static source has no mojibake double question token' (-not $source.Contains(('?' + '?')))
+    Check 'static source has no dangling handoff reference' (-not $source.Contains('handoff/'))
+    Check 'static source forbids Invoke-Expression' (-not $source.Contains('Invoke-Expression'))
+    Check 'static source forbids dynamic ScriptBlock creation' (-not $source.Contains('ScriptBlock]::Create'))
+    Check 'literal subagent route precedes stdin open' ($source.IndexOf("-ceq '--subagent'") -ge 0 -and $source.IndexOf("-ceq '--subagent'") -lt $source.IndexOf('OpenStandardInput'))
+    Check 'UNC lexical rejection precedes canonicalization' ($source.IndexOf("StartsWith('\\'") -ge 0 -and $source.IndexOf("StartsWith('\\'") -lt $source.IndexOf('GetFullPath($p)'))
+    Check 'reparse validation precedes config read' ($source.IndexOf('Test-SafeRegularFile $Path') -lt $source.IndexOf('Read-StrictUtf8File $Path'))
+    Check 'Bash oracle main extraction contains central scrub' ($bashSource.Contains('] | map(scrub) | join('))
+
+    $expectedRegistry = @('clock','cost','ctx','dir','duration','effort','git','limit5h','limit7d','lines','model','node','project','python','stash','style')
+    $builderBlock = [regex]::Match($source, '(?s)\$SegmentBuilders = \[ordered\]@\{(.*?)\n\}').Groups[1].Value
+    $actualRegistry = @([regex]::Matches($builderBlock, '(?m)^    ([A-Za-z0-9]+) =') | ForEach-Object { $_.Groups[1].Value } | Sort-Object)
+    Check 'closed PowerShell registry equals WIN-01 inventory' (($actualRegistry -join ' ') -eq (($expectedRegistry | Sort-Object) -join ' '))
+    $bashSegments = @([regex]::Matches($bashSource, '(?m)^seg_([A-Za-z0-9_]+)\(\)') | ForEach-Object { $_.Groups[1].Value } | Where-Object { $_ -ne 'len' -and $_ -ne 'limit' -and $_ -ne 'burn' } | Sort-Object -Unique)
+    Check 'Bash public registry minus burn equals WIN-01 inventory' (($bashSegments -join ' ') -eq (($expectedRegistry | Sort-Object) -join ' '))
+
+    $script:BashExe = $env:CORALLINE_TEST_BASH
+    if ([string]::IsNullOrEmpty($script:BashExe)) { $script:BashExe = 'C:\Program Files\Git\bin\bash.exe' }
+    Check 'Git Bash oracle executable exists' ([System.IO.File]::Exists($script:BashExe))
+    if (-not [System.IO.File]::Exists($script:BashExe)) { throw 'Git Bash oracle is required for WIN-01 tests' }
+    $bashProbe = Invoke-CapturedProcess $script:BashExe '--noprofile --norc -lc "command -v jq >/dev/null && printf ready"' '' @{} $Repo 5000
+    Check 'Git Bash jq oracle available' ($bashProbe.ExitCode -eq 0 -and $bashProbe.Stdout -eq 'ready' -and $bashProbe.StderrBytes.Length -eq 0)
+    if ($bashProbe.ExitCode -ne 0) { throw 'Git Bash jq oracle unavailable' }
+
+    $script:GitExe = (Get-Command git.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1).Source
+    $gitRoot = Join-Path $TempRoot 'fixture-repo'
+    [void][System.IO.Directory]::CreateDirectory($gitRoot)
+    [System.IO.File]::WriteAllText((Join-Path $gitRoot 'a.txt'), "one`n", $Utf8NoBom)
+    [System.IO.File]::WriteAllText((Join-Path $gitRoot '.nvmrc'), "v20.11.1`n", $Utf8NoBom)
+    [System.IO.File]::WriteAllText((Join-Path $gitRoot '.python-version'), "3.12.2`n", $Utf8NoBom)
+    [void](Run-Git $gitRoot 'init -q')
+    [void](Run-Git $gitRoot 'checkout -q -b main')
+    [void](Run-Git $gitRoot 'config user.email test@example.com')
+    [void](Run-Git $gitRoot 'config user.name test')
+    [void](Run-Git $gitRoot 'add a.txt .nvmrc .python-version')
+    [void](Run-Git $gitRoot 'commit -q -m init')
+    [System.IO.File]::AppendAllText((Join-Path $gitRoot 'a.txt'), "stash`n", $Utf8NoBom)
+    [void](Run-Git $gitRoot 'stash push -q -m fixture')
+    $cwd = Forward-Path $gitRoot
+    $repoLeaf = [System.IO.Path]::GetFileName($gitRoot)
+    $basePayload = New-Payload $cwd
+
+    $gitParityConfig = New-Config 'git-edge-parity' @('VL_SEGMENTS=git\ project','VL_CLOCK=off')
+    $unbornRoot = Join-Path $TempRoot 'empty-repo'
+    [void][System.IO.Directory]::CreateDirectory($unbornRoot)
+    [void](Run-Git $unbornRoot 'init -q')
+    [void](Run-Git $unbornRoot 'checkout -q -b main')
+    $unbornPayload = New-Payload (Forward-Path $unbornRoot)
+    $unbornPs = Invoke-Statusline (Json $unbornPayload) $gitParityConfig @{} '' 5000
+    $unbornBash = Invoke-BashStatusline (Json $unbornPayload) $gitParityConfig @{}
+    Check-Run 'PowerShell unborn Git repository' $unbornPs
+    Check-Run 'Bash unborn Git repository' $unbornBash
+    Check-Exact 'unborn Git repository differential is byte exact' $unbornPs $unbornBash
+    Check 'unborn Git renders branch and project' ((Plain $unbornPs.Stdout).Contains('main') -and (Plain $unbornPs.Stdout).Contains('empty-repo'))
+
+    $detachedRoot = Join-Path $TempRoot 'detached-repo'
+    [void][System.IO.Directory]::CreateDirectory($detachedRoot)
+    Write-Utf8 (Join-Path $detachedRoot 'tracked.txt') "tracked`n"
+    [void](Run-Git $detachedRoot 'init -q')
+    [void](Run-Git $detachedRoot 'checkout -q -b main')
+    [void](Run-Git $detachedRoot 'config user.email test@example.com')
+    [void](Run-Git $detachedRoot 'config user.name test')
+    [void](Run-Git $detachedRoot 'add tracked.txt')
+    [void](Run-Git $detachedRoot 'commit -q -m init')
+    $detachedShort = (Run-Git $detachedRoot 'rev-parse --short=7 HEAD').Stdout.Trim()
+    [void](Run-Git $detachedRoot 'checkout -q --detach')
+    $detachedPayload = New-Payload (Forward-Path $detachedRoot)
+    $detachedPs = Invoke-Statusline (Json $detachedPayload) $gitParityConfig @{} '' 5000
+    $detachedBash = Invoke-BashStatusline (Json $detachedPayload) $gitParityConfig @{}
+    Check-Run 'PowerShell detached Git repository' $detachedPs
+    Check-Run 'Bash detached Git repository' $detachedBash
+    Check-Exact 'detached Git repository differential is byte exact' $detachedPs $detachedBash
+    Check 'detached Git keeps short oid and project' ((Plain $detachedPs.Stdout).Contains($detachedShort) -and (Plain $detachedPs.Stdout).Contains('detached-repo'))
+
+    $unicodeLeaf = (Glyph 0x96EA) + 'repo'
+    $unicodeBranch = (Glyph 0x529F) + (Glyph 0x80FD)
+    $unicodeRoot = Join-Path $TempRoot $unicodeLeaf
+    [void][System.IO.Directory]::CreateDirectory($unicodeRoot)
+    Write-Utf8 (Join-Path $unicodeRoot 'tracked.txt') "tracked`n"
+    [void](Run-Git $unicodeRoot 'init -q')
+    [void](Run-Git $unicodeRoot ('checkout -q -b ' + $unicodeBranch))
+    [void](Run-Git $unicodeRoot 'config user.email test@example.com')
+    [void](Run-Git $unicodeRoot 'config user.name test')
+    [void](Run-Git $unicodeRoot 'add tracked.txt')
+    [void](Run-Git $unicodeRoot 'commit -q -m init')
+    $unicodePayload = New-Payload (Forward-Path $unicodeRoot)
+    $unicodeCommand = '[Console]::OutputEncoding=[Text.Encoding]::GetEncoding(437); & ''' + $Script + ''''
+    $unicodeArgs = '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "' + $unicodeCommand.Replace('"','\"') + '"'
+    $unicodePs = Invoke-CapturedProcess $PowerShellExe $unicodeArgs (Json $unicodePayload) (Runtime-Environment $gitParityConfig @{}) $Repo 5000
+    $unicodeBash = Invoke-BashStatusline (Json $unicodePayload) $gitParityConfig @{}
+    Check-Run 'PowerShell codepage 437 Unicode Git repository' $unicodePs
+    Check-Run 'Bash Unicode Git repository' $unicodeBash
+    Check-Exact 'Unicode Git repository differential is byte exact' $unicodePs $unicodeBash
+    Check 'Unicode Git keeps project and branch text' ((Plain $unicodePs.Stdout).Contains($unicodeLeaf) -and (Plain $unicodePs.Stdout).Contains($unicodeBranch))
+
+    $script:QuoteHelper = Join-Path $TempRoot 'configure-quote.sh'
+    Write-Utf8 $script:QuoteHelper @'
+#!/usr/bin/env bash
+eval "$(sed -n '/^shell_quote()/,/^}/p' "$CORALLINE_CONFIGURE")"
+shell_quote "$CORALLINE_Q_VALUE"
+'@
+    $quotedSegments = Quote-FromConfigure 'dir git model ctx'
+    Check 'real configure shell_quote emits escaped multi-word value' ($quotedSegments.Contains('\ '))
+    $quotedConfig = New-Config 'configure-q-segments' @("VL_SEGMENTS=$quotedSegments", 'VL_CLOCK=off')
+    $quotedRun = Invoke-Statusline (Json $basePayload) $quotedConfig @{} '' 5000
+    Check-Run 'configure %q segment list' $quotedRun
+    $quotedPlain = Plain $quotedRun.Stdout
+    Check 'configure %q segment list renders every token' ($quotedPlain.Contains($repoLeaf) -and $quotedPlain.Contains('main') -and $quotedPlain.Contains('MODEL_SENTINEL') -and $quotedPlain.Contains('62%'))
+
+    $paddedQuote = Quote-FromConfigure ' model '
+    $paddedLine = 'VL_SEGMENTS=' + $paddedQuote
+    $paddedConfig = New-Config 'configure-q-padded' @($paddedLine, 'VL_CLOCK=off')
+    $paddedRun = Invoke-Statusline (Json $basePayload) $paddedConfig @{} '' 5000
+    Check-Run 'configure %q leading and trailing spaces' $paddedRun
+    Check 'configure %q preserves one padded shell word' ((Plain $paddedRun.Stdout).Contains('MODEL_SENTINEL') -and -not (Plain $paddedRun.Stdout).Contains((Glyph 0x2299)))
+
+    $spaceRoot = Join-Path $TempRoot 'space root'
+    [void][System.IO.Directory]::CreateDirectory($spaceRoot)
+    $spaceTheme = Join-Path $spaceRoot 'space theme.conf'
+    Write-Utf8 $spaceTheme "VL_BG_MODEL=33`n"
+    $quotedInclude = Quote-FromConfigure (Forward-Path $spaceTheme)
+    $spaceConfig = Join-Path $spaceRoot 'coralline.conf'
+    Write-Utf8 $spaceConfig ('. ' + $quotedInclude + "`nVL_SEGMENTS=model`nVL_CLOCK=off`n")
+    [void](Run-ModelColor 'configure %q spaced include' $spaceConfig '33' @{})
+
+    $wordConfig = New-Config 'word-forms' @(
+        "VL_SEGMENTS='model'",
+        'VL_CLOCK="off"',
+        'VL_BG_MODEL=44'
+    )
+    [void](Run-ModelColor 'single and double shell words' $wordConfig '44' @{})
+    $bareConfig = New-Config 'bare-escape' @('VL_SEGMENTS=model\ ctx', 'VL_CLOCK=off')
+    $bareRun = Invoke-Statusline (Json $basePayload) $bareConfig @{} '' 5000
+    Check-Run 'bare backslash shell word' $bareRun
+    Check 'bare backslash shell word decodes spaces' ((Plain $bareRun.Stdout).Contains('MODEL_SENTINEL') -and (Plain $bareRun.Stdout).Contains('62%'))
+
+    $controlQuote = Quote-FromConfigure ("X`nY")
+    Check 'real configure quote selects ANSI-C for newline' ($controlQuote.StartsWith("$'", [System.StringComparison]::Ordinal))
+    $ansiConfig = New-Config 'ansi-c' @('VL_SEGMENTS=ctx', 'VL_CLOCK=off', "VL_CTX_GLYPH=$controlQuote")
+    $ansiRun = Invoke-Statusline (Json $basePayload) $ansiConfig @{} '' 5000
+    Check-Run 'ANSI-C percent-q decode' $ansiRun
+    Check 'decoded config controls are scrubbed before render' ((Plain $ansiRun.Stdout).Contains('XY') -and -not (Plain $ansiRun.Stdout).Contains("X`nY"))
+
+    $themeInclude = Quote-FromConfigure (Forward-Path (Join-Path $Repo 'themes\dracula.conf'))
+    $themeConfig = New-Config 'shipped-theme' @(('. ' + $themeInclude), 'VL_SEGMENTS=model', 'VL_CLOCK=off')
+    [void](Run-ModelColor 'approved runtime theme include' $themeConfig '189,147,249' @{})
+
+    $homeRoot = Join-Path $TempRoot 'fake-home'
+    $homeThemes = Join-Path $homeRoot 'themes'
+    [void][System.IO.Directory]::CreateDirectory($homeThemes)
+    foreach ($name in @('dollar','braced','tilde')) { Write-Utf8 (Join-Path $homeThemes "$name.conf") "VL_BG_MODEL=55`n" }
+    foreach ($case in @(
+        [pscustomobject]@{ Name='HOME include'; Word='$HOME/themes/dollar.conf' },
+        [pscustomobject]@{ Name='braced HOME include'; Word='${HOME}/themes/braced.conf' },
+        [pscustomobject]@{ Name='tilde include'; Word='~/themes/tilde.conf' }
+    )) {
+        $config = Join-Path $homeRoot ($case.Name.Replace(' ','-') + '.conf')
+        Write-Utf8 $config ('. ' + $case.Word + "`nVL_SEGMENTS=model`nVL_CLOCK=off`n")
+        [void](Run-ModelColor $case.Name $config '55' @{ HOME=$homeRoot; USERPROFILE=$homeRoot })
+    }
+
+    $driveConfig = New-Config 'msys-root' @('VL_SEGMENTS=model', 'VL_CLOCK=off', 'VL_BG_MODEL=56')
+    $drivePath = Forward-Path $driveConfig
+    $msysConfig = '/' + $drivePath.Substring(0,1).ToLowerInvariant() + $drivePath.Substring(2)
+    $msysRun = Invoke-Statusline (Json $basePayload) $msysConfig @{} '' 5000
+    Check-Run 'MSYS root config path' $msysRun
+    Check 'MSYS root config path applies config' ($msysRun.Stdout.Contains('48;5;56m'))
+
+    $includeDir = Join-Path $TempRoot 'transactions'
+    [void][System.IO.Directory]::CreateDirectory($includeDir)
+    $good = Join-Path $includeDir 'good.conf'
+    Write-Utf8 $good "VL_BG_MODEL=61`n"
+    $beforeAfter = Join-Path $includeDir 'before-after.conf'
+    Write-Utf8 $beforeAfter "VL_SEGMENTS=model`nVL_CLOCK=off`nVL_BG_MODEL=60`n. good.conf`nVL_BG_MODEL=62`n"
+    [void](Run-ModelColor 'assignment before and after include' $beforeAfter '62' @{})
+
+    $missing = Join-Path $includeDir 'missing-root.conf'
+    Write-Utf8 $missing "VL_SEGMENTS=model`nVL_CLOCK=off`n. missing.conf`nVL_BG_MODEL=63`n"
+    [void](Run-ModelColor 'missing include is nested no-op' $missing '63' @{})
+
+    $invalidChild = Join-Path $includeDir 'invalid-child.conf'
+    Write-Utf8 $invalidChild "VL_BG_MODEL=99`necho unsupported`n"
+    $invalidChildRoot = Join-Path $includeDir 'invalid-child-root.conf'
+    Write-Utf8 $invalidChildRoot "VL_SEGMENTS=model`nVL_CLOCK=off`nVL_BG_MODEL=64`n. invalid-child.conf`n"
+    [void](Run-ModelColor 'malformed include rolls back only include delta' $invalidChildRoot '64' @{})
+
+    $cycleA = Join-Path $includeDir 'cycle-a.conf'
+    $cycleB = Join-Path $includeDir 'cycle-b.conf'
+    Write-Utf8 $cycleA "VL_SEGMENTS=model`nVL_CLOCK=off`n. cycle-b.conf`n"
+    Write-Utf8 $cycleB "VL_BG_MODEL=65`n. cycle-a.conf`n"
+    [void](Run-ModelColor 'include cycle is silent no-op at cycle edge' $cycleA '65' @{})
+
+    $depthDir = Join-Path $includeDir 'depth'
+    [void][System.IO.Directory]::CreateDirectory($depthDir)
+    for ($i=1; $i -le 9; $i++) {
+        $lines = @("VL_BG_MODEL=$($i + 70)")
+        if ($i -lt 9) { $lines += ". d$($i + 1).conf" }
+        Write-Utf8 (Join-Path $depthDir "d$i.conf") (($lines -join "`n") + "`n")
+    }
+    $depthRoot = Join-Path $depthDir 'root.conf'
+    Write-Utf8 $depthRoot "VL_SEGMENTS=model`nVL_CLOCK=off`n. d1.conf`n"
+    [void](Run-ModelColor 'include depth eight commits and depth nine is no-op' $depthRoot '78' @{})
+
+    $outsideDir = Join-Path $TempRoot 'outside'
+    [void][System.IO.Directory]::CreateDirectory($outsideDir)
+    Write-Utf8 (Join-Path $outsideDir 'evil.conf') "VL_BG_MODEL=99`n"
+    $outRoot = Join-Path $includeDir 'out-root.conf'
+    Write-Utf8 $outRoot "VL_SEGMENTS=model`nVL_CLOCK=off`n. ../outside/evil.conf`nVL_BG_MODEL=66`n"
+    [void](Run-ModelColor 'out-of-root include is nested no-op' $outRoot '66' @{})
+
+    $malformedRoot = Join-Path $includeDir 'malformed-root.conf'
+    Write-Utf8 $malformedRoot "VL_SEGMENTS=model`nVL_CLOCK=off`nVL_BG_MODEL=99`necho unsupported`n"
+    [void](Run-ModelColor 'malformed root rolls back all root assignments' $malformedRoot '173' @{})
+    $includeThenBad = Join-Path $includeDir 'include-then-bad.conf'
+    Write-Utf8 $includeThenBad "VL_SEGMENTS=model`nVL_CLOCK=off`n. good.conf`necho unsupported`n"
+    [void](Run-ModelColor 'successful include delta rolls back with malformed root' $includeThenBad '173' @{})
+
+    foreach ($bad in @(
+        [pscustomobject]@{ Name='command substitution'; Value='$(whoami)' },
+        [pscustomobject]@{ Name='backtick'; Value='`whoami`' },
+        [pscustomobject]@{ Name='pipeline'; Value='model|ctx' },
+        [pscustomobject]@{ Name='redirect'; Value='model>file' },
+        [pscustomobject]@{ Name='semicolon'; Value='model;ctx' },
+        [pscustomobject]@{ Name='multiple words'; Value='model ctx' },
+        [pscustomobject]@{ Name='incomplete escape'; Value='model\' }
+    )) {
+        $config = Join-Path $includeDir ('reject-' + $bad.Name.Replace(' ','-') + '.conf')
+        Write-Utf8 $config ("VL_BG_MODEL=99`nVL_SEGMENTS=$($bad.Value)`n")
+        [void](Run-ModelColor ("reject " + $bad.Name) $config '173' @{})
+    }
+
+    $conditional = Join-Path $includeDir 'conditional.conf'
+    # Safe-subset rule: parser control flow reads REMORA_ACTIVE only from the process environment.
+    Write-Utf8 $conditional @'
+VL_SEGMENTS=model
+VL_CLOCK=off
+REMORA_ACTIVE=1
+if [ "${REMORA_ACTIVE:-0}" = "1" ]; then
+VL_BG_MODEL=81
+else
+VL_BG_MODEL=82
+fi
+'@
+    foreach ($case in @(
+        [pscustomobject]@{ Name='REMORA unset uses zero'; Env=@{}; Color='82' },
+        [pscustomobject]@{ Name='REMORA empty uses zero'; Env=@{ REMORA_ACTIVE='' }; Color='82' },
+        [pscustomobject]@{ Name='REMORA zero selects else'; Env=@{ REMORA_ACTIVE='0' }; Color='82' },
+        [pscustomobject]@{ Name='REMORA one selects then'; Env=@{ REMORA_ACTIVE='1' }; Color='81' }
+    )) { [void](Run-ModelColor $case.Name $conditional $case.Color $case.Env) }
+
+    $notEqual = Join-Path $includeDir 'conditional-ne.conf'
+    Write-Utf8 $notEqual @'
+VL_SEGMENTS=model
+VL_CLOCK=off
+if [ "${REMORA_ACTIVE:-0}" != "1" ]; then
+VL_BG_MODEL=83
+else
+VL_BG_MODEL=84
+fi
+'@
+    [void](Run-ModelColor 'REMORA not-equal true branch' $notEqual '83' @{ REMORA_ACTIVE='0' })
+    [void](Run-ModelColor 'REMORA not-equal else branch' $notEqual '84' @{ REMORA_ACTIVE='1' })
+
+    $inactive = Join-Path $includeDir 'inactive.conf'
+    Write-Utf8 $inactive @'
+VL_SEGMENTS=model
+VL_CLOCK=off
+if [ "${REMORA_ACTIVE:-0}" = "1" ]; then
+VL_BG_MODEL=$(unsupported)
+. missing.conf
+else
+VL_BG_MODEL=85
+fi
+'@
+    [void](Run-ModelColor 'inactive branch assignments and includes have no effect' $inactive '85' @{ REMORA_ACTIVE='0' })
+    $unsupportedIf = Join-Path $includeDir 'unsupported-if.conf'
+    Write-Utf8 $unsupportedIf "VL_BG_MODEL=99`nif test -n x; then`nVL_BG_MODEL=1`nfi`n"
+    [void](Run-ModelColor 'unsupported conditional rolls back root' $unsupportedIf '173' @{})
+
+    $budgetDir = Join-Path $includeDir 'budget'
+    [void][System.IO.Directory]::CreateDirectory($budgetDir)
+    Write-Utf8 (Join-Path $budgetDir 'target16.conf') "VL_BG_MODEL=91`n"
+    Write-Utf8 (Join-Path $budgetDir 'target17.conf') "VL_BG_MODEL=92`n"
+    Write-Utf8 (Join-Path $budgetDir 'dup.conf') "VL_FG_DIM=1`n"
+    foreach ($kind in @('missing','duplicate','cycle','rejected')) {
+        $root = Join-Path $budgetDir ("budget-$kind.conf")
+        $lines = @('VL_SEGMENTS=model','VL_CLOCK=off')
+        for ($i=1; $i -le 15; $i++) {
+            switch ($kind) {
+                'missing' { $lines += ". missing-$i.conf" }
+                'duplicate' { $lines += '. dup.conf' }
+                'cycle' { $lines += ('. ' + [System.IO.Path]::GetFileName($root)) }
+                'rejected' { $lines += '. ../../outside/evil.conf' }
+            }
+        }
+        $lines += '. target16.conf'
+        $lines += '. target17.conf'
+        $lines += 'VL_FG_TEXT=42'
+        Write-Utf8 $root (($lines -join "`n") + "`n")
+        $run = Run-ModelColor ("include budget counts $kind attempts") $root '91' @{}
+        Check "include budget $kind leaves later root assignment live" ($run.Stdout.Contains('38;5;42m'))
+        Check "include budget $kind makes seventeenth a complete no-op" (-not $run.Stdout.Contains('48;5;92m'))
+    }
+
+    $inactiveBudget = Join-Path $budgetDir 'inactive-budget.conf'
+    $inactiveLines = @('VL_SEGMENTS=model','VL_CLOCK=off','if [ "${REMORA_ACTIVE:-0}" = "1" ]; then')
+    for ($i=1; $i -le 20; $i++) { $inactiveLines += ". inactive-$i.conf" }
+    $inactiveLines += 'else'
+    for ($i=1; $i -le 15; $i++) { $inactiveLines += ". active-missing-$i.conf" }
+    $inactiveLines += '. target16.conf'
+    $inactiveLines += 'fi'
+    Write-Utf8 $inactiveBudget (($inactiveLines -join "`n") + "`n")
+    [void](Run-ModelColor 'inactive includes consume no shared budget' $inactiveBudget '91' @{ REMORA_ACTIVE='0' })
+
+    $baseConfigLines = @('VL_CLOCK=off')
+    $segmentCases = [ordered]@{
+        clock = [pscustomobject]@{ Show=@('VL_SEGMENTS=clock','VL_CLOCK=24h','VL_CLOCK_SECONDS=0'); Needle=(Glyph 0x2299); Suppress={ param($p) $p }; SuppressConfig=@('VL_SEGMENTS=clock','VL_CLOCK=off') }
+        cost = [pscustomobject]@{ Show=@('VL_SEGMENTS=cost','VL_CLOCK=off'); Needle='$1.23'; Suppress={ param($p) $p.cost.total_cost_usd=0; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=cost' }
+        ctx = [pscustomobject]@{ Show=@('VL_SEGMENTS=ctx','VL_CLOCK=off'); Needle='62%'; Suppress={ param($p) $p.context_window.used_percentage=$null; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=ctx' }
+        dir = [pscustomobject]@{ Show=@('VL_SEGMENTS=dir','VL_CLOCK=off'); Needle=$repoLeaf; Suppress={ param($p) $p.cwd=''; $p.workspace.current_dir=''; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=dir' }
+        duration = [pscustomobject]@{ Show=@('VL_SEGMENTS=duration','VL_CLOCK=off'); Needle='1h30m'; Suppress={ param($p) $p.cost.total_duration_ms=0; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=duration' }
+        effort = [pscustomobject]@{ Show=@('VL_SEGMENTS=effort','VL_CLOCK=off'); Needle='high'; Suppress={ param($p) $p.effort.level=''; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=effort' }
+        git = [pscustomobject]@{ Show=@('VL_SEGMENTS=git','VL_CLOCK=off'); Needle='main'; Suppress={ param($p) $p.cwd='C:/tmp/coralline-win01-no-repo'; $p.workspace.current_dir=$p.cwd; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=git' }
+        limit5h = [pscustomobject]@{ Show=@('VL_SEGMENTS=limit5h','VL_CLOCK=off'); Needle='41%'; Suppress={ param($p) $p.rate_limits.five_hour.used_percentage=$null; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=limit5h' }
+        limit7d = [pscustomobject]@{ Show=@('VL_SEGMENTS=limit7d','VL_CLOCK=off'); Needle='79%'; Suppress={ param($p) $p.rate_limits.seven_day.used_percentage=$null; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=limit7d' }
+        lines = [pscustomobject]@{ Show=@('VL_SEGMENTS=lines','VL_CLOCK=off'); Needle='+321 -87'; Suppress={ param($p) $p.cost.total_lines_added=0; $p.cost.total_lines_removed=0; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=lines' }
+        model = [pscustomobject]@{ Show=@('VL_SEGMENTS=model','VL_CLOCK=off'); Needle='MODEL_SENTINEL'; Suppress={ param($p) $p.model.display_name=''; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=model' }
+        node = [pscustomobject]@{ Show=@('VL_SEGMENTS=node','VL_CLOCK=off'); Needle='20.11.1'; Suppress={ param($p) $p.cwd='C:/tmp/coralline-win01-no-pin'; $p.workspace.current_dir=$p.cwd; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=node' }
+        project = [pscustomobject]@{ Show=@('VL_SEGMENTS=project','VL_CLOCK=off'); Needle=[System.IO.Path]::GetFileName($gitRoot); Suppress={ param($p) $p.cwd=''; $p.workspace.current_dir=''; $p }; SuppressConfig=@('VL_SEGMENTS=dir\ project','VL_CLOCK=off') }
+        python = [pscustomobject]@{ Show=@('VL_SEGMENTS=python','VL_CLOCK=off'); Needle='3.12.2'; Suppress={ param($p) $p.cwd='C:/tmp/coralline-win01-no-pin'; $p.workspace.current_dir=$p.cwd; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=python' }
+        stash = [pscustomobject]@{ Show=@('VL_SEGMENTS=stash','VL_CLOCK=off'); Needle='1'; Suppress={ param($p) $p.cwd='C:/tmp/coralline-win01-no-repo'; $p.workspace.current_dir=$p.cwd; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=stash' }
+        style = [pscustomobject]@{ Show=@('VL_SEGMENTS=style','VL_CLOCK=off'); Needle='Explanatory'; Suppress={ param($p) $p.output_style.name='default'; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=style' }
+    }
+
+    foreach ($name in $expectedRegistry) {
+        $case = $segmentCases[$name]
+        $showConfig = New-Config ("segment-$name-show") $case.Show
+        $show = Invoke-Statusline (Json $basePayload) $showConfig @{} '' 5000
+        Check-Run "$name show" $show
+        Check "$name show/value" ((Plain $show.Stdout).Contains([string]$case.Needle))
+        $suppressedPayload = Clone-Object $basePayload
+        $suppressedPayload = & $case.Suppress $suppressedPayload
+        $suppressConfig = New-Config ("segment-$name-suppress") $case.SuppressConfig
+        $suppress = Invoke-Statusline (Json $suppressedPayload) $suppressConfig @{} '' 5000
+        Check-Run "$name suppress" $suppress
+        Check "$name suppresses without an empty pill" ([string]::IsNullOrEmpty($suppress.Stdout))
+    }
+
+    $orderedNames = @('dir','project','git','node','python','model','effort','ctx','limit5h','limit7d','lines','cost','style','duration','stash')
+    $orderedValue = $orderedNames -join ' '
+    $orderConfig = New-Config 'segment-order' @(('VL_SEGMENTS=' + (Quote-FromConfigure $orderedValue)), 'VL_CLOCK=off')
+    $orderRun = Invoke-Statusline (Json $basePayload) $orderConfig @{} '' 5000
+    Check-Run 'configured segment order' $orderRun
+    $visible = Plain $orderRun.Stdout
+    $needles = @($repoLeaf, $repoLeaf, 'main', '20.11.1', '3.12.2', 'MODEL_SENTINEL', 'high', '62%', '5h', '7d', '+321 -87', '$1.23', 'Explanatory', '1h30m', ((Glyph 0x2691) + ' 1'))
+    $lastIndex = -1
+    $orderOk = $true
+    foreach ($needle in $needles) {
+        $nextIndex = $visible.IndexOf($needle, $lastIndex + 1, [System.StringComparison]::Ordinal)
+        if ($nextIndex -le $lastIndex) { $orderOk = $false; break }
+        $lastIndex = $nextIndex
+    }
+    Check 'configured segment order is preserved exactly' $orderOk
+
+    $bashOrder = Invoke-BashStatusline (Json $basePayload) $orderConfig @{}
+    Check-Run 'Bash full stateless oracle' $bashOrder
+    Check-Exact 'full fixed-pill differential is byte exact' $orderRun $bashOrder
+    if (-not ($orderRun.Stdout -ceq $bashOrder.Stdout)) { [Console]::Out.WriteLine('DIAG  order-config=' + [Convert]::ToBase64String([System.IO.File]::ReadAllBytes($orderConfig))) }
+
+    $themePs = Invoke-Statusline (Json $basePayload) $themeConfig @{} '' 5000
+    $themeBash = Invoke-BashStatusline (Json $basePayload) $themeConfig @{}
+    Check-Run 'PowerShell theme differential input' $themePs
+    Check-Run 'Bash theme differential input' $themeBash
+    Check-Exact 'theme include differential is byte exact' $themePs $themeBash
+
+    $glyphConfig = New-Config 'glyph-knobs' @(
+        'VL_SEGMENTS=project\ ctx',
+        'VL_CLOCK=off',
+        'VL_BAR_FILL=F',
+        'VL_BAR_EMPTY=E',
+        'VL_CTX_GLYPH=C',
+        'VL_PROJECT_GLYPH=P'
+    )
+    $glyphRun = Invoke-Statusline (Json $basePayload) $glyphConfig @{} '' 5000
+    Check-Run 'four documented glyph knobs' $glyphRun
+    $glyphPlain = Plain $glyphRun.Stdout
+    Check 'project and ctx glyph overrides render' ($glyphPlain.Contains(' P ') -and $glyphPlain.Contains(' C '))
+    Check 'bar fill and empty overrides render' ($glyphPlain.Contains('FFFEE'))
+
+    $missingTokens = Clone-Object $basePayload
+    $missingTokens.context_window.total_input_tokens = $null
+    $missingTokens.context_window.total_output_tokens = $null
+    $missingTokens.context_window.current_usage.cache_read_input_tokens = $null
+    $missingTokens.context_window.current_usage.cache_creation_input_tokens = $null
+    $tokenConfig = New-Config 'missing-tokens' @('VL_SEGMENTS=ctx','VL_CLOCK=off')
+    $tokenRun = Invoke-Statusline (Json $missingTokens) $tokenConfig @{} '' 5000
+    Check-Run 'missing token values' $tokenRun
+    Check 'missing token values render zero' ((Plain $tokenRun.Stdout).Contains((Glyph 0x2191) + '0 ' + (Glyph 0x2193) + '0 cr:0 cw:0'))
+
+    $dirConfig = New-Config 'dir-only' @('VL_SEGMENTS=dir','VL_CLOCK=off','VL_PATH_DEPTH=4')
+    foreach ($case in @(
+        [pscustomobject]@{ Name='Unix root'; Path='/'; Expected=' / ' },
+        [pscustomobject]@{ Name='drive root'; Path='C:/'; Expected=' C:/ ' },
+        [pscustomobject]@{ Name='deep drive'; Path='C:/one/two/three/four'; Expected=' C:/one/' + (Glyph 0x2026) + '/four ' },
+        [pscustomobject]@{ Name='UNC root'; Path='//server/share/'; Expected=' //server/share ' },
+        [pscustomobject]@{ Name='deep UNC'; Path='//server/share/one/two/three'; Expected=' //server/share/' + (Glyph 0x2026) + '/three ' }
+    )) {
+        $payload = New-Payload $case.Path
+        $run = Invoke-Statusline (Json $payload) $dirConfig @{} '' 5000
+        Check-Run $case.Name $run
+        Check "$($case.Name) path semantics" ((Plain $run.Stdout).Contains($case.Expected))
+    }
+
+    $durationConfig = New-Config 'duration-main' @('VL_SEGMENTS=duration','VL_CLOCK=off')
+    $durationRun = Invoke-Statusline (Json $basePayload) $durationConfig @{} '' 5000
+    Check 'main duration omits seconds once minutes render' ((Plain $durationRun.Stdout).Contains('1h30m') -and -not (Plain $durationRun.Stdout).Contains('1h30m54s'))
+
+    $midpointConfig = New-Config 'percent-midpoint' @('VL_SEGMENTS=ctx\ limit5h\ limit7d','VL_CLOCK=off')
+    foreach ($raw in @('61.5','62.5')) {
+        $payload = Clone-Object $basePayload
+        $value = [double]::Parse($raw, $Invariant)
+        $payload.context_window.used_percentage = $value
+        $payload.rate_limits.five_hour.used_percentage = $value
+        $payload.rate_limits.seven_day.used_percentage = $value
+        $psRun = Invoke-Statusline (Json $payload) $midpointConfig @{} '' 5000
+        $bashRun = Invoke-BashStatusline (Json $payload) $midpointConfig @{}
+        Check-Run "PowerShell percentage midpoint $raw" $psRun
+        Check-Run "Bash percentage midpoint $raw" $bashRun
+        Check-Exact "percentage midpoint $raw differential is byte exact" $psRun $bashRun
+    }
+
+    foreach ($raw in @('-5','NaN','Infinity','1e999','999999999999999999999999999999')) {
+        $payload = Clone-Object $basePayload
+        $payload.context_window.used_percentage = $raw
+        $payload.rate_limits.five_hour.used_percentage = $raw
+        $payload.cost.total_cost_usd = $raw
+        $payload.cost.total_duration_ms = $raw
+        $payload.cost.total_lines_added = $raw
+        $numericConfig = New-Config ('numeric-' + [Math]::Abs($raw.GetHashCode())) @(
+            'VL_SEGMENTS=ctx\ limit5h\ cost\ duration\ lines',
+            'VL_CLOCK=off',
+            'VL_BAR_WIDTH=999999999999999999999',
+            'VL_COST_DECIMALS=-1',
+            'VL_WARN_PCT=NaN',
+            'VL_HOT_PCT=Infinity',
+            'VL_BG_CTX=999'
+        )
+        $run = Invoke-Statusline (Json $payload) $numericConfig @{} '' 5000
+        Check-Run "bounded numeric $raw" $run
+        Check "bounded numeric $raw output is finite" ($run.StdoutBytes.Length -lt 4096 -and -not $run.Stdout.Contains('NaN') -and -not $run.Stdout.Contains('Infinity'))
+        Check "bounded numeric $raw invalid color falls back" ($run.Stdout.Contains('48;5;238m'))
+    }
+
+    $absentConfig = New-Config 'absent-executables' @('VL_SEGMENTS=git\ node\ python\ model','VL_CLOCK=off','VL_RUNTIME_PROBE=1')
+    $absentPayload = New-Payload (Forward-Path (Join-Path $TempRoot 'no-pin-dir'))
+    [void][System.IO.Directory]::CreateDirectory((Join-Path $TempRoot 'no-pin-dir'))
+    $emptyPath = Join-Path $TempRoot 'empty-path'
+    [void][System.IO.Directory]::CreateDirectory($emptyPath)
+    $absentRun = Invoke-Statusline (Json $absentPayload) $absentConfig @{ PATH=$emptyPath } '' 5000
+    Check-Run 'absent Git Node Python executables' $absentRun
+    Check 'absent executables suppress only dependent segments' ((Plain $absentRun.Stdout).Contains('MODEL_SENTINEL') -and -not (Plain $absentRun.Stdout).Contains('20.11.1') -and -not (Plain $absentRun.Stdout).Contains('3.12.2'))
+
+    $pythonEnvConfig = New-Config 'python-env-cwd-gate' @('VL_SEGMENTS=python','VL_CLOCK=off')
+    foreach ($case in @(
+        [pscustomobject]@{ Name='virtualenv'; Environment=@{ VIRTUAL_ENV='C:/venvs/demo' } },
+        [pscustomobject]@{ Name='conda'; Environment=@{ CONDA_DEFAULT_ENV='demo' } }
+    )) {
+        $emptyPs = Invoke-Statusline '{}' $pythonEnvConfig $case.Environment '' 5000
+        $emptyBash = Invoke-BashStatusline '{}' $pythonEnvConfig $case.Environment
+        Check-Run "PowerShell empty-cwd $($case.Name)" $emptyPs
+        Check-Run "Bash empty-cwd $($case.Name)" $emptyBash
+        Check-Exact "empty-cwd $($case.Name) differential is byte exact" $emptyPs $emptyBash
+        Check "empty-cwd $($case.Name) suppresses python" ($emptyPs.StdoutBytes.Length -eq 0)
+
+        $cwdPs = Invoke-Statusline (Json $basePayload) $pythonEnvConfig $case.Environment '' 5000
+        $cwdBash = Invoke-BashStatusline (Json $basePayload) $pythonEnvConfig $case.Environment
+        Check-Run "PowerShell cwd $($case.Name)" $cwdPs
+        Check-Run "Bash cwd $($case.Name)" $cwdBash
+        Check-Exact "cwd $($case.Name) differential is byte exact" $cwdPs $cwdBash
+        Check "cwd $($case.Name) renders env label" ((Plain $cwdPs.Stdout).Contains('demo'))
+    }
+
+    $controlPayload = New-Payload ''
+    $controlPayload.model.display_name = 'Claude A' + [char]0 + 'B' + [char]27 + '[2J' + 'C' + [char]10 + 'D' + [char]13 + 'E' + [char]0x7F + 'F' + [char]0x85 + 'G'
+    $controlConfig = New-Config 'control-scrub' @('VL_SEGMENTS=model','VL_CLOCK=off')
+    $controlRun = Invoke-Statusline (Json $controlPayload) $controlConfig @{} '' 5000
+    Check-Run 'main payload control scrub' $controlRun
+    $controlPlain = Plain $controlRun.Stdout
+    Check 'main payload controls are removed from visible text' ($controlPlain.Contains('AB[2JCDEFG'))
+    $maliciousAnsi = [byte[]]@(27,91,50,74)
+    $hasMalicious = $false
+    for ($i=0; $i -le $controlRun.StdoutBytes.Length - $maliciousAnsi.Length; $i++) {
+        $same = $true
+        for ($j=0; $j -lt $maliciousAnsi.Length; $j++) { if ($controlRun.StdoutBytes[$i+$j] -ne $maliciousAnsi[$j]) { $same=$false; break } }
+        if ($same) { $hasMalicious=$true; break }
+    }
+    Check 'payload ESC cannot create terminal ANSI' (-not $hasMalicious)
+    Check 'renderer-generated ANSI remains present' ($controlRun.Stdout.Contains(([string][char]27 + '[48;5;173m')))
+    Check 'payload CR and C1 bytes are absent' (-not ($controlRun.StdoutBytes -contains [byte]13) -and -not $controlRun.Stdout.Contains([string][char]0x85))
+    $controlBash = Invoke-BashStatusline (Json $controlPayload) $controlConfig @{}
+    Check-Run 'Bash main payload control scrub' $controlBash
+    Check 'Bash and PowerShell scrub have the same observable output' ($controlRun.Stdout -eq $controlBash.Stdout)
+
+    $codepagePayload = New-Payload ''
+    $codepagePayload.model.display_name = 'Claude UTF8-' + (Glyph 0x96EA)
+    $codepageConfig = New-Config 'codepage' @('VL_SEGMENTS=model','VL_CLOCK=off')
+    $command = '[Console]::OutputEncoding=[Text.Encoding]::GetEncoding(437); & ''' + $Script + ''''
+    $cpArgs = '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "' + $command.Replace('"','\"') + '"'
+    $codepageRun = Invoke-CapturedProcess $PowerShellExe $cpArgs (Json $codepagePayload) (Runtime-Environment $codepageConfig @{}) $Repo 5000
+    Check-Run 'codepage 437 raw I/O' $codepageRun
+    Check 'stdout is UTF-8 without BOM' ($codepageRun.StdoutBytes.Length -ge 3 -and -not ($codepageRun.StdoutBytes[0] -eq 0xEF -and $codepageRun.StdoutBytes[1] -eq 0xBB -and $codepageRun.StdoutBytes[2] -eq 0xBF) -and $codepageRun.Stdout.Contains((Glyph 0x96EA)))
+    Check 'stdout uses LF without CR' (-not ($codepageRun.StdoutBytes -contains [byte]13) -and $codepageRun.StdoutBytes[$codepageRun.StdoutBytes.Length - 1] -eq 10)
+
+    $subagentRun = Invoke-Statusline '' '\\localhost\never\touch.conf' @{} '--subagent' 5000
+    Check-Run 'literal subagent early route' $subagentRun
+    Check 'literal subagent route emits no main output' ($subagentRun.StdoutBytes.Length -eq 0)
+
+    $secRoot = Join-Path $TempRoot 'security'
+    $secConfigRoot = Join-Path $secRoot 'config'
+    $secOutside = Join-Path $secRoot 'outside'
+    [void][System.IO.Directory]::CreateDirectory($secConfigRoot)
+    [void][System.IO.Directory]::CreateDirectory($secOutside)
+    $evil = Join-Path $secOutside 'evil.conf'
+    Write-Utf8 $evil "VL_BG_MODEL=99`n"
+    $evilBefore = Snapshot-File $evil
+
+    $sec01 = Join-Path $secConfigRoot 'sec-inc-01.conf'
+    Write-Utf8 $sec01 "VL_SEGMENTS=model`nVL_CLOCK=off`n. ../outside/evil.conf`n"
+    $run01 = Run-ModelColor 'SEC-INC-01 traversal rejection' $sec01 '173' @{}
+    Check 'SEC-INC-01 outside canary unchanged' ((Snapshot-File $evil) -eq $evilBefore)
+    Check 'SEC-INC-01 completes within five seconds' ($run01.ElapsedMs -lt 5000)
+    Assert-NoUnexpectedResidue $secRoot 'SEC-INC-01'
+
+    $uncCanary = '\\localhost\C$\tmp\' + [System.IO.Path]::GetFileName($Repo) + '\' + [System.IO.Path]::GetFileName($TempRoot) + '\security\outside\evil.conf'
+    $probeCommand = "try { [IO.File]::ReadAllText('$uncCanary') | Out-Null; exit 0 } catch { exit 2 }"
+    $uncProbe = Invoke-CapturedProcess $PowerShellExe ('-NoLogo -NoProfile -NonInteractive -Command "' + $probeCommand + '"') '' @{} $Repo 3000
+    $staticUnc = $source.IndexOf("StartsWith('\\'") -ge 0 -and $source.IndexOf("StartsWith('\\'") -lt $source.IndexOf('GetFullPath($p)')
+    if ($uncProbe.ExitCode -eq 0 -and -not $uncProbe.TimedOut) {
+        $sec02 = Join-Path $secConfigRoot 'sec-inc-02.conf'
+        Write-Utf8 $sec02 ("VL_SEGMENTS=model`nVL_CLOCK=off`n. '$uncCanary'`n")
+        $run02 = Run-ModelColor 'SEC-INC-02 UNC rejection' $sec02 '173' @{}
+        Check 'SEC-INC-02 rejects before five-second watchdog' ($run02.ElapsedMs -lt 5000)
+        Check 'SEC-INC-02 canary unchanged' ((Snapshot-File $evil) -eq $evilBefore)
+        Check 'SEC-INC-02 static pre-I/O ordering evidence' $staticUnc
+    } else {
+        Check 'SEC-INC-02 static pre-I/O ordering evidence' $staticUnc
+        Blocked 'SEC-INC-02' 'readable loopback UNC share unavailable on host'
+    }
+
+    foreach ($device in @('\\?\' + $evil, '\\.\' + $evil)) {
+        $sec03 = Join-Path $secConfigRoot ('sec-inc-03-' + [Math]::Abs($device.GetHashCode()) + '.conf')
+        Write-Utf8 $sec03 ("VL_SEGMENTS=model`nVL_CLOCK=off`n. '$device'`n")
+        $run03 = Run-ModelColor 'SEC-INC-03 device namespace rejection' $sec03 '173' @{}
+        Check 'SEC-INC-03 canary unchanged' ((Snapshot-File $evil) -eq $evilBefore)
+        Check 'SEC-INC-03 completes within five seconds' ($run03.ElapsedMs -lt 5000)
+    }
+
+    $carrier = Join-Path $secConfigRoot 'carrier.txt'
+    Write-Utf8 $carrier 'PRIMARY'
+    $adsAvailable = $true
+    try {
+        Set-Content -LiteralPath $carrier -Stream 'evil.conf' -Value 'VL_BG_MODEL=99' -Encoding UTF8 -NoNewline -ErrorAction Stop
+        $adsBefore = Snapshot-Ads $carrier 'evil.conf'
+        if ($null -eq $adsBefore) { $adsAvailable = $false }
+    } catch { $adsAvailable = $false }
+    if ($adsAvailable) {
+        $primaryBefore = Snapshot-File $carrier
+        $sec04 = Join-Path $secConfigRoot 'sec-inc-04.conf'
+        Write-Utf8 $sec04 "VL_SEGMENTS=model`nVL_CLOCK=off`n. carrier.txt:evil.conf`n"
+        [void](Run-ModelColor 'SEC-INC-04 ADS rejection' $sec04 '173' @{})
+        Check 'SEC-INC-04 primary stream unchanged' ((Snapshot-File $carrier) -eq $primaryBefore)
+        Check 'SEC-INC-04 alternate stream unchanged' ((Snapshot-Ads $carrier 'evil.conf') -eq $adsBefore)
+    } else { Blocked 'SEC-INC-04' 'NTFS alternate data streams unavailable' }
+
+    $junction = Join-Path $secConfigRoot 'theme-link'
+    $mkArgs = '/d /s /c "mklink /J ""' + $junction + '"" ""' + $secOutside + '"""'
+    $mk = Invoke-CapturedProcess $env:ComSpec $mkArgs '' @{} $Repo 5000
+    $junctionReady = $mk.ExitCode -eq 0 -and [System.IO.Directory]::Exists($junction)
+    $staticReparse = $source.IndexOf('FileAttributes]::ReparsePoint') -ge 0 -and $source.IndexOf('Test-NoReparseComponents $Path') -lt $source.IndexOf('ReadAllBytes($Path)')
+    if ($junctionReady) {
+        $linkAttrsBefore = [System.IO.File]::GetAttributes($junction)
+        $sec05 = Join-Path $secConfigRoot 'sec-inc-05.conf'
+        Write-Utf8 $sec05 "VL_SEGMENTS=model`nVL_CLOCK=off`n. theme-link/evil.conf`n"
+        [void](Run-ModelColor 'SEC-INC-05 junction rejection' $sec05 '173' @{})
+        $linkAttrsAfter = [System.IO.File]::GetAttributes($junction)
+        Check 'SEC-INC-05 junction identity remains reparse point' (($linkAttrsBefore -band [System.IO.FileAttributes]::ReparsePoint) -ne 0 -and ($linkAttrsAfter -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)
+        Check 'SEC-INC-05 outside canary unchanged' ((Snapshot-File $evil) -eq $evilBefore)
+        Check 'SEC-INC-05 static no-follow ordering evidence' $staticReparse
+    } else {
+        Check 'SEC-INC-05 static no-follow ordering evidence' $staticReparse
+        Blocked 'SEC-INC-05' 'junction creation capability unavailable'
+    }
+    Assert-NoUnexpectedResidue $secRoot 'SEC-INC matrix'
+
+} finally {
+    try { Remove-Item -LiteralPath $TempRoot -Recurse -Force -ErrorAction Stop } catch { }
+    $cleanupOk = -not (Test-Path -LiteralPath $TempRoot)
+}
+
+Check 'finally removes the harness temp root' $cleanupOk
+Write-Output "SUMMARY pass=$script:Pass fail=$script:Fail blocked=$script:Blocked"
+if ($script:Fail -ne 0) { exit 1 }
+exit 0

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -789,6 +789,16 @@ shell_quote "$CORALLINE_Q_VALUE"
     $homePrefixRun = Invoke-Statusline (Json $basePayload) $homePrefixConfig @{ HOME=$homeRoot; USERPROFILE=$homeRoot } '' 5000
     Check-Run 'PowerShell HOME variable boundary' $homePrefixRun
     Check 'longer HOME-prefixed variable cannot authorize float output' (-not [System.IO.File]::Exists($homePrefixFloat))
+    $quotedHomePrefixConfig = New-Config 'quoted-HOME-variable-boundary' @(
+        'VL_SEGMENTS=model',
+        'VL_CLOCK=off',
+        'VL_FLOAT=1',
+        'VL_FLOAT_SEGMENTS=model',
+        'VL_FLOAT_FILE="$HOME_BACKUP/float.txt"'
+    )
+    $quotedHomePrefixRun = Invoke-Statusline (Json $basePayload) $quotedHomePrefixConfig @{ HOME=$homeRoot; USERPROFILE=$homeRoot } '' 5000
+    Check-Run 'PowerShell quoted HOME variable boundary' $quotedHomePrefixRun
+    Check 'quoted longer HOME-prefixed variable cannot authorize float output' (-not [System.IO.File]::Exists($homePrefixFloat))
 
     $driveConfig = New-Config 'msys-root' @('VL_SEGMENTS=model', 'VL_CLOCK=off', 'VL_BG_MODEL=56')
     $drivePath = Forward-Path $driveConfig

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -690,6 +690,28 @@ shell_quote "$CORALLINE_Q_VALUE"
     Check-Exact 'case-variant config keys cannot overwrite supported keys' $casePs $caseBash
     Check 'case-sensitive config keeps the model segment' ((Plain $casePs.Stdout).Contains('MODEL_SENTINEL'))
 
+    $segmentCaseConfig = New-Config 'case-sensitive-segment-name' @('VL_SEGMENTS=CLOCK', 'VL_CLOCK=24h')
+    $segmentCasePs = Invoke-Statusline (Json $basePayload) $segmentCaseConfig @{} '' 5000
+    $segmentCaseBash = Invoke-BashStatusline (Json $basePayload) $segmentCaseConfig @{}
+    Check-Run 'PowerShell case-sensitive segment name' $segmentCasePs
+    Check-Run 'Bash case-sensitive segment name' $segmentCaseBash
+    Check-Exact 'case-variant segment name stays unknown' $segmentCasePs $segmentCaseBash
+    Check 'case-variant segment name renders nothing' ([string]::IsNullOrEmpty($segmentCasePs.Stdout))
+
+    $styleCaseConfig = New-Config 'case-sensitive-style-value' @('VL_SEGMENTS=model\ ctx', 'VL_CLOCK=off', 'VL_STYLE=CLASSIC')
+    $styleCasePs = Invoke-Statusline (Json $basePayload) $styleCaseConfig @{} '' 5000
+    $styleCaseBash = Invoke-BashStatusline (Json $basePayload) $styleCaseConfig @{}
+    Check-Run 'PowerShell case-sensitive style value' $styleCasePs
+    Check-Run 'Bash case-sensitive style value' $styleCaseBash
+    Check-Exact 'case-variant style value keeps pill fallback' $styleCasePs $styleCaseBash
+
+    $layoutCaseConfig = New-Config 'case-sensitive-layout-value' @('VL_LAYOUT=AUTO', 'VL_SEGMENTS=model', 'VL_SEGMENTS2=ctx', 'VL_CLOCK=off')
+    $layoutCasePs = Invoke-Statusline (Json $basePayload) $layoutCaseConfig @{ COLUMNS='1' } '' 5000
+    $layoutCaseBash = Invoke-BashStatusline (Json $basePayload) $layoutCaseConfig @{ COLUMNS='1' }
+    Check-Run 'PowerShell case-sensitive layout value' $layoutCasePs
+    Check-Run 'Bash case-sensitive layout value' $layoutCaseBash
+    Check-Exact 'case-variant layout value keeps fixed rows' $layoutCasePs $layoutCaseBash
+
     $paddedQuote = Quote-FromConfigure ' model '
     $paddedLine = 'VL_SEGMENTS=' + $paddedQuote
     $paddedConfig = New-Config 'configure-q-padded' @($paddedLine, 'VL_CLOCK=off')
@@ -754,6 +776,19 @@ shell_quote "$CORALLINE_Q_VALUE"
         Write-Utf8 $config ('. ' + $case.Word + "`nVL_SEGMENTS=model`nVL_CLOCK=off`n")
         [void](Run-ModelColor $case.Name $config '55' @{ HOME=$homeRoot; USERPROFILE=$homeRoot })
     }
+    $homePrefixTarget = $homeRoot + '_BACKUP'
+    [void][System.IO.Directory]::CreateDirectory($homePrefixTarget)
+    $homePrefixFloat = Join-Path $homePrefixTarget 'float.txt'
+    $homePrefixConfig = New-Config 'HOME-variable-boundary' @(
+        'VL_SEGMENTS=model',
+        'VL_CLOCK=off',
+        'VL_FLOAT=1',
+        'VL_FLOAT_SEGMENTS=model',
+        'VL_FLOAT_FILE=$HOME_BACKUP/float.txt'
+    )
+    $homePrefixRun = Invoke-Statusline (Json $basePayload) $homePrefixConfig @{ HOME=$homeRoot; USERPROFILE=$homeRoot } '' 5000
+    Check-Run 'PowerShell HOME variable boundary' $homePrefixRun
+    Check 'longer HOME-prefixed variable cannot authorize float output' (-not [System.IO.File]::Exists($homePrefixFloat))
 
     $driveConfig = New-Config 'msys-root' @('VL_SEGMENTS=model', 'VL_CLOCK=off', 'VL_BG_MODEL=56')
     $drivePath = Forward-Path $driveConfig

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -698,6 +698,16 @@ shell_quote "$CORALLINE_Q_VALUE"
     Check-Exact 'case-variant segment name stays unknown' $segmentCasePs $segmentCaseBash
     Check 'case-variant segment name renders nothing' ([string]::IsNullOrEmpty($segmentCasePs.Stdout))
 
+    $clockOffCaseConfig = New-Config 'case-sensitive-clock-off' @('VL_SEGMENTS=clock', 'VL_CLOCK=OFF', 'VL_CLOCK_SECONDS=0')
+    $clockOffCasePs = Invoke-Statusline (Json $basePayload) $clockOffCaseConfig @{} '' 5000
+    Check-Run 'PowerShell case-sensitive clock off value' $clockOffCasePs
+    Check 'case-variant OFF keeps the Bash 12h fallback' ((Plain $clockOffCasePs.Stdout) -match '\b(0[1-9]|1[0-2]):[0-5][0-9] (am|pm)\b')
+
+    $clock24CaseConfig = New-Config 'case-sensitive-clock-24h' @('VL_SEGMENTS=clock', 'VL_CLOCK=24H', 'VL_CLOCK_SECONDS=0')
+    $clock24CasePs = Invoke-Statusline (Json $basePayload) $clock24CaseConfig @{} '' 5000
+    Check-Run 'PowerShell case-sensitive clock 24h value' $clock24CasePs
+    Check 'case-variant 24H keeps the Bash 12h fallback' ((Plain $clock24CasePs.Stdout) -match '\b(0[1-9]|1[0-2]):[0-5][0-9] (am|pm)\b')
+
     $styleCaseConfig = New-Config 'case-sensitive-style-value' @('VL_SEGMENTS=model\ ctx', 'VL_CLOCK=off', 'VL_STYLE=CLASSIC')
     $styleCasePs = Invoke-Statusline (Json $basePayload) $styleCaseConfig @{} '' 5000
     $styleCaseBash = Invoke-BashStatusline (Json $basePayload) $styleCaseConfig @{}


### PR DESCRIPTION
## Summary

Adds `statusline.ps1`, a Windows PowerShell 5.1 port of `statusline.sh` for PowerShell-only Windows setups (no Git Bash required).

- No bash, no jq. Session JSON via `ConvertFrom-Json`. Git/stash/project segments use `git.exe` on PATH only.
- Reads the same `~/.claude/coralline.conf` (and its one theme `. "path"` include) that a bash install already writes. Small KEY=value regex reader; no new config format and no second config file.
- Covers every main-bar JSON-driven segment except `burn` and the `--subagent` panel protocol (deferred). lean/classic and auto layout fall back to pill/fixed instead of erroring.
- `test/test-statusline-ps1.ps1` (17 checks) plus README settings.json wiring under "Windows without Git Bash".

Fixes #8 (approach comment: https://github.com/Nanako0129/coralline/issues/8#issuecomment-5055876575).

Credit: Stan Shih (@stantheman0128). Implementation was AI-assisted; verified on Windows 11 with PowerShell 5.1.

## Parity (this slice)

| Area | bash | PowerShell | Notes |
|---|---|---|---|
| Config + theme include | yes | yes | Same file, no format change |
| Style pill | yes | yes | |
| Style lean / classic | yes | fallback to pill | |
| Layout fixed | yes | yes | |
| Layout auto | yes | fallback to fixed | |
| Segments dir, project, git, stash, model, effort, ctx, limit5h, limit7d, lines, cost, style, duration, node, python, clock | yes | yes | |
| Segment burn | yes | not yet | Cross-session store; follow-up |
| VL_LIMIT_SYNC | yes | not yet | Same pattern as burn |
| --subagent protocol | yes | not yet | Separate stdin/stdout protocol |
| install.sh / configure.sh | bash | not yet | Documented manual copy path for now |

## Evidence

### Automated harness (Windows PowerShell 5.1)

```
PS> powershell -NoProfile -File test\test-statusline-ps1.ps1
ok    exits 0 on the shared sample input
ok    dir segment shows the sample cwd
ok    model segment shows the display name
ok    ctx segment shows the used percentage
ok    5h limit segment renders
ok    7d limit segment renders
ok    cost segment renders
ok    no PowerShell errors on stderr (git/jq/bash-free path)
ok    ASCII mode exits 0
ok    ASCII mode uses # for the filled gauge
ok    ASCII mode uses - for the empty gauge
ok    missing config file does not error
ok    missing config file still renders the default segments
ok    empty stdin exits 0
ok    malformed stdin exits 0
ok    theme include resolves and its color reaches the render
ok    git segment shows the branch name on a clean repo
ok    git segment marks a modified working tree
ALL PASS
```

Re-run in this publish session: ALL PASS.

### Manual checks on this box

- Dracula theme with full non-burn / non-subagent segment list inside a real git worktree.
- `.nvmrc` / `.python-version` fixtures for node and python segments.
- UTF-8 console output encoding forced so powerline glyphs survive Claude Code stdout capture under Windows PowerShell 5.1 OEM codepage.
- ANSI escapes match the bash palette for the same theme file (256-color and true-color).

### What was not tested

- Live Claude Code statusLine wiring end-to-end (documented; not exercised against a live Claude Code session in this PR).
- burn slope fit, VL_LIMIT_SYNC, --subagent panel rows, lean/classic styles, auto layout.
- install.ps1 / configure.ps1 (out of scope; bash installer still required to bootstrap a full tree unless the README manual copy path is used).

## Files

- `statusline.ps1` (new)
- `test/test-statusline-ps1.ps1` (new)
- `README.md` (Windows without Git Bash section)

No changes to `statusline.sh`, `install.sh`, `configure.sh`, or `themes/*.conf`.