### PR TITLE
chore: switch funding link to Patreon

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-ko_fi: nanako0129
+custom: ["https://www.patreon.com/cw/Nanako0129/membership"]

--- a/README.md
+++ b/README.md
@@ -502,9 +502,9 @@ QA, and installer verification across macOS, Linux, and Windows with Git Bash.
 Sponsorship helps cover the Claude access and maintainer time behind that
 compatibility work while coralline remains MIT-licensed and free. If the
 statusline makes your daily sessions clearer, you can support its continued
-development on Ko-fi.
+development on Patreon.
 
-[![Support coralline on Ko-fi](https://img.shields.io/badge/Support_on_Ko--fi-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/nanako0129)
+[![Support coralline on Patreon](https://img.shields.io/badge/Support_on_Patreon-FF424D?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/cw/Nanako0129/membership)
 
 ## Acknowledgements
 


### PR DESCRIPTION
## Summary

- replace the Ko-fi funding entry with the Patreon membership page
- keep the GitHub Sponsor sidebar pointed at the current support channel

## Verification

- `git diff --check`
- confirmed the Patreon membership URL returns HTTP 200