### PR TITLE
docs: add Ko-fi sponsorship details

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: nanako0129

--- a/README.md
+++ b/README.md
@@ -492,6 +492,20 @@ It runs every second (`refreshInterval: 1`), so the script is built to be cheap 
 call provides branch, dirty state, and ahead/behind together. No `bc`, no per-field subprocess
 spam. Works on stock macOS bash 3.2 and any Linux bash.
 
+## Support coralline
+
+coralline makes no network or API calls and uses zero tokens at runtime. The
+maintenance work is elsewhere: tracking Claude Code payload changes, optional
+live subagent-panel checks, shell regressions, nine-theme screenshot and font
+QA, and installer verification across macOS, Linux, and Windows with Git Bash.
+
+Sponsorship helps cover the Claude access and maintainer time behind that
+compatibility work while coralline remains MIT-licensed and free. If the
+statusline makes your daily sessions clearer, you can support its continued
+development on Ko-fi.
+
+[![Support coralline on Ko-fi](https://img.shields.io/badge/Support_on_Ko--fi-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/nanako0129)
+
 ## Acknowledgements
 
 The visual language of coralline — segmented pills, powerline transitions, the `⇡⇣` git


### PR DESCRIPTION
## Summary

- add `.github/FUNDING.yml` for the `nanako0129` Ko-fi page
- add a project-specific README section explaining what ongoing sponsorship supports

## Why

coralline stays local at runtime and makes no API calls, uses no tokens, and sends no telemetry. Its maintenance cost comes from Claude Code compatibility, optional live subagent-panel checks, shell regression coverage, nine-theme visual and font QA, and installer verification across supported platforms. The README now makes that distinction explicit.

## Scope

This changes documentation and GitHub funding metadata only. Runtime scripts, themes, installer behavior, and configuration remain unchanged.

## Verification

- every `test/test-*.sh` script passed
- `git diff --check origin/main...HEAD` — passed
- confirmed the commit contains only `README.md` and `.github/FUNDING.yml`

## Automation disclosure

This documentation change was authored with Codex assistance. The final diff, full shell test set, and commit scope were independently checked locally.