### PR TITLE
fix(subagent): route the panel ctx row through VL_CTX_GLYPH

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ The renderer shares your config file but reads only the knobs that shape a row:
 `VL_LEAN_CAP_L`/`VL_LEAN_CAP_R`, `VL_LEAN_FG`, `VL_BG_BAR`) — `VL_ASCII`,
 `VL_NAME_MAX` (recommended — panel labels are long, and overlong rows are
 clipped from the right, hiding model/ctx first), the gauge knobs
-(`VL_BAR_WIDTH`, `VL_BAR_FILL`, `VL_BAR_EMPTY`, `VL_WARN_PCT`, `VL_HOT_PCT`),
+(`VL_BAR_WIDTH`, `VL_BAR_FILL`, `VL_BAR_EMPTY`, `VL_CTX_GLYPH`, `VL_WARN_PCT`,
+`VL_HOT_PCT`),
 the shared palette (`VL_FG_TEXT`, `VL_FG_DIM`, `VL_FG_OK`, `VL_FG_WARN`,
 `VL_FG_HOT`), and the row colors `VL_BG_SUB_NAME` / `VL_BG_SUB_MODEL` /
 `VL_BG_SUB_CTX` / `VL_BG_SUB_ELAPSED` (empty = fall back to `VL_BG_DIR` /

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -98,7 +98,7 @@ subagent renderer 與主列共用同一份 config，但只讀取與「單列外�
 `VL_LEAN_CAP_L`/`VL_LEAN_CAP_R`、`VL_LEAN_FG`、`VL_BG_BAR`）——`VL_ASCII`、
 `VL_NAME_MAX`（建議設定——面板 label 通常很長，列過寬時 Claude Code 從右側裁切，
 最先消失的就是 model/ctx）、用量條參數（`VL_BAR_WIDTH`、`VL_BAR_FILL`、
-`VL_BAR_EMPTY`、`VL_WARN_PCT`、`VL_HOT_PCT`）、共用色盤（`VL_FG_TEXT`、
+`VL_BAR_EMPTY`、`VL_CTX_GLYPH`、`VL_WARN_PCT`、`VL_HOT_PCT`）、共用色盤（`VL_FG_TEXT`、
 `VL_FG_DIM`、`VL_FG_OK`、`VL_FG_WARN`、`VL_FG_HOT`），以及列顏色
 `VL_BG_SUB_NAME` / `VL_BG_SUB_MODEL` / `VL_BG_SUB_CTX` / `VL_BG_SUB_ELAPSED`
 （留空 = 分別退回 `VL_BG_DIR` / `VL_BG_MODEL` / `VL_BG_CTX` /

--- a/statusline.sh
+++ b/statusline.sh
@@ -50,7 +50,7 @@ VL_BAR_EMPTY="▱"
 # font that lacks them leaves the substitution to the terminal's own fallback —
 # which may land on a glyph wider than one cell and shove the rest of the row
 # out of alignment (#47). Override with characters your terminal font carries.
-VL_CTX_GLYPH="⬡"                # glyph for the ctx segment
+VL_CTX_GLYPH="⬡"                # glyph for the ctx segment (main bar and subagent rows)
 VL_PROJECT_GLYPH="⬢"            # glyph for the project segment
 VL_CLOCK="12h"                  # 12h | 24h | off
 VL_CLOCK_SECONDS=1
@@ -1021,10 +1021,10 @@ subseg_ctx() {  # per-task context gauge; bare token count without a window size
     make_bar "$ci"; pct_fg "$ci"
     fg "$_PFG";      fgc="$_FG"
     fg "$VL_FG_DIM"; fgd="$_FG"
-    push "${VL_BG_SUB_CTX:-$VL_BG_CTX}" "${fgc} ⬡ ${_BAR} ${ci}% ${fgd}${_TOK} "
+    push "${VL_BG_SUB_CTX:-$VL_BG_CTX}" "${fgc} ${VL_CTX_GLYPH} ${_BAR} ${ci}% ${fgd}${_TOK} "
   else
     fg "$VL_FG_DIM"
-    push "${VL_BG_SUB_CTX:-$VL_BG_CTX}" "${_FG} ⬡ ${_TOK} "
+    push "${VL_BG_SUB_CTX:-$VL_BG_CTX}" "${_FG} ${VL_CTX_GLYPH} ${_TOK} "
   fi
 }
 

--- a/test/test-subagent.sh
+++ b/test/test-subagent.sh
@@ -98,6 +98,17 @@ case "$c1" in (*"Explore config sources"*) ok "row1 uses label when name absent"
 case "$c1" in (*"local_agent"*) bad "row1 must not show raw type: [$c1]" ;; (*) ok "row1 hides local_agent type" ;; esac
 case "$c1" in (*$'\033['*) ok "row1 carries ANSI" ;; (*) bad "row1 ANSI" ;; esac
 case "$c1" in (*"⧖"*) ok "row1 has elapsed" ;; (*) bad "row1 elapsed: [$c1]" ;; esac
+case "$c1" in (*"⬡"*) ok "row1 uses the default ctx glyph" ;; (*) bad "row1 ctx glyph: [$c1]" ;; esac
+
+# VL_CTX_GLYPH has to reach the panel too, not just the main bar: the glyph it
+# replaces is plain Unicode that some Nerd Fonts lack, so a user who overrides it
+# for the main row would otherwise keep a broken hexagon here (#47).
+GCONF=$(mktemp "${TMPDIR:-/tmp}/coralline-subglyph.XXXXXX") || exit 1
+printf 'VL_CTX_GLYPH="◔"\n' > "$GCONF"
+GOUT=$(CORALLINE_CONFIG="$GCONF" bash "$SCRIPT" --subagent < "$SAMPLE" | sed -n 1p | jq -r .content)
+rm -f "$GCONF"
+case "$GOUT" in (*"◔"*) ok "VL_CTX_GLYPH reaches the subagent ctx row" ;; (*) bad "subagent VL_CTX_GLYPH: [$GOUT]" ;; esac
+case "$GOUT" in (*"⬡"*) bad "subagent row kept the default glyph: [$GOUT]" ;; (*) ok "subagent override displaces the default" ;; esac
 
 # Claude omits agentType from the payload, but writes it to the task sidecar.
 # Recover that native role without a subprocess; explicit payload names still win.


### PR DESCRIPTION
## Summary

`VL_CTX_GLYPH` shipped in #48, but the subagent panel's context row still used a hardcoded `⬡` U+2B21. Both push sites in the panel renderer now read the knob. Refs #47.

## How it slipped through

#44 (subagent panel) and #48 (glyph overrides) were open at the same time and touch different regions of `statusline.sh`, so they merged cleanly with no textual conflict. The result is a knob that half works: a user on a font without the hexagon sets `VL_CTX_GLYPH`, the main bar comes good, and every subagent row keeps the substituted wide glyph. That is the defect #47 reports, in the one place the advertised fix did not reach.

## Changes

Both branches of the panel's ctx segment now use the knob: the gauge branch, and the bare-token branch taken when `contextWindowSize` is absent. The declaration comment in `statusline.sh` records that the knob covers the main bar and the subagent rows, since the panel reads the same config file.

Both READMEs list `VL_CTX_GLYPH` among the row-shaping knobs the panel honors, next to the gauge settings. That list is the contract for which main-bar knobs cross into subagent mode, so omitting it would have made a working override look unsupported.

`test/test-subagent.sh` gains three assertions on the end-to-end `--subagent` path: the default row still carries the shipped glyph, an override reaches the row, and the override displaces the default rather than rendering alongside it.

## Verification

```
bash -n statusline.sh test/test-subagent.sh    syntax ok
test/*.sh (16 suites)                          no failures
```

```
ok    row1 uses the default ctx glyph
ok    VL_CTX_GLYPH reaches the subagent ctx row
ok    subagent override displaces the default
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ko1EREzLjvhhwUrHdMgLM