### PR TITLE
fix: show the Patreon icon in GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: ["https://www.patreon.com/cw/Nanako0129/membership"]
+patreon: Nanako0129


### PR DESCRIPTION
## Summary

- replace the custom funding URL with GitHub's native `patreon` entry
- preserve the direct membership URL in the README support badge

## Why

GitHub renders custom funding links with a generic icon. The native Patreon entry restores the Patreon platform icon in the Sponsor menu.

## Verification

- `git diff --check`
- confirmed `https://www.patreon.com/Nanako0129` resolves to the public creator page
- confirmed README badges still target the membership page