### PR TITLE
feat(windows): add native PowerShell subagent rows

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,8 +27,11 @@ Check the actual shell and tools before choosing a path:
 For the native path, explain that `install.ps1` writes only `statusline.ps1` and
 the ten shipped themes under `$HOME\.claude\coralline`, then losslessly merges
 the exact-case top-level `statusLine` value in `$HOME\.claude\settings.json`.
-It never creates or edits `$HOME\.claude\coralline.conf`, never writes
-`subagentStatusLine`, and retains timestamped sibling backups when existing
+It never creates or edits `$HOME\.claude\coralline.conf`. Ask whether the user
+wants native themed subagent rows: pass `-SubagentRows on` only after yes,
+`-SubagentRows off` only for an explicit disable request, and otherwise keep the
+default `preserve` so an existing `subagentStatusLine` remains byte-for-byte
+untouched. The installer retains timestamped sibling backups when existing
 managed content changes. An identical rerun is a true no-op. Renderer state and
 custom files remain in place because updates replace only the managed allowlist.
 Installer invocations are serialized. Single-file runtime rollback rejects
@@ -44,7 +47,7 @@ README one-line after approval. If already inside an audited local checkout, use
 the zero-network local mode instead:
 
 ```powershell
-& "$PSHOME\powershell.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File .\install.ps1 -SourceDirectory (Get-Location).Path -InstallRoot "$HOME\.claude\coralline" -SettingsPath "$HOME\.claude\settings.json"
+& "$PSHOME\powershell.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File .\install.ps1 -SourceDirectory (Get-Location).Path -InstallRoot "$HOME\.claude\coralline" -SettingsPath "$HOME\.claude\settings.json" -SubagentRows preserve
 ```
 
 Pass only drive-absolute local-mode paths (`C:\...` or `C:/...`), never
@@ -80,7 +83,7 @@ places the renderer under `~/.claude/coralline`, writes
 | `sample-input.json` | `~/.claude/coralline/sample-input.json` | Local preview and verification sample |
 | generated config | `~/.claude/coralline.conf` | User layout, segments, and theme choices |
 | `statusLine` entry | `~/.claude/settings.json` | Registers coralline in Claude Code |
-| `subagentStatusLine` entry | `~/.claude/settings.json` | Opt-in only — themed agent-panel rows, written when the user says yes (wizard question or `configure.sh --subagent-rows=on`) |
+| `subagentStatusLine` entry | `~/.claude/settings.json` | Opt-in only — themed agent-panel rows, written when the user says yes (wizard question, `configure.sh --subagent-rows=on`, or native `install.ps1 -SubagentRows on`) |
 
 ## Fast Path
 
@@ -225,12 +228,14 @@ Ask concise questions. If the user says "you decide", choose the defaults.
    default; it only converges sessions when they redraw and cannot refresh a fully idle one.
 6. **Subagent panel rows** (optional, needs Claude Code v2.1.205+ for the per-task
    model/context fields): offer to theme only the subagent rows below the prompt — the
-   native main-session row remains visible. If the user says yes, run
+   native main-session row remains visible. On Bash-capable installs, if the user says yes, run
    `bash ~/.claude/coralline/configure.sh --subagent-rows=on` after the bootstrap; it
    registers `subagentStatusLine` in `~/.claude/settings.json` (with the same
    backup-then-merge as the installer) and prints a preview. To disable it, run
    `bash ~/.claude/coralline/configure.sh --subagent-rows=off`; this removes only that
-   settings entry. Explain that model comes from Claude Code's per-task payload, missing
+   settings entry. On PowerShell-only Windows, rerun the native installer with
+   `-SubagentRows on` or `-SubagentRows off`; `preserve` remains the ordinary default.
+   Explain that model comes from Claude Code's per-task payload, missing
    fields degrade their own segments (`tokenCount` still shows without a context window),
    and redraws are panel-event-driven rather than a one-second poll. Claude Code v2.1.211
    omits the native `agentType` role from this payload, so coralline recovers it from the

--- a/README.md
+++ b/README.md
@@ -50,12 +50,11 @@ defaults to `name · description · token count`. coralline can theme the
 
 Claude Code v2.1.211 does not include its internal `agentType` role in the
 `subagentStatusLine` payload, but local Agent tasks have a small metadata
-sidecar next to the session transcript. coralline reads that file with Bash
-builtins, so roles such as `scout` and `executor` return without another
-process. The row keeps both identity and task label: an explicit per-task
-`name` is retained alongside the role when both exist, followed by `label` or
-`description`. If the sidecar is absent or unreadable, the payload fields still
-render normally.
+sidecar next to the session transcript. coralline reads that local file without
+starting another process, so roles such as `scout` and `executor` return. The
+row keeps both identity and task label: an explicit per-task `name` is retained
+alongside the role when both exist, followed by `label` or `description`. If the
+sidecar is absent or unreadable, the payload fields still render normally.
 
 The model comes directly from Claude Code's per-task `model` payload field;
 coralline never infers it from the main-session model or the agent role. Known
@@ -71,6 +70,9 @@ bash ~/.claude/coralline/configure.sh --subagent-rows=off
 
 The setup wizard offers the same toggle. Disabling removes only the
 `subagentStatusLine` entry and preserves every other Claude setting.
+On PowerShell-only Windows, rerun the native one-line installer below with
+`$subagentRows="on"` or `$subagentRows="off"`. Its default
+`$subagentRows="preserve"` leaves any existing `subagentStatusLine` untouched.
 
 Per-task `model` and `contextWindowSize` need Claude Code **v2.1.205+**. Missing
 fields degrade one segment at a time: no model hides only the model segment;
@@ -119,8 +121,10 @@ Everything else —
 `VL_SEGMENTS*`, layout (`VL_LAYOUT`, `VL_MAX_LINES`, `VL_WRAP_MARGIN`), clock,
 cost, lines, float, limit-sync, burn, git, and the runtime segments — is
 main-bar-only and ignored here. To theme panel rows independently of the main
-bar, point the registration at its own config file:
+bar, point the registration at its own config file. For example, the Bash
+registration can use:
 `CORALLINE_CONFIG=~/.claude/coralline-subagent.conf bash ~/.claude/coralline/statusline.sh --subagent`.
+The native renderer honors the same `CORALLINE_CONFIG` environment variable.
 
 ## Install
 
@@ -201,15 +205,15 @@ version too).
 It reads the exact same `~/.claude/coralline.conf` (and theme file) a bash install already
 wrote, so nothing about the config format changes; only the renderer is new. The native main
 bar supports the same segments, `pill`/`lean`/`classic` styles, `fixed`/`auto` layouts, burn
-history, limit sync, and float publication as the bash renderer. The `--subagent` panel-row
-protocol remains bash-only and exits without output in `statusline.ps1`.
+history, limit sync, float publication, and themed `--subagent` panel rows as the bash
+renderer.
 
 The following is the **mutable `main`** one-line installer. It resolves `main` to a commit SHA,
 downloads `install.ps1` from that SHA with a bounded `HttpWebRequest`, parses it before
 execution, and launches the absolute `$PSHOME\powershell.exe` with the same SHA:
 
 ```powershell
-& { $ErrorActionPreference='Stop';$repo='Nanako0129/coralline';$ref='main';if($repo -notmatch '^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})/[A-Za-z0-9._-]{1,100}$' -or $ref -notmatch '^[A-Za-z0-9][A-Za-z0-9._/-]*$' -or $ref.Length -gt 200 -or $ref.Contains('..') -or $ref.Contains('//') -or $ref.Contains('@{') -or $ref.EndsWith('/') -or $ref.EndsWith('.') -or $ref -match '(?i)(^|/)[^/]*\.lock($|/)'){throw 'invalid Repo or Ref'};$safe={param([string]$p,[string]$label,[bool]$cmd=$false);if([string]::IsNullOrWhiteSpace($p) -or $p -match '[\x00-\x1f\x7f-\x9f]' -or $p.StartsWith('\\') -or $p.StartsWith('//') -or $p.IndexOf(':',2) -ge 0){throw "$label is not a safe local path"};$full=[IO.Path]::GetFullPath($p).Replace('/','\');$root=[IO.Path]::GetPathRoot($full);if($root -notmatch '^[A-Za-z]:\\$'){throw "$label is not on a local drive"};$drive=New-Object IO.DriveInfo($root);if($drive.DriveType -eq [IO.DriveType]::Network){throw "$label is on a network drive"};if($cmd -and ($full.Contains('"') -or $full.Contains('%') -or $full.Contains('!'))){throw "$label is not cmd-safe"};$current=$root;foreach($part in $full.Substring($root.Length).Split(@([char]'\'),[StringSplitOptions]::RemoveEmptyEntries)){$current=[IO.Path]::Combine($current,$part);$item=Get-Item -LiteralPath $current -Force -ErrorAction SilentlyContinue;if($null -eq $item){break};if(($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0){throw "$label contains a reparse point"}};if($full.Length -gt $root.Length){$full=$full.TrimEnd('\')};return $full};$fetch={param([uri]$uri,[long]$cap,[string]$label);if($uri.Scheme -cne 'https' -or ($uri.Host -cne 'api.github.com' -and $uri.Host -cne 'raw.githubusercontent.com') -or $uri.UserInfo -or $uri.Query -or $uri.Fragment){throw "unexpected $label URI"};$request=[Net.HttpWebRequest]::Create($uri);$request.Method='GET';$request.AllowAutoRedirect=$false;$request.Timeout=15000;$request.ReadWriteTimeout=15000;$request.UserAgent='coralline-bootstrap';$response=$null;try{$response=[Net.HttpWebResponse]$request.GetResponse();if($response.StatusCode -ne [Net.HttpStatusCode]::OK -or $response.ResponseUri.AbsoluteUri -cne $uri.AbsoluteUri){throw "$label request failed or redirected"};if($response.ContentLength -gt $cap){throw "$label Content-Length exceeds limit"};$input=$response.GetResponseStream();$memory=New-Object IO.MemoryStream;try{$buffer=New-Object byte[] 8192;$total=0L;while(($read=$input.Read($buffer,0,$buffer.Length)) -gt 0){$total+=$read;if($total -gt $cap){throw "$label stream exceeds limit"};$memory.Write($buffer,0,$read)};if($response.ContentLength -ge 0 -and $total -ne $response.ContentLength){throw "$label download was truncated"};return ,$memory.ToArray()}finally{if($null -ne $input){$input.Dispose()};$memory.Dispose()}}finally{if($null -ne $response){$response.Dispose()}}};$old=[Net.ServicePointManager]::SecurityProtocol;$tmp=$null;$made=$false;$code=0;try{[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12;$parts=$repo.Split('/');$commit=$ref;if($commit -cnotmatch '^[0-9a-f]{40}$'){$api=[uri]('https://api.github.com/repos/'+[uri]::EscapeDataString($parts[0])+'/'+[uri]::EscapeDataString($parts[1])+'/commits/'+[uri]::EscapeDataString($ref));$strict=New-Object Text.UTF8Encoding($false,$true);try{$payload=$strict.GetString((& $fetch $api 1MB 'commit resolution'))|ConvertFrom-Json}catch{throw ('commit resolution response is invalid: '+$_.Exception.Message)};if($null -eq $payload -or $payload.PSObject.Properties.Name -notcontains 'sha'){throw 'commit resolution response has no sha'};$commit=[string]$payload.sha;if($commit -cnotmatch '^[0-9a-f]{40}$'){throw 'commit resolution returned an invalid sha'}};$uri=[uri]('https://raw.githubusercontent.com/'+[uri]::EscapeDataString($parts[0])+'/'+[uri]::EscapeDataString($parts[1])+'/'+$commit+'/install.ps1');$bytes=& $fetch $uri 1MB 'installer';$tempRoot=& $safe ([IO.Path]::GetTempPath()) 'TEMP';$tmp=& $safe ([IO.Path]::Combine($tempRoot,('coralline-install-'+[guid]::NewGuid().ToString('N')+'.ps1'))) 'installer temp';$output=[IO.File]::Open($tmp,[IO.FileMode]::CreateNew,[IO.FileAccess]::Write,[IO.FileShare]::None);$made=$true;try{$output.Write($bytes,0,$bytes.Length);$output.Flush($true)}finally{$output.Dispose()};$checked=& $safe $tmp 'downloaded installer';if($checked -cne $tmp){throw 'installer temp identity changed'};$tokens=$null;$errors=$null;[void][Management.Automation.Language.Parser]::ParseFile($tmp,[ref]$tokens,[ref]$errors);if($errors.Count -ne 0){throw ('downloaded installer parse failed: '+$errors[0].Message)};$exe=& $safe ([IO.Path]::Combine($PSHOME,'powershell.exe')) 'PowerShell executable' $true;if(-not [IO.File]::Exists($exe)){throw 'trusted powershell.exe is missing'};$psi=New-Object Diagnostics.ProcessStartInfo;$psi.FileName=$exe;$psi.UseShellExecute=$false;$psi.Arguments='-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "'+$tmp+'" -Repo "'+$repo+'" -Ref "'+$commit+'"';$process=New-Object Diagnostics.Process;$process.StartInfo=$psi;try{if(-not $process.Start()){throw 'installer child did not start'};$process.WaitForExit();$code=$process.ExitCode}finally{$process.Dispose()}}finally{[Net.ServicePointManager]::SecurityProtocol=$old;if($made -and $null -ne $tmp -and [IO.File]::Exists($tmp)){$checked=& $safe $tmp 'installer cleanup';if($checked -cne $tmp){throw 'refusing unexpected cleanup path'};$item=Get-Item -LiteralPath $tmp -Force;if(($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0){throw 'refusing reparse-point cleanup'};[IO.File]::Delete($tmp)}};if($code -ne 0){exit $code} }
+& { $ErrorActionPreference='Stop';$repo='Nanako0129/coralline';$ref='main';$subagentRows="preserve";if($subagentRows -cnotin @("preserve","on","off")){throw "invalid SubagentRows"};if($repo -notmatch '^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})/[A-Za-z0-9._-]{1,100}$' -or $ref -notmatch '^[A-Za-z0-9][A-Za-z0-9._/-]*$' -or $ref.Length -gt 200 -or $ref.Contains('..') -or $ref.Contains('//') -or $ref.Contains('@{') -or $ref.EndsWith('/') -or $ref.EndsWith('.') -or $ref -match '(?i)(^|/)[^/]*\.lock($|/)'){throw 'invalid Repo or Ref'};$safe={param([string]$p,[string]$label,[bool]$cmd=$false);if([string]::IsNullOrWhiteSpace($p) -or $p -match '[\x00-\x1f\x7f-\x9f]' -or $p.StartsWith('\\') -or $p.StartsWith('//') -or $p.IndexOf(':',2) -ge 0){throw "$label is not a safe local path"};$full=[IO.Path]::GetFullPath($p).Replace('/','\');$root=[IO.Path]::GetPathRoot($full);if($root -notmatch '^[A-Za-z]:\\$'){throw "$label is not on a local drive"};$drive=New-Object IO.DriveInfo($root);if($drive.DriveType -eq [IO.DriveType]::Network){throw "$label is on a network drive"};if($cmd -and ($full.Contains('"') -or $full.Contains('%') -or $full.Contains('!'))){throw "$label is not cmd-safe"};$current=$root;foreach($part in $full.Substring($root.Length).Split(@([char]'\'),[StringSplitOptions]::RemoveEmptyEntries)){$current=[IO.Path]::Combine($current,$part);$item=Get-Item -LiteralPath $current -Force -ErrorAction SilentlyContinue;if($null -eq $item){break};if(($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0){throw "$label contains a reparse point"}};if($full.Length -gt $root.Length){$full=$full.TrimEnd('\')};return $full};$fetch={param([uri]$uri,[long]$cap,[string]$label);if($uri.Scheme -cne 'https' -or ($uri.Host -cne 'api.github.com' -and $uri.Host -cne 'raw.githubusercontent.com') -or $uri.UserInfo -or $uri.Query -or $uri.Fragment){throw "unexpected $label URI"};$request=[Net.HttpWebRequest]::Create($uri);$request.Method='GET';$request.AllowAutoRedirect=$false;$request.Timeout=15000;$request.ReadWriteTimeout=15000;$request.UserAgent='coralline-bootstrap';$response=$null;try{$response=[Net.HttpWebResponse]$request.GetResponse();if($response.StatusCode -ne [Net.HttpStatusCode]::OK -or $response.ResponseUri.AbsoluteUri -cne $uri.AbsoluteUri){throw "$label request failed or redirected"};if($response.ContentLength -gt $cap){throw "$label Content-Length exceeds limit"};$input=$response.GetResponseStream();$memory=New-Object IO.MemoryStream;try{$buffer=New-Object byte[] 8192;$total=0L;while(($read=$input.Read($buffer,0,$buffer.Length)) -gt 0){$total+=$read;if($total -gt $cap){throw "$label stream exceeds limit"};$memory.Write($buffer,0,$read)};if($response.ContentLength -ge 0 -and $total -ne $response.ContentLength){throw "$label download was truncated"};return ,$memory.ToArray()}finally{if($null -ne $input){$input.Dispose()};$memory.Dispose()}}finally{if($null -ne $response){$response.Dispose()}}};$old=[Net.ServicePointManager]::SecurityProtocol;$tmp=$null;$made=$false;$code=0;try{[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12;$parts=$repo.Split('/');$commit=$ref;if($commit -cnotmatch '^[0-9a-f]{40}$'){$api=[uri]('https://api.github.com/repos/'+[uri]::EscapeDataString($parts[0])+'/'+[uri]::EscapeDataString($parts[1])+'/commits/'+[uri]::EscapeDataString($ref));$strict=New-Object Text.UTF8Encoding($false,$true);try{$payload=$strict.GetString((& $fetch $api 1MB 'commit resolution'))|ConvertFrom-Json}catch{throw ('commit resolution response is invalid: '+$_.Exception.Message)};if($null -eq $payload -or $payload.PSObject.Properties.Name -notcontains 'sha'){throw 'commit resolution response has no sha'};$commit=[string]$payload.sha;if($commit -cnotmatch '^[0-9a-f]{40}$'){throw 'commit resolution returned an invalid sha'}};$uri=[uri]('https://raw.githubusercontent.com/'+[uri]::EscapeDataString($parts[0])+'/'+[uri]::EscapeDataString($parts[1])+'/'+$commit+'/install.ps1');$bytes=& $fetch $uri 1MB 'installer';$tempRoot=& $safe ([IO.Path]::GetTempPath()) 'TEMP';$tmp=& $safe ([IO.Path]::Combine($tempRoot,('coralline-install-'+[guid]::NewGuid().ToString('N')+'.ps1'))) 'installer temp';$output=[IO.File]::Open($tmp,[IO.FileMode]::CreateNew,[IO.FileAccess]::Write,[IO.FileShare]::None);$made=$true;try{$output.Write($bytes,0,$bytes.Length);$output.Flush($true)}finally{$output.Dispose()};$checked=& $safe $tmp 'downloaded installer';if($checked -cne $tmp){throw 'installer temp identity changed'};$tokens=$null;$errors=$null;[void][Management.Automation.Language.Parser]::ParseFile($tmp,[ref]$tokens,[ref]$errors);if($errors.Count -ne 0){throw ('downloaded installer parse failed: '+$errors[0].Message)};$exe=& $safe ([IO.Path]::Combine($PSHOME,'powershell.exe')) 'PowerShell executable' $true;if(-not [IO.File]::Exists($exe)){throw 'trusted powershell.exe is missing'};$psi=New-Object Diagnostics.ProcessStartInfo;$psi.FileName=$exe;$psi.UseShellExecute=$false;$psi.Arguments='-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "'+$tmp+'" -Repo "'+$repo+'" -Ref "'+$commit+'"';$psi.Arguments+=" -SubagentRows "+[char]34+$subagentRows+[char]34;$process=New-Object Diagnostics.Process;$process.StartInfo=$psi;try{if(-not $process.Start()){throw 'installer child did not start'};$process.WaitForExit();$code=$process.ExitCode}finally{$process.Dispose()}}finally{[Net.ServicePointManager]::SecurityProtocol=$old;if($made -and $null -ne $tmp -and [IO.File]::Exists($tmp)){$checked=& $safe $tmp 'installer cleanup';if($checked -cne $tmp){throw 'refusing unexpected cleanup path'};$item=Get-Item -LiteralPath $tmp -Force;if(($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0){throw 'refusing reparse-point cleanup'};[IO.File]::Delete($tmp)}};if($code -ne 0){exit $code} }
 ```
 
 For an audited release or commit, copy the same line and replace only
@@ -218,8 +222,11 @@ can technically be moved; only an audited 40-character commit SHA makes the boot
 immutable. The bootstrap resolves a mutable name or tag before downloading executable code,
 then the installer downloads every managed file from that same commit.
 
-`install.ps1` installs `statusline.ps1` plus all ten themes, then losslessly merges only the
-exact-case top-level `statusLine` member in `$HOME\.claude\settings.json`. It preserves
+`install.ps1` installs `statusline.ps1` plus all ten themes, then losslessly merges the
+exact-case top-level `statusLine` member in `$HOME\.claude\settings.json`. The
+`-SubagentRows preserve|on|off` option leaves `subagentStatusLine` untouched by default,
+registers the native `statusline.ps1 --subagent` command when set to `on`, or removes only
+that exact-case top-level member when set to `off`. It preserves
 `$HOME\.claude\coralline.conf` byte-for-byte and never creates it. Existing runtime and settings
 are backed up with timestamped sibling names when their managed content changes. Installer
 invocations are serialized. Single-file runtime rollback refuses to overwrite concurrent edits and
@@ -238,7 +245,7 @@ If the one-line bootstrap cannot run, download a GitHub source archive in the br
 it, extract it locally, and run the checked-out installer without network access:
 
 ```powershell
-& "$PSHOME\powershell.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File C:\path\to\coralline\install.ps1 -SourceDirectory C:\path\to\coralline -InstallRoot "$HOME\.claude\coralline" -SettingsPath "$HOME\.claude\settings.json"
+& "$PSHOME\powershell.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File C:\path\to\coralline\install.ps1 -SourceDirectory C:\path\to\coralline -InstallRoot "$HOME\.claude\coralline" -SettingsPath "$HOME\.claude\settings.json" -SubagentRows preserve
 ```
 
 All three local-mode paths must be drive-absolute (`C:\...` or `C:/...`); drive-relative forms
@@ -304,8 +311,9 @@ that skepticism is inspection, not trust:
 - **What gets written, exactly:** Bash setup writes its runtime, your approved config, and
   Claude settings as described above. The native installer writes only `statusline.ps1` and
   ten themes under `~/.claude/coralline`, plus the exact top-level `statusLine` value in
-  `settings.json`. It never creates or edits `coralline.conf` and never writes
-  `subagentStatusLine`. Changed existing runtime/settings get timestamped sibling backups.
+  `settings.json`. It never creates or edits `coralline.conf`; `subagentStatusLine` is
+  preserved unless the explicit native opt-in or opt-out is selected. Changed existing
+  runtime/settings get timestamped sibling backups.
 - **What runs afterwards:** the registered Bash or PowerShell renderer runs on every prompt
   and makes zero network requests. The native command quotes the absolute trusted
   `$PSHOME\powershell.exe` and the absolute renderer path; it never searches the workspace
@@ -584,21 +592,21 @@ The wizard discovers themes automatically from `themes/*.conf` and nested collec
 | macOS | ✅ supported (works on the stock bash 3.2) |
 | Linux | ✅ supported |
 | Windows + Git Bash | ✅ supported — Claude Code runs the status line through Git Bash when it's installed |
-| Windows without Git Bash | ✅ supported for the main bar through native Windows PowerShell 5.1 |
+| Windows without Git Bash | ✅ supported through native Windows PowerShell 5.1 |
 
 > **Windows note:** the native PowerShell renderer needs neither Git Bash nor `jq`. `git.exe`
 > is optional and only enables the `git`, `stash`, and `project` segments. The interactive
-> wizard and themed `--subagent` rows remain bash-only.
+> wizard remains bash-only; main and themed `--subagent` rows are native.
 
 ## Why it's fast
 
-The statusline is just a local shell script: it makes no network or API calls and uses zero
+The statusline is just a local renderer: it makes no network or API calls and uses zero
 tokens. Claude Code pipes the session JSON to it on stdin and renders whatever it prints.
 
-It runs every second (`refreshInterval: 1`), so the script is built to be cheap on CPU: one
-`jq` invocation extracts every field at once, and one `git status --porcelain=v2 --branch`
-call provides branch, dirty state, and ahead/behind together. No `bc`, no per-field subprocess
-spam. Works on stock macOS bash 3.2 and any Linux bash.
+The main bar runs every second (`refreshInterval: 1`), while subagent rows redraw on panel
+events. The Bash renderer extracts every field with one `jq` call; the native PowerShell
+renderer parses in-process. Both use at most one `git status --porcelain=v2 --branch` call per
+render, and neither launches per-field subprocesses.
 
 ## Support coralline
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -50,11 +50,10 @@ Claude Code 在 subagent 執行時會於 prompt 下方顯示 agent 面板；每�
 
 Claude Code v2.1.211 沒有把內部的 `agentType` role 放進
 `subagentStatusLine` payload，但本機 Agent task 會在 session transcript
-旁留下小型 metadata sidecar。coralline 以 Bash builtin 直接讀取，不會增加
-process，因此可恢復 `scout`、`executor` 等 role。列上會同時保留 identity
-與 task label：若另有明確的 per-task `name`，會和 role 一起顯示，後面再接
-`label` 或 `description`。sidecar 不存在或無法讀取時，payload 原有欄位仍會
-正常顯示。
+旁留下小型 metadata sidecar。coralline 會直接讀取這個本機檔案，不會再啟動
+process，因此可恢復 `scout`、`executor` 等 role。列上會同時保留 identity 與
+task label：若另有明確的 per-task `name`，會和 role 一起顯示，後面再接 `label`
+或 `description`。sidecar 不存在或無法讀取時，payload 原有欄位仍會正常顯示。
 
 model 直接取自 Claude Code 傳入的 per-task `model` 欄位；coralline 不會從
 主 session model 或 agent role 推測。已知的 Claude ID 會縮短顯示
@@ -70,6 +69,9 @@ bash ~/.claude/coralline/configure.sh --subagent-rows=off
 
 設定 wizard 提供相同的開關。停用時只會移除 `subagentStatusLine`，其他 Claude
 設定都會保留。
+僅有 PowerShell 的 Windows 請重跑下方原生一行安裝指令，並把
+`$subagentRows` 設為 `"on"` 或 `"off"`。預設的 `"preserve"` 不會改動現有
+`subagentStatusLine`。
 
 每個 task 的 `model` 與 `contextWindowSize` 需要 Claude Code **v2.1.205+**。
 缺少欄位時會逐一降級：沒有 model 只會隱藏 model segment；沒有
@@ -111,8 +113,10 @@ subagent renderer 與主列共用同一份 config，但只讀取與「單列外�
 把 `VL_BG_SUB_NAME=""` 設空即可換回亮色 pill。其餘參數——`VL_SEGMENTS*`、版面（`VL_LAYOUT`、
 `VL_MAX_LINES`、`VL_WRAP_MARGIN`）、clock、cost、lines、float、limit-sync、
 burn、git 與 runtime segments——都只作用於主列，在 subagent 模式一律忽略。
-想讓面板列使用與主列不同的主題，把註冊的 command 指向獨立 config 即可：
+想讓面板列使用與主列不同的主題，把註冊的 command 指向獨立 config 即可。例如
+Bash 註冊可以使用：
 `CORALLINE_CONFIG=~/.claude/coralline-subagent.conf bash ~/.claude/coralline/statusline.sh --subagent`。
+原生 renderer 也會讀取相同的 `CORALLINE_CONFIG` 環境變數。
 
 ## 安裝
 
@@ -188,15 +192,15 @@ cp ~/.claude/coralline-src/themes/claude-coral.conf ~/.claude/coralline/themes/
 
 它會讀取 bash 版本相同的 `~/.claude/coralline.conf` 與 theme 檔。原生主列與 bash
 renderer 支援相同的 segments、`pill`／`lean`／`classic` styles、
-`fixed`／`auto` layouts、burn history、limit sync 與 float publication。
-只有 `--subagent` 面板列協定仍限定使用 bash；`statusline.ps1 --subagent` 不會輸出內容。
+`fixed`／`auto` layouts、burn history、limit sync、float publication 與套用主題的
+`--subagent` 面板列。
 
 以下是會跟隨開發進度的 **mutable `main`** 一行安裝指令。它先把 `main` 解析成
 commit SHA，再以有上限的 `HttpWebRequest` 從該 SHA 下載 `install.ps1`，先解析語法，
 最後透過絕對路徑 `$PSHOME\powershell.exe` 啟動，並傳入相同 SHA：
 
 ```powershell
-& { $ErrorActionPreference='Stop';$repo='Nanako0129/coralline';$ref='main';if($repo -notmatch '^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})/[A-Za-z0-9._-]{1,100}$' -or $ref -notmatch '^[A-Za-z0-9][A-Za-z0-9._/-]*$' -or $ref.Length -gt 200 -or $ref.Contains('..') -or $ref.Contains('//') -or $ref.Contains('@{') -or $ref.EndsWith('/') -or $ref.EndsWith('.') -or $ref -match '(?i)(^|/)[^/]*\.lock($|/)'){throw 'invalid Repo or Ref'};$safe={param([string]$p,[string]$label,[bool]$cmd=$false);if([string]::IsNullOrWhiteSpace($p) -or $p -match '[\x00-\x1f\x7f-\x9f]' -or $p.StartsWith('\\') -or $p.StartsWith('//') -or $p.IndexOf(':',2) -ge 0){throw "$label is not a safe local path"};$full=[IO.Path]::GetFullPath($p).Replace('/','\');$root=[IO.Path]::GetPathRoot($full);if($root -notmatch '^[A-Za-z]:\\$'){throw "$label is not on a local drive"};$drive=New-Object IO.DriveInfo($root);if($drive.DriveType -eq [IO.DriveType]::Network){throw "$label is on a network drive"};if($cmd -and ($full.Contains('"') -or $full.Contains('%') -or $full.Contains('!'))){throw "$label is not cmd-safe"};$current=$root;foreach($part in $full.Substring($root.Length).Split(@([char]'\'),[StringSplitOptions]::RemoveEmptyEntries)){$current=[IO.Path]::Combine($current,$part);$item=Get-Item -LiteralPath $current -Force -ErrorAction SilentlyContinue;if($null -eq $item){break};if(($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0){throw "$label contains a reparse point"}};if($full.Length -gt $root.Length){$full=$full.TrimEnd('\')};return $full};$fetch={param([uri]$uri,[long]$cap,[string]$label);if($uri.Scheme -cne 'https' -or ($uri.Host -cne 'api.github.com' -and $uri.Host -cne 'raw.githubusercontent.com') -or $uri.UserInfo -or $uri.Query -or $uri.Fragment){throw "unexpected $label URI"};$request=[Net.HttpWebRequest]::Create($uri);$request.Method='GET';$request.AllowAutoRedirect=$false;$request.Timeout=15000;$request.ReadWriteTimeout=15000;$request.UserAgent='coralline-bootstrap';$response=$null;try{$response=[Net.HttpWebResponse]$request.GetResponse();if($response.StatusCode -ne [Net.HttpStatusCode]::OK -or $response.ResponseUri.AbsoluteUri -cne $uri.AbsoluteUri){throw "$label request failed or redirected"};if($response.ContentLength -gt $cap){throw "$label Content-Length exceeds limit"};$input=$response.GetResponseStream();$memory=New-Object IO.MemoryStream;try{$buffer=New-Object byte[] 8192;$total=0L;while(($read=$input.Read($buffer,0,$buffer.Length)) -gt 0){$total+=$read;if($total -gt $cap){throw "$label stream exceeds limit"};$memory.Write($buffer,0,$read)};if($response.ContentLength -ge 0 -and $total -ne $response.ContentLength){throw "$label download was truncated"};return ,$memory.ToArray()}finally{if($null -ne $input){$input.Dispose()};$memory.Dispose()}}finally{if($null -ne $response){$response.Dispose()}}};$old=[Net.ServicePointManager]::SecurityProtocol;$tmp=$null;$made=$false;$code=0;try{[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12;$parts=$repo.Split('/');$commit=$ref;if($commit -cnotmatch '^[0-9a-f]{40}$'){$api=[uri]('https://api.github.com/repos/'+[uri]::EscapeDataString($parts[0])+'/'+[uri]::EscapeDataString($parts[1])+'/commits/'+[uri]::EscapeDataString($ref));$strict=New-Object Text.UTF8Encoding($false,$true);try{$payload=$strict.GetString((& $fetch $api 1MB 'commit resolution'))|ConvertFrom-Json}catch{throw ('commit resolution response is invalid: '+$_.Exception.Message)};if($null -eq $payload -or $payload.PSObject.Properties.Name -notcontains 'sha'){throw 'commit resolution response has no sha'};$commit=[string]$payload.sha;if($commit -cnotmatch '^[0-9a-f]{40}$'){throw 'commit resolution returned an invalid sha'}};$uri=[uri]('https://raw.githubusercontent.com/'+[uri]::EscapeDataString($parts[0])+'/'+[uri]::EscapeDataString($parts[1])+'/'+$commit+'/install.ps1');$bytes=& $fetch $uri 1MB 'installer';$tempRoot=& $safe ([IO.Path]::GetTempPath()) 'TEMP';$tmp=& $safe ([IO.Path]::Combine($tempRoot,('coralline-install-'+[guid]::NewGuid().ToString('N')+'.ps1'))) 'installer temp';$output=[IO.File]::Open($tmp,[IO.FileMode]::CreateNew,[IO.FileAccess]::Write,[IO.FileShare]::None);$made=$true;try{$output.Write($bytes,0,$bytes.Length);$output.Flush($true)}finally{$output.Dispose()};$checked=& $safe $tmp 'downloaded installer';if($checked -cne $tmp){throw 'installer temp identity changed'};$tokens=$null;$errors=$null;[void][Management.Automation.Language.Parser]::ParseFile($tmp,[ref]$tokens,[ref]$errors);if($errors.Count -ne 0){throw ('downloaded installer parse failed: '+$errors[0].Message)};$exe=& $safe ([IO.Path]::Combine($PSHOME,'powershell.exe')) 'PowerShell executable' $true;if(-not [IO.File]::Exists($exe)){throw 'trusted powershell.exe is missing'};$psi=New-Object Diagnostics.ProcessStartInfo;$psi.FileName=$exe;$psi.UseShellExecute=$false;$psi.Arguments='-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "'+$tmp+'" -Repo "'+$repo+'" -Ref "'+$commit+'"';$process=New-Object Diagnostics.Process;$process.StartInfo=$psi;try{if(-not $process.Start()){throw 'installer child did not start'};$process.WaitForExit();$code=$process.ExitCode}finally{$process.Dispose()}}finally{[Net.ServicePointManager]::SecurityProtocol=$old;if($made -and $null -ne $tmp -and [IO.File]::Exists($tmp)){$checked=& $safe $tmp 'installer cleanup';if($checked -cne $tmp){throw 'refusing unexpected cleanup path'};$item=Get-Item -LiteralPath $tmp -Force;if(($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0){throw 'refusing reparse-point cleanup'};[IO.File]::Delete($tmp)}};if($code -ne 0){exit $code} }
+& { $ErrorActionPreference='Stop';$repo='Nanako0129/coralline';$ref='main';$subagentRows="preserve";if($subagentRows -cnotin @("preserve","on","off")){throw "invalid SubagentRows"};if($repo -notmatch '^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})/[A-Za-z0-9._-]{1,100}$' -or $ref -notmatch '^[A-Za-z0-9][A-Za-z0-9._/-]*$' -or $ref.Length -gt 200 -or $ref.Contains('..') -or $ref.Contains('//') -or $ref.Contains('@{') -or $ref.EndsWith('/') -or $ref.EndsWith('.') -or $ref -match '(?i)(^|/)[^/]*\.lock($|/)'){throw 'invalid Repo or Ref'};$safe={param([string]$p,[string]$label,[bool]$cmd=$false);if([string]::IsNullOrWhiteSpace($p) -or $p -match '[\x00-\x1f\x7f-\x9f]' -or $p.StartsWith('\\') -or $p.StartsWith('//') -or $p.IndexOf(':',2) -ge 0){throw "$label is not a safe local path"};$full=[IO.Path]::GetFullPath($p).Replace('/','\');$root=[IO.Path]::GetPathRoot($full);if($root -notmatch '^[A-Za-z]:\\$'){throw "$label is not on a local drive"};$drive=New-Object IO.DriveInfo($root);if($drive.DriveType -eq [IO.DriveType]::Network){throw "$label is on a network drive"};if($cmd -and ($full.Contains('"') -or $full.Contains('%') -or $full.Contains('!'))){throw "$label is not cmd-safe"};$current=$root;foreach($part in $full.Substring($root.Length).Split(@([char]'\'),[StringSplitOptions]::RemoveEmptyEntries)){$current=[IO.Path]::Combine($current,$part);$item=Get-Item -LiteralPath $current -Force -ErrorAction SilentlyContinue;if($null -eq $item){break};if(($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0){throw "$label contains a reparse point"}};if($full.Length -gt $root.Length){$full=$full.TrimEnd('\')};return $full};$fetch={param([uri]$uri,[long]$cap,[string]$label);if($uri.Scheme -cne 'https' -or ($uri.Host -cne 'api.github.com' -and $uri.Host -cne 'raw.githubusercontent.com') -or $uri.UserInfo -or $uri.Query -or $uri.Fragment){throw "unexpected $label URI"};$request=[Net.HttpWebRequest]::Create($uri);$request.Method='GET';$request.AllowAutoRedirect=$false;$request.Timeout=15000;$request.ReadWriteTimeout=15000;$request.UserAgent='coralline-bootstrap';$response=$null;try{$response=[Net.HttpWebResponse]$request.GetResponse();if($response.StatusCode -ne [Net.HttpStatusCode]::OK -or $response.ResponseUri.AbsoluteUri -cne $uri.AbsoluteUri){throw "$label request failed or redirected"};if($response.ContentLength -gt $cap){throw "$label Content-Length exceeds limit"};$input=$response.GetResponseStream();$memory=New-Object IO.MemoryStream;try{$buffer=New-Object byte[] 8192;$total=0L;while(($read=$input.Read($buffer,0,$buffer.Length)) -gt 0){$total+=$read;if($total -gt $cap){throw "$label stream exceeds limit"};$memory.Write($buffer,0,$read)};if($response.ContentLength -ge 0 -and $total -ne $response.ContentLength){throw "$label download was truncated"};return ,$memory.ToArray()}finally{if($null -ne $input){$input.Dispose()};$memory.Dispose()}}finally{if($null -ne $response){$response.Dispose()}}};$old=[Net.ServicePointManager]::SecurityProtocol;$tmp=$null;$made=$false;$code=0;try{[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12;$parts=$repo.Split('/');$commit=$ref;if($commit -cnotmatch '^[0-9a-f]{40}$'){$api=[uri]('https://api.github.com/repos/'+[uri]::EscapeDataString($parts[0])+'/'+[uri]::EscapeDataString($parts[1])+'/commits/'+[uri]::EscapeDataString($ref));$strict=New-Object Text.UTF8Encoding($false,$true);try{$payload=$strict.GetString((& $fetch $api 1MB 'commit resolution'))|ConvertFrom-Json}catch{throw ('commit resolution response is invalid: '+$_.Exception.Message)};if($null -eq $payload -or $payload.PSObject.Properties.Name -notcontains 'sha'){throw 'commit resolution response has no sha'};$commit=[string]$payload.sha;if($commit -cnotmatch '^[0-9a-f]{40}$'){throw 'commit resolution returned an invalid sha'}};$uri=[uri]('https://raw.githubusercontent.com/'+[uri]::EscapeDataString($parts[0])+'/'+[uri]::EscapeDataString($parts[1])+'/'+$commit+'/install.ps1');$bytes=& $fetch $uri 1MB 'installer';$tempRoot=& $safe ([IO.Path]::GetTempPath()) 'TEMP';$tmp=& $safe ([IO.Path]::Combine($tempRoot,('coralline-install-'+[guid]::NewGuid().ToString('N')+'.ps1'))) 'installer temp';$output=[IO.File]::Open($tmp,[IO.FileMode]::CreateNew,[IO.FileAccess]::Write,[IO.FileShare]::None);$made=$true;try{$output.Write($bytes,0,$bytes.Length);$output.Flush($true)}finally{$output.Dispose()};$checked=& $safe $tmp 'downloaded installer';if($checked -cne $tmp){throw 'installer temp identity changed'};$tokens=$null;$errors=$null;[void][Management.Automation.Language.Parser]::ParseFile($tmp,[ref]$tokens,[ref]$errors);if($errors.Count -ne 0){throw ('downloaded installer parse failed: '+$errors[0].Message)};$exe=& $safe ([IO.Path]::Combine($PSHOME,'powershell.exe')) 'PowerShell executable' $true;if(-not [IO.File]::Exists($exe)){throw 'trusted powershell.exe is missing'};$psi=New-Object Diagnostics.ProcessStartInfo;$psi.FileName=$exe;$psi.UseShellExecute=$false;$psi.Arguments='-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "'+$tmp+'" -Repo "'+$repo+'" -Ref "'+$commit+'"';$psi.Arguments+=" -SubagentRows "+[char]34+$subagentRows+[char]34;$process=New-Object Diagnostics.Process;$process.StartInfo=$psi;try{if(-not $process.Start()){throw 'installer child did not start'};$process.WaitForExit();$code=$process.ExitCode}finally{$process.Dispose()}}finally{[Net.ServicePointManager]::SecurityProtocol=$old;if($made -and $null -ne $tmp -and [IO.File]::Exists($tmp)){$checked=& $safe $tmp 'installer cleanup';if($checked -cne $tmp){throw 'refusing unexpected cleanup path'};$item=Get-Item -LiteralPath $tmp -Force;if(($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0){throw 'refusing reparse-point cleanup'};[IO.File]::Delete($tmp)}};if($code -ne 0){exit $code} }
 ```
 
 若要安裝已稽核的 release 或 commit，複製同一行，只把 `$ref='main'` 改成
@@ -205,8 +209,10 @@ commit SHA，再以有上限的 `HttpWebRequest` 從該 SHA 下載 `install.ps1`
 bootstrap 都會在下載可執行程式碼前先解析可變名稱或 tag，再由 installer 從同一個
 commit 下載全部受管理檔案。
 
-`install.ps1` 會安裝 `statusline.ps1` 與全部十個 themes，並只對
+`install.ps1` 會安裝 `statusline.ps1` 與全部十個 themes，並對
 `$HOME\.claude\settings.json` 最上層、大小寫完全相符的 `statusLine` 做無損合併。
+`-SubagentRows preserve|on|off` 預設保留 `subagentStatusLine`；設為 `on` 才註冊原生
+`statusline.ps1 --subagent` command，設為 `off` 只移除大小寫完全相符的最上層欄位。
 `$HOME\.claude\coralline.conf` 會逐 byte 保留，而且 installer 永遠不會建立它。
 受管理的 runtime 或 settings 確實變更時，舊版本會保留為帶時間戳的同層備份。
 Installer 會序列化執行。單檔 runtime rollback 不會覆寫同時發生的編輯，並會保留
@@ -224,7 +230,7 @@ settings、不建立備份，也不改 timestamp。PowerShell-only 安裝不含 
 本機，再以零網路的 local mode 執行：
 
 ```powershell
-& "$PSHOME\powershell.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File C:\path\to\coralline\install.ps1 -SourceDirectory C:\path\to\coralline -InstallRoot "$HOME\.claude\coralline" -SettingsPath "$HOME\.claude\settings.json"
+& "$PSHOME\powershell.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File C:\path\to\coralline\install.ps1 -SourceDirectory C:\path\to\coralline -InstallRoot "$HOME\.claude\coralline" -SettingsPath "$HOME\.claude\settings.json" -SubagentRows preserve
 ```
 
 Local mode 的三個路徑都必須是 drive-absolute（`C:\...` 或 `C:/...`）；`C:folder`
@@ -284,8 +290,9 @@ curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.s
 - **確切會寫入什麼：** Bash 流程會依前述規則寫入 runtime、經你同意的 config 與
   Claude settings。原生 installer 只會在 `~/.claude/coralline` 寫入
   `statusline.ps1` 與十個 themes，並更新 `settings.json` 最上層完全相符的
-  `statusLine` 值。它不建立或修改 `coralline.conf`，也不寫
-  `subagentStatusLine`。既有 runtime/settings 有變更時會留下同層時間戳備份。
+  `statusLine` 值。它不建立或修改 `coralline.conf`；除非明確選擇原生 opt-in 或
+  opt-out，否則會保留 `subagentStatusLine`。既有 runtime/settings 有變更時會留下
+  同層時間戳備份。
 - **裝完之後跑的是什麼：** 每次 prompt 會執行註冊的 Bash 或 PowerShell renderer，
   runtime 都不會發出網路請求。原生命令會引用絕對路徑的可信
   `$PSHOME\powershell.exe` 與 renderer，不會從 workspace 搜尋 `powershell.exe`。
@@ -524,21 +531,21 @@ wizard 會自動掃描 `themes/*.conf` 與 `themes/best-themes/*.conf` 這類巢
 | macOS | ✅ 支援（內建 bash 3.2 即可） |
 | Linux | ✅ 支援 |
 | Windows + Git Bash | ✅ 支援——有裝 Git Bash 時，Claude Code 會用它執行 statusline |
-| Windows 無 Git Bash | ✅ 原生 Windows PowerShell 5.1 支援主列 |
+| Windows 無 Git Bash | ✅ 原生 Windows PowerShell 5.1 支援 |
 
 > **Windows 提醒：** 原生 PowerShell renderer 不需要 Git Bash 或 `jq`。`git.exe`
-> 是選用項目，只用來啟用 `git`、`stash`、`project` segments。互動式 wizard 與套用
-> theme 的 `--subagent` 列仍限定使用 bash。
+> 是選用項目，只用來啟用 `git`、`stash`、`project` segments。互動式 wizard 仍限定
+> 使用 bash；主列與套用 theme 的 `--subagent` 列都有原生版本。
 
 ## 為什麼很快
 
-statusline 就是一支本地 shell 腳本：完全不打網路、不呼叫任何 API、不消耗任何 token。
+statusline 就是一個本地 renderer：完全不打網路、不呼叫任何 API、不消耗任何 token。
 Claude Code 只是把 session 的 JSON 從 stdin 餵給它，再顯示它印出的內容。
 
-它每秒執行一次（`refreshInterval: 1`），所以腳本在 CPU 上必須夠便宜：
-單次 `jq` 呼叫一口氣取出所有欄位，單次 `git status --porcelain=v2 --branch`
-同時拿到分支、檔案狀態與領先/落後數。不依賴 `bc`，也沒有逐欄位的子程序開銷。
-macOS 內建的 bash 3.2 和任何 Linux bash 都能跑。
+主列每秒執行一次（`refreshInterval: 1`），subagent 列則由 panel event 觸發重繪。
+Bash renderer 以單次 `jq` 呼叫取出所有欄位，原生 PowerShell renderer 在程序內解析；
+兩者每次 render 最多呼叫一次 `git status --porcelain=v2 --branch`，都不會為每個欄位
+個別啟動子程序。
 
 ## 致敬與致謝
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,8 +7,9 @@
 >
 > This playbook updates Bash-based installs. On PowerShell-only Windows, do not run
 > `install.sh`; re-run the native archive procedure under
-> [Windows without Git Bash](README.md#windows-without-git-bash), which preserves
-> `coralline.conf` and `settings.json`.
+> [Windows without Git Bash](README.md#windows-without-git-bash). It preserves
+> `coralline.conf` and keeps `subagentStatusLine` unchanged by default; use
+> `-SubagentRows on` or `-SubagentRows off` only for an explicit user choice.
 
 ## Overview
 

--- a/install.ps1
+++ b/install.ps1
@@ -27,7 +27,10 @@ param(
 
     [Parameter(Mandatory = $true, ParameterSetName = 'Local')]
     [ValidateNotNullOrEmpty()]
-    [string]$SettingsPath
+    [string]$SettingsPath,
+
+    [ValidateSet('preserve', 'on', 'off', IgnoreCase = $false)]
+    [string]$SubagentRows = 'preserve'
 )
 
 Set-StrictMode -Version 2.0
@@ -770,7 +773,12 @@ function ConvertTo-JsonString([string]$Value) {
     return $builder.ToString()
 }
 
-function Get-SettingsPlan([string]$Path, [string]$DesiredValue) {
+function Get-SettingsPlan(
+    [string]$Path,
+    [string]$DesiredValue,
+    [string]$SubagentMode,
+    [string]$DesiredSubagentValue
+) {
     $existed = [System.IO.File]::Exists($Path)
     $original = [byte[]]@()
     if ($existed) {
@@ -803,12 +811,21 @@ function Get-SettingsPlan([string]$Path, [string]$DesiredValue) {
     $memberCount = 0
     $managedStart = -1
     $managedEnd = -1
+    $subagentMemberStart = -1
+    $subagentValueStart = -1
+    $subagentValueEnd = -1
+    $subagentPreviousComma = -1
+    $subagentFollowingComma = -1
+    $subagentKeySeen = $false
+    $subagentCaseVariantSeen = $false
+    $previousComma = -1
     $closingBrace = -1
     if ($index -lt $text.Length -and $text[$index] -eq '}') {
         $closingBrace = $index
         $index++
     } else {
         while ($true) {
+            $memberStart = $index
             $key = Read-JsonString $text ([ref]$index)
             Skip-JsonWhitespace $text ([ref]$index)
             if ($index -ge $text.Length -or $text[$index] -ne ':') {
@@ -824,6 +841,25 @@ function Get-SettingsPlan([string]$Path, [string]$DesiredValue) {
                 $managedStart = $valueStart
                 $managedEnd = $valueEnd
             }
+            $isExactSubagent = $key -ceq 'subagentStatusLine'
+            if ([string]::Equals(
+                $key,
+                'subagentStatusLine',
+                [System.StringComparison]::OrdinalIgnoreCase
+            )) {
+                if ($subagentKeySeen) {
+                    throw 'settings.json contains duplicate or case-colliding subagentStatusLine members'
+                }
+                $subagentKeySeen = $true
+                if ($isExactSubagent) {
+                    $subagentMemberStart = $memberStart
+                    $subagentValueStart = $valueStart
+                    $subagentValueEnd = $valueEnd
+                    $subagentPreviousComma = $previousComma
+                } else {
+                    $subagentCaseVariantSeen = $true
+                }
+            }
             $memberCount++
             Skip-JsonWhitespace $text ([ref]$index)
             if ($index -ge $text.Length) { throw 'truncated top-level JSON object' }
@@ -835,6 +871,8 @@ function Get-SettingsPlan([string]$Path, [string]$DesiredValue) {
             if ($text[$index] -ne ',') {
                 throw "expected comma after top-level JSON member at offset $index"
             }
+            if ($isExactSubagent) { $subagentFollowingComma = $index }
+            $previousComma = $index
             $index++
             Skip-JsonWhitespace $text ([ref]$index)
         }
@@ -842,13 +880,64 @@ function Get-SettingsPlan([string]$Path, [string]$DesiredValue) {
     Skip-JsonWhitespace $text ([ref]$index)
     if ($index -ne $text.Length) { throw "unexpected data after top-level JSON object at offset $index" }
 
+    if ($SubagentMode -ceq 'on' -and $subagentCaseVariantSeen) {
+        throw 'settings.json contains a case-variant subagentStatusLine member; refusing ambiguous insertion'
+    }
+
+    $edits = @()
+    $insertions = @()
+    $remainingMemberCount = $memberCount
     if ($managedStart -ge 0) {
-        $updated = $text.Substring(0, $managedStart) + $DesiredValue + $text.Substring($managedEnd)
+        $edits += [pscustomobject]@{
+            Start = $managedStart
+            End = $managedEnd
+            Value = $DesiredValue
+        }
     } else {
+        $insertions += '"statusLine":' + $DesiredValue
+    }
+    if ($SubagentMode -ceq 'on') {
+        if ($subagentValueStart -ge 0) {
+            $edits += [pscustomobject]@{
+                Start = $subagentValueStart
+                End = $subagentValueEnd
+                Value = $DesiredSubagentValue
+            }
+        } else {
+            $insertions += '"subagentStatusLine":' + $DesiredSubagentValue
+        }
+    } elseif ($SubagentMode -ceq 'off' -and $subagentValueStart -ge 0) {
+        $removeStart = $subagentMemberStart
+        $removeEnd = $subagentValueEnd
+        if ($subagentFollowingComma -ge 0) {
+            $removeEnd = $subagentFollowingComma + 1
+        } elseif ($subagentPreviousComma -ge 0) {
+            $removeStart = $subagentPreviousComma
+        }
+        $edits += [pscustomobject]@{
+            Start = $removeStart
+            End = $removeEnd
+            Value = ''
+        }
+        $remainingMemberCount--
+    }
+    if ($insertions.Count -gt 0) {
         $prefix = ''
-        if ($memberCount -gt 0) { $prefix = ',' }
-        $insertion = $prefix + '"statusLine":' + $DesiredValue
-        $updated = $text.Substring(0, $closingBrace) + $insertion + $text.Substring($closingBrace)
+        if ($remainingMemberCount -gt 0) { $prefix = ',' }
+        $edits += [pscustomobject]@{
+            Start = $closingBrace
+            End = $closingBrace
+            Value = $prefix + ($insertions -join ',')
+        }
+    }
+
+    $updated = $text
+    foreach ($edit in @($edits | Sort-Object Start -Descending)) {
+        $updated = (
+            $updated.Substring(0, [int]$edit.Start) +
+            [string]$edit.Value +
+            $updated.Substring([int]$edit.End)
+        )
     }
     $contentBytes = $script:Utf8NoBom.GetBytes($updated)
     if ($hadBom) {
@@ -1318,6 +1407,8 @@ function Invoke-CorallineInstall {
     Assert-CommandPath $runtimePath 'installed runtime path'
     $command = '"' + $powershell + '" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + $runtimePath + '"'
     $desiredStatusLine = '{"type":"command","command":' + (ConvertTo-JsonString $command) + ',"refreshInterval":1}'
+    $desiredSubagentStatusLine = '{"type":"command","command":' +
+        (ConvertTo-JsonString ($command + ' --subagent')) + '}'
 
     $installMutex = New-Object System.Threading.Mutex(
         $false,
@@ -1357,7 +1448,9 @@ function Invoke-CorallineInstall {
         Assert-ValidStagedPayload $stage
         $runtimeExpected = Get-ManagedPayloadBytes $stage
         $runtimeChanged = -not (Test-ManagedPayloadEqual $stage $install)
-        $settingsPlan = Get-SettingsPlan $settings $desiredStatusLine
+        $settingsPlan = Get-SettingsPlan (
+            $settings
+        ) $desiredStatusLine $SubagentRows $desiredSubagentStatusLine
         $settingsChanged = [bool]$settingsPlan.Changed
 
         if (-not $runtimeChanged -and -not $settingsChanged) {

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -5,14 +5,10 @@
   This runtime implements the main bar and optional float producer without Bash,
   jq, WSL, or PowerShell 7. Config is read from the same coralline.conf through a
   narrow, non-executing Bash-word parser. Burn and synced limit state share the
-  same immutable store as Bash; subagent rows remain a later protocol slice.
+  same immutable store as Bash; --subagent renders native panel rows.
 #>
 
-# Claude Code registers this exact literal. It must leave before stdin, config,
-# executable discovery, or any other main-bar work.
-if ($args.Count -gt 0 -and [string]$args[0] -ceq '--subagent') {
-    [Environment]::Exit(0)
-}
+$SubagentMode = $args.Count -gt 0 -and [string]$args[0] -ceq '--subagent'
 
 $ErrorActionPreference = 'SilentlyContinue'
 $ProgressPreference = 'SilentlyContinue'
@@ -20,9 +16,26 @@ $ProgressPreference = 'SilentlyContinue'
 $StrictUtf8 = New-Object System.Text.UTF8Encoding($false, $true)
 $Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
 $InputStream = [Console]::OpenStandardInput()
-$InputReader = New-Object System.IO.StreamReader($InputStream, $StrictUtf8, $false, 4096, $false)
-try { $rawInput = $InputReader.ReadToEnd() } catch { $rawInput = '' }
-$InputReader.Dispose()
+if ($SubagentMode) {
+    # Read one byte beyond the limit before allocating a decoded string. This
+    # distinguishes an exact-cap stream from a longer one without unbounded I/O.
+    $inputCap = 4194304
+    $inputBytes = New-Object byte[] ($inputCap + 1)
+    $inputLength = 0
+    try {
+        while ($inputLength -lt $inputBytes.Length) {
+            $read = $InputStream.Read($inputBytes, $inputLength, $inputBytes.Length - $inputLength)
+            if ($read -le 0) { break }
+            $inputLength += $read
+        }
+        if ($inputLength -gt $inputCap) { [Environment]::Exit(0) }
+        $rawInput = $StrictUtf8.GetString($inputBytes, 0, $inputLength)
+    } catch { [Environment]::Exit(0) }
+} else {
+    $InputReader = New-Object System.IO.StreamReader($InputStream, $StrictUtf8, $false, 4096, $false)
+    try { $rawInput = $InputReader.ReadToEnd() } catch { $rawInput = '' }
+    $InputReader.Dispose()
+}
 
 $OutputStream = [Console]::OpenStandardOutput()
 $OutputWriter = New-Object System.IO.StreamWriter($OutputStream, $Utf8NoBom, 4096, $false)
@@ -101,6 +114,17 @@ $Defaults = [ordered]@{
     VL_BG_SUB_MODEL = ''
     VL_BG_SUB_CTX = ''
     VL_BG_SUB_ELAPSED = ''
+    VL_FG_SUB_TEXT = ''
+    VL_FG_SUB_OK = ''
+    VL_FG_SUB_HOT = ''
+    VL_FG_SUB_DIM = ''
+    _VL_SUB_BG_NAME = ''
+    _VL_SUB_FG_TEXT = ''
+    _VL_SUB_FG_OK = ''
+    _VL_SUB_FG_HOT = ''
+    _VL_SUB_FG_DIM = ''
+    _VL_SUB_FP = ''
+    _VL_SUB_BAR = ''
 
     CORALLINE_BURN_WINDOW = '600'
     VL_BURN_GLYPH = (Glyph 0x2197)
@@ -480,11 +504,12 @@ function Read-StrictUtf8File([string]$Path) {
 function Import-ConfigFile(
     [string]$Path,
     [System.Collections.IDictionary]$BaseConfig,
+    [System.Collections.Generic.HashSet[string]]$BaseAssignments,
     [hashtable]$State,
     [int]$Depth,
     [string[]]$ApprovedRoots
 ) {
-    $failed = [pscustomobject]@{ Success = $false; Config = $BaseConfig }
+    $failed = [pscustomobject]@{ Success = $false; Config = $BaseConfig; Assignments = $BaseAssignments }
     if ($Depth -gt 8) { return $failed }
     if ($State.Visited.Contains($Path)) { return $failed }
     [void]$State.Visited.Add($Path)
@@ -493,6 +518,8 @@ function Import-ConfigFile(
     if ($null -eq $text) { return $failed }
 
     $candidate = Copy-Config $BaseConfig
+    $candidateAssignments = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
+    foreach ($assignedName in $BaseAssignments) { [void]$candidateAssignments.Add($assignedName) }
     $rootFloatAuthorized = $false
     $stack = New-Object System.Collections.ArrayList
     $active = $true
@@ -549,8 +576,11 @@ function Import-ConfigFile(
                 if (Test-PathInside $includePath $root) { $inside = $true; break }
             }
             if (-not $inside) { continue }
-            $child = Import-ConfigFile $includePath $candidate $State ($Depth + 1) $ApprovedRoots
-            if ($child.Success) { $candidate = $child.Config }
+            $child = Import-ConfigFile $includePath $candidate $candidateAssignments $State ($Depth + 1) $ApprovedRoots
+            if ($child.Success) {
+                $candidate = $child.Config
+                $candidateAssignments = $child.Assignments
+            }
             continue
         }
 
@@ -564,6 +594,7 @@ function Import-ConfigFile(
             if ($name -ieq 'VL_FLOAT_FILE') {
                 if ($Depth -eq 0 -and $name -ceq 'VL_FLOAT_FILE') {
                     $candidate['VL_FLOAT_FILE'] = $decoded.Value
+                    [void]$candidateAssignments.Add($name)
                     $rootFloatAuthorized = $true
                 }
                 continue
@@ -571,7 +602,10 @@ function Import-ConfigFile(
             # Bash variable names are case-sensitive. OrderedDictionary is not,
             # so ignore unknown and case-variant keys instead of letting them
             # overwrite a supported setting.
-            if ($ConfigKeys.Contains($name)) { $candidate[$name] = $decoded.Value }
+            if ($ConfigKeys.Contains($name)) {
+                $candidate[$name] = $decoded.Value
+                [void]$candidateAssignments.Add($name)
+            }
             continue
         }
 
@@ -581,10 +615,16 @@ function Import-ConfigFile(
 
     if ($stack.Count -ne 0) { $valid = $false }
     if (-not $valid) { return $failed }
-    return [pscustomobject]@{ Success = $true; Config = $candidate; FloatFileAuthorized = ($Depth -eq 0 -and $rootFloatAuthorized) }
+    return [pscustomobject]@{
+        Success = $true
+        Config = $candidate
+        Assignments = $candidateAssignments
+        FloatFileAuthorized = ($Depth -eq 0 -and $rootFloatAuthorized)
+    }
 }
 
 $Cfg = Copy-Config $Defaults
+$ConfigAssignments = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
 $FloatFileRootAuthorized = $false
 $ConfigInput = [string]$env:CORALLINE_CONFIG
 if ([string]::IsNullOrEmpty($ConfigInput)) { $ConfigInput = [System.IO.Path]::Combine($HomeDir, '.claude\coralline.conf') }
@@ -596,9 +636,10 @@ if (-not [string]::IsNullOrEmpty($ConfigPath)) {
     if (-not [string]::IsNullOrEmpty($ThemesRoot)) { $approved += $ThemesRoot }
     $visited = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
     $state = @{ IncludeCount = 0; Visited = $visited }
-    $parsed = Import-ConfigFile $ConfigPath $Cfg $state 0 $approved
+    $parsed = Import-ConfigFile $ConfigPath $Cfg $ConfigAssignments $state 0 $approved
     if ($parsed.Success) {
         $Cfg = $parsed.Config
+        $ConfigAssignments = $parsed.Assignments
         $FloatFileRootAuthorized = [bool]$parsed.FloatFileAuthorized
     }
 }
@@ -661,6 +702,9 @@ if ([int]$Cfg.VL_HOT_PCT -lt [int]$Cfg.VL_WARN_PCT) {
 foreach ($key in @($Cfg.Keys | Where-Object { $_ -like 'VL_BG_*' -or $_ -like 'VL_FG_*' })) {
     if (-not (Test-Color $Cfg[$key])) { $Cfg[$key] = $Defaults[$key] }
 }
+foreach ($key in @('_VL_SUB_BG_NAME', '_VL_SUB_FG_TEXT', '_VL_SUB_FG_OK', '_VL_SUB_FG_HOT', '_VL_SUB_FG_DIM')) {
+    if (-not (Test-Color $Cfg[$key])) { $Cfg[$key] = '' }
+}
 if (-not (Test-Color $Cfg.VL_LEAN_BG)) { $Cfg.VL_LEAN_BG = '' }
 if (-not (Test-Color $Cfg.VL_LEAN_FG)) { $Cfg.VL_LEAN_FG = '' }
 
@@ -674,6 +718,42 @@ $Cfg.VL_LAYOUT = switch -CaseSensitive ([string]$Cfg.VL_LAYOUT) {
     'fixed' { 'fixed'; break }
     'auto' { 'auto'; break }
     default { 'fixed' }
+}
+
+# Adopt bundled subagent inks only while the palette and painted ground still
+# match the theme that supplied them. Exact assignment tracking preserves Bash's
+# distinction between an unset public knob and an explicitly empty override.
+$stockSubFingerprint = '81,166,199|231|114|167|245'
+$stockSubBar = '|'
+$candidateFingerprint = $stockSubFingerprint
+$candidateBar = $stockSubBar
+if ($ConfigAssignments.Contains('_VL_SUB_FP')) { $candidateFingerprint = [string]$Cfg._VL_SUB_FP }
+if ($ConfigAssignments.Contains('_VL_SUB_BAR')) { $candidateBar = [string]$Cfg._VL_SUB_BAR }
+$adoptSubPalette = -not $ConfigAssignments.Contains('VL_BG_SUB_NAME') -and [string]::IsNullOrEmpty([string]$Cfg.VL_LEAN_FG)
+if ($Cfg.VL_STYLE -ceq 'lean') {
+    if ([string]::IsNullOrEmpty([string]$Cfg.VL_LEAN_BG)) { $adoptSubPalette = $false }
+    if (([string]$Cfg.VL_BG_BAR + '|' + [string]$Cfg.VL_LEAN_BG) -cne $candidateBar) { $adoptSubPalette = $false }
+} elseif ($Cfg.VL_STYLE -ceq 'classic') {
+    if (([string]$Cfg.VL_BG_BAR + '|' + [string]$Cfg.VL_LEAN_BG) -cne $candidateBar) { $adoptSubPalette = $false }
+}
+$liveSubFingerprint = [string]$Cfg.VL_BG_DIR + '|' + [string]$Cfg.VL_FG_TEXT + '|' + [string]$Cfg.VL_FG_OK + '|' + [string]$Cfg.VL_FG_HOT + '|' + [string]$Cfg.VL_FG_DIM
+if ($liveSubFingerprint -cne $candidateFingerprint) { $adoptSubPalette = $false }
+if ($adoptSubPalette) {
+    if (-not $ConfigAssignments.Contains('VL_BG_SUB_NAME')) {
+        $Cfg.VL_BG_SUB_NAME = if ($ConfigAssignments.Contains('_VL_SUB_BG_NAME')) { $Cfg._VL_SUB_BG_NAME } else { '68,68,68' }
+    }
+    if (-not $ConfigAssignments.Contains('VL_FG_SUB_TEXT')) {
+        $Cfg.VL_FG_SUB_TEXT = if ($ConfigAssignments.Contains('_VL_SUB_FG_TEXT')) { $Cfg._VL_SUB_FG_TEXT } else { '255,255,255' }
+    }
+    if (-not $ConfigAssignments.Contains('VL_FG_SUB_OK')) {
+        $Cfg.VL_FG_SUB_OK = if ($ConfigAssignments.Contains('_VL_SUB_FG_OK')) { $Cfg._VL_SUB_FG_OK } else { '' }
+    }
+    if (-not $ConfigAssignments.Contains('VL_FG_SUB_HOT')) {
+        $Cfg.VL_FG_SUB_HOT = if ($ConfigAssignments.Contains('_VL_SUB_FG_HOT')) { $Cfg._VL_SUB_FG_HOT } else { '231,157,157' }
+    }
+    if (-not $ConfigAssignments.Contains('VL_FG_SUB_DIM')) {
+        $Cfg.VL_FG_SUB_DIM = if ($ConfigAssignments.Contains('_VL_SUB_FG_DIM')) { $Cfg._VL_SUB_FG_DIM } else { '177,177,177' }
+    }
 }
 
 # Bash applies ASCII first, then classic's lean defaults, then lean overrides.
@@ -796,6 +876,682 @@ function Get-Trunc([string]$S, [int]$Max) {
     $headEnd = if ($head -lt $count) { $offsets[$head] } else { $S.Length }
     $tailStart = $offsets[$count - $tail]
     return $S.Substring(0, $headEnd) + $G.Ellipsis + $S.Substring($tailStart)
+}
+
+function New-StrictJsonNode([string]$Kind, $Value) {
+    return [pscustomobject]@{ Kind = $Kind; Value = $Value }
+}
+
+function Skip-StrictJsonWhitespace([hashtable]$State) {
+    while ($State.Index -lt $State.Text.Length) {
+        $ch = $State.Text[$State.Index]
+        if ($ch -ne ' ' -and $ch -ne "`t" -and $ch -ne "`n" -and $ch -ne "`r") { break }
+        $State.Index++
+    }
+}
+
+function Read-StrictJsonString([hashtable]$State) {
+    if ($State.Index -ge $State.Text.Length -or $State.Text[$State.Index] -ne '"') {
+        $State.Valid = $false
+        return $null
+    }
+    $State.Index++
+    $builder = New-Object System.Text.StringBuilder
+    :jsonStringCharacters while ($State.Index -lt $State.Text.Length) {
+        $ch = $State.Text[$State.Index]
+        $State.Index++
+        if ($ch -eq '"') { return $builder.ToString() }
+        if ($ch -eq '\') {
+            if ($State.Index -ge $State.Text.Length) { $State.Valid = $false; return $null }
+            $escape = $State.Text[$State.Index]
+            $State.Index++
+            switch -CaseSensitive ([string]$escape) {
+                '"' { [void]$builder.Append('"'); continue jsonStringCharacters }
+                '\' { [void]$builder.Append('\'); continue jsonStringCharacters }
+                '/' { [void]$builder.Append('/'); continue jsonStringCharacters }
+                'b' { [void]$builder.Append([char]8); continue jsonStringCharacters }
+                'f' { [void]$builder.Append([char]12); continue jsonStringCharacters }
+                'n' { [void]$builder.Append([char]10); continue jsonStringCharacters }
+                'r' { [void]$builder.Append([char]13); continue jsonStringCharacters }
+                't' { [void]$builder.Append([char]9); continue jsonStringCharacters }
+                'u' {
+                    if (($State.Index + 4) -gt $State.Text.Length) { $State.Valid = $false; return $null }
+                    $hex = $State.Text.Substring($State.Index, 4)
+                    if ($hex -notmatch '\A[0-9A-Fa-f]{4}\z') { $State.Valid = $false; return $null }
+                    $State.Index += 4
+                    try { $code = [Convert]::ToInt32($hex, 16) } catch { $State.Valid = $false; return $null }
+                    if ($code -ge 0xD800 -and $code -le 0xDBFF) {
+                        if (($State.Index + 6) -gt $State.Text.Length -or $State.Text[$State.Index] -ne '\' -or $State.Text[$State.Index + 1] -cne 'u') {
+                            $State.Valid = $false
+                            return $null
+                        }
+                        $lowHex = $State.Text.Substring($State.Index + 2, 4)
+                        if ($lowHex -notmatch '\A[0-9A-Fa-f]{4}\z') { $State.Valid = $false; return $null }
+                        try { $low = [Convert]::ToInt32($lowHex, 16) } catch { $State.Valid = $false; return $null }
+                        if ($low -lt 0xDC00 -or $low -gt 0xDFFF) { $State.Valid = $false; return $null }
+                        [void]$builder.Append([char]$code)
+                        [void]$builder.Append([char]$low)
+                        $State.Index += 6
+                        continue jsonStringCharacters
+                    }
+                    if ($code -ge 0xDC00 -and $code -le 0xDFFF) { $State.Valid = $false; return $null }
+                    [void]$builder.Append([char]$code)
+                    continue jsonStringCharacters
+                }
+                default { $State.Valid = $false; return $null }
+            }
+        }
+        $codepoint = [int][char]$ch
+        if ($codepoint -le 0x1F) { $State.Valid = $false; return $null }
+        if ([char]::IsHighSurrogate($ch)) {
+            if ($State.Index -ge $State.Text.Length -or -not [char]::IsLowSurrogate($State.Text[$State.Index])) {
+                $State.Valid = $false
+                return $null
+            }
+            [void]$builder.Append($ch)
+            [void]$builder.Append($State.Text[$State.Index])
+            $State.Index++
+            continue jsonStringCharacters
+        }
+        if ([char]::IsLowSurrogate($ch)) { $State.Valid = $false; return $null }
+        [void]$builder.Append($ch)
+    }
+    $State.Valid = $false
+    return $null
+}
+
+function Read-StrictJsonNumber([hashtable]$State) {
+    $start = [int]$State.Index
+    if ($State.Text[$State.Index] -eq '-') {
+        $State.Index++
+        if ($State.Index -ge $State.Text.Length) { $State.Valid = $false; return $null }
+    }
+    if ($State.Text[$State.Index] -eq '0') {
+        $State.Index++
+    } elseif ($State.Text[$State.Index] -ge '1' -and $State.Text[$State.Index] -le '9') {
+        $State.Index++
+        while ($State.Index -lt $State.Text.Length -and $State.Text[$State.Index] -ge '0' -and $State.Text[$State.Index] -le '9') { $State.Index++ }
+    } else {
+        $State.Valid = $false
+        return $null
+    }
+    if ($State.Index -lt $State.Text.Length -and $State.Text[$State.Index] -eq '.') {
+        $State.Index++
+        $fractionStart = [int]$State.Index
+        while ($State.Index -lt $State.Text.Length -and $State.Text[$State.Index] -ge '0' -and $State.Text[$State.Index] -le '9') { $State.Index++ }
+        if ($State.Index -eq $fractionStart) { $State.Valid = $false; return $null }
+    }
+    if ($State.Index -lt $State.Text.Length -and ($State.Text[$State.Index] -eq 'e' -or $State.Text[$State.Index] -eq 'E')) {
+        $State.Index++
+        if ($State.Index -lt $State.Text.Length -and ($State.Text[$State.Index] -eq '+' -or $State.Text[$State.Index] -eq '-')) { $State.Index++ }
+        $exponentStart = [int]$State.Index
+        while ($State.Index -lt $State.Text.Length -and $State.Text[$State.Index] -ge '0' -and $State.Text[$State.Index] -le '9') { $State.Index++ }
+        if ($State.Index -eq $exponentStart) { $State.Valid = $false; return $null }
+    }
+    return $State.Text.Substring($start, $State.Index - $start)
+}
+
+function Read-StrictJsonValueStart(
+    [hashtable]$State,
+    [System.Collections.Generic.List[object]]$Stack
+) {
+    if ($State.Index -ge $State.Text.Length) { $State.Valid = $false; return $null }
+    if ([int]$State.NodeCount -ge 32768) { $State.Valid = $false; return $null }
+    $State.NodeCount = [int]$State.NodeCount + 1
+    $ch = $State.Text[$State.Index]
+    if ($ch -eq '"') {
+        $value = Read-StrictJsonString $State
+        if (-not $State.Valid) { return $null }
+        return New-StrictJsonNode 'string' $value
+    }
+    if ($ch -eq '{') {
+        if ($Stack.Count -ge 128) { $State.Valid = $false; return $null }
+        $State.Index++
+        $members = New-Object 'System.Collections.Generic.Dictionary[string,object]' ([System.StringComparer]::Ordinal)
+        $seen = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+        $node = New-StrictJsonNode 'object' $members
+        [void]$Stack.Add([pscustomobject]@{ Type='object'; State='keyOrEnd'; Node=$node; Seen=$seen; Key='' })
+        return $node
+    }
+    if ($ch -eq '[') {
+        if ($Stack.Count -ge 128) { $State.Valid = $false; return $null }
+        $State.Index++
+        $items = New-Object 'System.Collections.Generic.List[object]'
+        $node = New-StrictJsonNode 'array' $items
+        [void]$Stack.Add([pscustomobject]@{ Type='array'; State='valueOrEnd'; Node=$node })
+        return $node
+    }
+    if ($ch -eq '-' -or ($ch -ge '0' -and $ch -le '9')) {
+        $number = Read-StrictJsonNumber $State
+        if (-not $State.Valid) { return $null }
+        return New-StrictJsonNode 'number' $number
+    }
+    if (($State.Index + 4) -le $State.Text.Length -and $State.Text.Substring($State.Index, 4) -ceq 'true') {
+        $State.Index += 4
+        return New-StrictJsonNode 'bool' $true
+    }
+    if (($State.Index + 5) -le $State.Text.Length -and $State.Text.Substring($State.Index, 5) -ceq 'false') {
+        $State.Index += 5
+        return New-StrictJsonNode 'bool' $false
+    }
+    if (($State.Index + 4) -le $State.Text.Length -and $State.Text.Substring($State.Index, 4) -ceq 'null') {
+        $State.Index += 4
+        return New-StrictJsonNode 'null' $null
+    }
+    $State.Valid = $false
+    return $null
+}
+
+function Read-StrictJsonValue([hashtable]$State) {
+    $stack = New-Object 'System.Collections.Generic.List[object]'
+    $root = Read-StrictJsonValueStart $State $stack
+    if (-not $State.Valid) { return $null }
+    while ($stack.Count -gt 0 -and $State.Valid) {
+        $frame = $stack[$stack.Count - 1]
+        Skip-StrictJsonWhitespace $State
+        if ($frame.Type -ceq 'object') {
+            if ($frame.State -ceq 'keyOrEnd' -or $frame.State -ceq 'key') {
+                if ($frame.State -ceq 'keyOrEnd' -and $State.Index -lt $State.Text.Length -and $State.Text[$State.Index] -eq '}') {
+                    $State.Index++
+                    $stack.RemoveAt($stack.Count - 1)
+                    continue
+                }
+                if ($State.Index -ge $State.Text.Length -or $State.Text[$State.Index] -ne '"') { $State.Valid = $false; break }
+                $key = Read-StrictJsonString $State
+                if (-not $State.Valid -or -not $frame.Seen.Add($key)) { $State.Valid = $false; break }
+                $frame.Key = $key
+                $frame.State = 'colon'
+                continue
+            }
+            if ($frame.State -ceq 'colon') {
+                if ($State.Index -ge $State.Text.Length -or $State.Text[$State.Index] -ne ':') { $State.Valid = $false; break }
+                $State.Index++
+                $frame.State = 'value'
+                continue
+            }
+            if ($frame.State -ceq 'value') {
+                Skip-StrictJsonWhitespace $State
+                $node = Read-StrictJsonValueStart $State $stack
+                if (-not $State.Valid) { break }
+                $frame.Node.Value.Add([string]$frame.Key, $node)
+                $frame.State = 'commaOrEnd'
+                continue
+            }
+            if ($State.Index -lt $State.Text.Length -and $State.Text[$State.Index] -eq ',') {
+                $State.Index++
+                $frame.State = 'key'
+                continue
+            }
+            if ($State.Index -lt $State.Text.Length -and $State.Text[$State.Index] -eq '}') {
+                $State.Index++
+                $stack.RemoveAt($stack.Count - 1)
+                continue
+            }
+            $State.Valid = $false
+            break
+        }
+
+        if ($frame.State -ceq 'valueOrEnd' -or $frame.State -ceq 'value') {
+            if ($frame.State -ceq 'valueOrEnd' -and $State.Index -lt $State.Text.Length -and $State.Text[$State.Index] -eq ']') {
+                $State.Index++
+                $stack.RemoveAt($stack.Count - 1)
+                continue
+            }
+            $node = Read-StrictJsonValueStart $State $stack
+            if (-not $State.Valid) { break }
+            [void]$frame.Node.Value.Add($node)
+            $frame.State = 'commaOrEnd'
+            continue
+        }
+        if ($State.Index -lt $State.Text.Length -and $State.Text[$State.Index] -eq ',') {
+            $State.Index++
+            $frame.State = 'value'
+            continue
+        }
+        if ($State.Index -lt $State.Text.Length -and $State.Text[$State.Index] -eq ']') {
+            $State.Index++
+            $stack.RemoveAt($stack.Count - 1)
+            continue
+        }
+        $State.Valid = $false
+    }
+    if (-not $State.Valid) { return $null }
+    return $root
+}
+
+function Read-StrictJsonStream([string]$Text) {
+    $state = @{ Text=$Text; Index=0; Valid=$true; NodeCount=0 }
+    $last = $null
+    $count = 0
+    Skip-StrictJsonWhitespace $state
+    while ($state.Index -lt $state.Text.Length -and $state.Valid) {
+        $last = Read-StrictJsonValue $state
+        if (-not $state.Valid) { break }
+        $count++
+        Skip-StrictJsonWhitespace $state
+    }
+    return [pscustomobject]@{ Success=($state.Valid -and $count -gt 0 -and $state.Index -eq $state.Text.Length); Count=$count; Last=$last }
+}
+
+function Get-StrictJsonMember($Node, [string]$Name) {
+    if ($null -eq $Node -or $Node.Kind -cne 'object') { return $null }
+    $value = $null
+    if (-not $Node.Value.TryGetValue($Name, [ref]$value)) { return $null }
+    return $value
+}
+
+function Convert-StrictJsonNumber([string]$Raw) {
+    # jq's decimal tostring preserves coefficient scale. It switches to
+    # scientific form when the decimal quantum is positive or adjusts below -6.
+    $match = [regex]::Match($Raw, '\A(-?)([0-9]+)(?:\.([0-9]+))?(?:[eE]([+-]?[0-9]+))?\z')
+    if (-not $match.Success) { return $null }
+    $sign = $match.Groups[1].Value
+    $fraction = $match.Groups[3].Value
+    $exponentText = if ($match.Groups[4].Success) { $match.Groups[4].Value } else { '0' }
+    $explicitExponent = [bigint]::Zero
+    if (-not [bigint]::TryParse($exponentText, $IntegerStyle, $Invariant, [ref]$explicitExponent)) { return $null }
+
+    $quantum = $explicitExponent - [bigint]([int]$fraction.Length)
+    $coefficient = ($match.Groups[2].Value + $fraction).TrimStart('0')
+    if ([string]::IsNullOrEmpty($coefficient)) { $coefficient = '0' }
+    $maxAdjusted = [bigint]999999999
+    $minQuantum = [bigint](-1147483646)
+    $adjusted = $quantum + [bigint]([int]$coefficient.Length - 1)
+
+    if ($coefficient -ceq '0') {
+        if ($quantum -gt $maxAdjusted) { $quantum = $maxAdjusted }
+        elseif ($quantum -lt $minQuantum) { $quantum = $minQuantum }
+        $adjusted = $quantum
+    } else {
+        if ($adjusted -gt $maxAdjusted) { return $sign + '1.7976931348623157e+308' }
+        if ($quantum -lt $minQuantum) {
+            $discard = $minQuantum - $quantum
+            if ($discard -gt [bigint]([int]$coefficient.Length)) {
+                $coefficient = '0'
+            } else {
+                $discardCount = [int]$discard
+                $retainedCount = $coefficient.Length - $discardCount
+                $retainedText = if ($retainedCount -gt 0) { $coefficient.Substring(0, $retainedCount) } else { '0' }
+                $rounded = [bigint]::Zero
+                if (-not [bigint]::TryParse($retainedText, $IntegerStyle, $Invariant, [ref]$rounded)) { return $null }
+                if ($coefficient[$retainedCount] -ge '5') { $rounded += [bigint]::One }
+                $coefficient = $rounded.ToString($Invariant)
+            }
+            $quantum = $minQuantum
+            $adjusted = $quantum + [bigint]([int]$coefficient.Length - 1)
+        }
+    }
+
+    if ($quantum -gt [bigint]::Zero -or $adjusted -lt [bigint](-6)) {
+        $mantissa = [string]$coefficient[0]
+        if ($coefficient.Length -gt 1) { $mantissa += '.' + $coefficient.Substring(1) }
+        $shownExponent = $adjusted.ToString($Invariant)
+        if ($adjusted -ge [bigint]::Zero) { $shownExponent = '+' + $shownExponent }
+        return $sign + $mantissa + 'E' + $shownExponent
+    }
+
+    $point = [int]([bigint]([int]$coefficient.Length) + $quantum)
+    if ($point -eq $coefficient.Length) { return $sign + $coefficient }
+    if ($point -gt 0) {
+        return $sign + $coefficient.Substring(0, $point) + '.' + $coefficient.Substring($point)
+    }
+    return $sign + '0.' + (('0' * (-$point)) -join '') + $coefficient
+}
+
+function Convert-StrictJsonScalar($Node, [int]$ByteCap) {
+    if ($null -eq $Node) { return [pscustomobject]@{ Valid=$false; Value='' } }
+    switch -CaseSensitive ([string]$Node.Kind) {
+        'null' { $value = ''; break }
+        'string' { $value = [string]$Node.Value; break }
+        'number' {
+            $rawNumber = [string]$Node.Value
+            try {
+                if ($StrictUtf8.GetByteCount($rawNumber) -gt $ByteCap) { return [pscustomobject]@{ Valid=$false; Value='' } }
+            } catch { return [pscustomobject]@{ Valid=$false; Value='' } }
+            $value = Convert-StrictJsonNumber $rawNumber
+            if ($null -eq $value) { return [pscustomobject]@{ Valid=$false; Value='' } }
+            break
+        }
+        'bool' { $value = if ([bool]$Node.Value) { 'true' } else { 'false' }; break }
+        default { return [pscustomobject]@{ Valid=$false; Value='' } }
+    }
+    $value = Remove-ControlChars $value
+    try {
+        if ($StrictUtf8.GetByteCount($value) -gt $ByteCap) { return [pscustomobject]@{ Valid=$false; Value='' } }
+    } catch { return [pscustomobject]@{ Valid=$false; Value='' } }
+    return [pscustomobject]@{ Valid=$true; Value=$value }
+}
+
+function ConvertTo-StrictJsonString([string]$Value) {
+    $builder = New-Object System.Text.StringBuilder
+    [void]$builder.Append('"')
+    :jsonEscapeCharacters for ($i = 0; $i -lt $Value.Length; $i++) {
+        $ch = $Value[$i]
+        $code = [int][char]$ch
+        switch ($code) {
+            8 { [void]$builder.Append('\b'); continue jsonEscapeCharacters }
+            9 { [void]$builder.Append('\t'); continue jsonEscapeCharacters }
+            10 { [void]$builder.Append('\n'); continue jsonEscapeCharacters }
+            12 { [void]$builder.Append('\f'); continue jsonEscapeCharacters }
+            13 { [void]$builder.Append('\r'); continue jsonEscapeCharacters }
+            34 { [void]$builder.Append('\"'); continue jsonEscapeCharacters }
+            92 { [void]$builder.Append('\\'); continue jsonEscapeCharacters }
+        }
+        if ($code -lt 0x20) {
+            [void]$builder.Append(('\u{0:x4}' -f $code))
+            continue
+        }
+        [void]$builder.Append($ch)
+    }
+    [void]$builder.Append('"')
+    return $builder.ToString()
+}
+
+function Read-BoundedStrictUtf8RegularFile([string]$Path, [int]$ByteCap) {
+    if (-not (Test-SafeRegularFile $Path)) { return $null }
+    try {
+        $info = New-Object System.IO.FileInfo($Path)
+        if ($info.Length -gt $ByteCap) { return $null }
+        $share = [System.IO.FileShare]::ReadWrite -bor [System.IO.FileShare]::Delete
+        $stream = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, $share)
+        try {
+            $bytes = New-Object byte[] ($ByteCap + 1)
+            $length = 0
+            while ($length -lt $bytes.Length) {
+                $read = $stream.Read($bytes, $length, $bytes.Length - $length)
+                if ($read -le 0) { break }
+                $length += $read
+            }
+            if ($length -gt $ByteCap) { return $null }
+            return $StrictUtf8.GetString($bytes, 0, $length)
+        } finally { $stream.Dispose() }
+    } catch { return $null }
+}
+
+function Get-SubagentSidecarPath([string]$Transcript, [string]$Id) {
+    if ([string]::IsNullOrEmpty($Transcript) -or $Transcript.Length -gt 4096) { return $null }
+    if ([string]::IsNullOrEmpty($Id) -or $Id -match '[<>:"/\\|?*]') { return $null }
+    $path = $Transcript.Replace('/', '\')
+    if ($path -notmatch '\A[A-Za-z]:\\') { return $null }
+    if (-not $path.EndsWith('.jsonl', [System.StringComparison]::Ordinal)) { return $null }
+    if ($path.StartsWith('\\', [System.StringComparison]::Ordinal) -or $path.StartsWith('\\?\', [System.StringComparison]::Ordinal) -or $path.StartsWith('\\.\', [System.StringComparison]::Ordinal)) { return $null }
+    if ($path.IndexOf(':', 2) -ge 0 -or $path -match '[\u0000-\u001f\u007f-\u009f]') { return $null }
+    $rest = $path.Substring(3)
+    if ([string]::IsNullOrEmpty($rest)) { return $null }
+    $components = $rest.Split('\')
+    foreach ($component in $components) {
+        if ([string]::IsNullOrEmpty($component) -or $component -eq '.' -or $component -eq '..') { return $null }
+        if ($component.EndsWith('.') -or $component.EndsWith(' ') -or ($component -match '[<>":|?*]')) { return $null }
+        if (Test-DosDeviceComponent $component) { return $null }
+    }
+    try {
+        $fullTranscript = [System.IO.Path]::GetFullPath($path)
+        if ($fullTranscript.Length -gt 4096 -or [System.IO.Path]::GetPathRoot($fullTranscript).Length -ne 3) { return $null }
+        $base = $fullTranscript.Substring(0, $fullTranscript.Length - 6)
+        if ([string]::IsNullOrEmpty($base)) { return $null }
+        $expectedDir = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($base, 'subagents'))
+        $candidate = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($expectedDir, ('agent-' + $Id + '.meta.json')))
+    } catch { return $null }
+    if ($expectedDir.Length -gt 4096 -or $candidate.Length -gt 4096) { return $null }
+    if (-not [System.IO.Path]::GetDirectoryName($candidate).Equals($expectedDir, [System.StringComparison]::OrdinalIgnoreCase)) { return $null }
+    if (-not (Test-PathInside $candidate $expectedDir) -or $candidate.Equals($expectedDir, [System.StringComparison]::OrdinalIgnoreCase)) { return $null }
+    if (-not (Test-NoReparseComponents $fullTranscript) -or -not (Test-NoReparseComponents $expectedDir) -or -not (Test-NoReparseComponents $candidate)) { return $null }
+    return $candidate
+}
+
+function Get-SubagentRole([string]$Transcript, [string]$Id) {
+    $path = Get-SubagentSidecarPath $Transcript $Id
+    if ([string]::IsNullOrEmpty($path)) { return '' }
+    $text = Read-BoundedStrictUtf8RegularFile $path 65536
+    if ($null -eq $text) { return '' }
+    $parsed = Read-StrictJsonStream $text
+    if (-not $parsed.Success -or $parsed.Count -ne 1 -or $null -eq $parsed.Last -or $parsed.Last.Kind -cne 'object') { return '' }
+    $roleResult = Convert-StrictJsonScalar (Get-StrictJsonMember $parsed.Last 'agentType') 16384
+    if (-not $roleResult.Valid -or $roleResult.Value -notmatch '\A[A-Za-z0-9._:]+\z') { return '' }
+    return [string]$roleResult.Value
+}
+
+function Get-SubagentModelShort([string]$Model) {
+    if (-not $Model.StartsWith('claude-', [System.StringComparison]::Ordinal)) { return $Model }
+    $value = $Model.Substring(7)
+    if ($value -match '-[0-9]{8}\z') { $value = $value.Substring(0, $value.Length - 9) }
+    $dash = $value.IndexOf('-')
+    if ($dash -le 0 -or $dash -ge ($value.Length - 1)) { return $Model }
+    $family = $value.Substring(0, $dash)
+    $version = $value.Substring($dash + 1)
+    if ($version -notmatch '\A[0-9-]+\z') { return $Model }
+    switch -CaseSensitive ($family) {
+        'fable' { $family = 'Fable'; break }
+        'opus' { $family = 'Opus'; break }
+        'sonnet' { $family = 'Sonnet'; break }
+        'haiku' { $family = 'Haiku'; break }
+        default { return $Model }
+    }
+    return $family + ' ' + $version.Replace('-', '.')
+}
+
+function Try-SubagentUnsigned([string]$Raw, [ref]$Value) {
+    if ($Raw -notmatch '\A[0-9]{1,16}\z') { return $false }
+    $parsed = 0L
+    if (-not [long]::TryParse($Raw, $IntegerStyle, $Invariant, [ref]$parsed) -or $parsed -gt 9999999999999999L) { return $false }
+    $Value.Value = $parsed
+    return $true
+}
+
+function Get-SubagentEpoch([string]$Raw) {
+    if ($Raw -match '\A[0-9]{1,16}\z') {
+        $value = 0L
+        if (-not [long]::TryParse($Raw, $IntegerStyle, $Invariant, [ref]$value)) { return $null }
+        if ($Raw.Length -ge 13) {
+            $unused = 0L
+            $value = [Math]::DivRem($value, 1000L, [ref]$unused)
+        }
+        if ($value -lt 0 -or $value -gt 253402300799L) { return $null }
+        return $value
+    }
+    # Canonical grammar is YYYY-MM-DDTHH:mm:ss[.digits]Z. Fractions are
+    # validated but intentionally discarded because elapsed renders seconds.
+    if ($Raw -cnotmatch '\A[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]+)?Z\z') { return $null }
+    $year = 0
+    $month = 0
+    $day = 0
+    $hour = 0
+    $minute = 0
+    $second = 0
+    if (
+        -not [int]::TryParse($Raw.Substring(0, 4), $IntegerStyle, $Invariant, [ref]$year) -or
+        -not [int]::TryParse($Raw.Substring(5, 2), $IntegerStyle, $Invariant, [ref]$month) -or
+        -not [int]::TryParse($Raw.Substring(8, 2), $IntegerStyle, $Invariant, [ref]$day) -or
+        -not [int]::TryParse($Raw.Substring(11, 2), $IntegerStyle, $Invariant, [ref]$hour) -or
+        -not [int]::TryParse($Raw.Substring(14, 2), $IntegerStyle, $Invariant, [ref]$minute) -or
+        -not [int]::TryParse($Raw.Substring(17, 2), $IntegerStyle, $Invariant, [ref]$second)
+    ) { return $null }
+    if ($month -lt 1 -or $month -gt 12 -or $hour -gt 23 -or $minute -gt 59 -or $second -gt 59) { return $null }
+    $monthDays = @(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+    if (($year % 4) -eq 0 -and (($year % 100) -ne 0 -or ($year % 400) -eq 0)) {
+        $monthDays[1] = 29
+    }
+    if ($day -lt 1 -or $day -gt $monthDays[$month - 1]) { return $null }
+
+    $shiftedYear = [long]$year
+    if ($month -le 2) { $shiftedYear-- }
+    $eraNumerator = $shiftedYear
+    if ($shiftedYear -lt 0) { $eraNumerator -= 399L }
+    $unused = 0L
+    $era = [Math]::DivRem($eraNumerator, 400L, [ref]$unused)
+    $yearOfEra = $shiftedYear - ($era * 400L)
+    $adjustedMonth = [long]$month + 9L
+    if ($month -gt 2) { $adjustedMonth = [long]$month - 3L }
+    $dayOfYear = [Math]::DivRem((153L * $adjustedMonth) + 2L, 5L, [ref]$unused) + [long]$day - 1L
+    $quarters = [Math]::DivRem($yearOfEra, 4L, [ref]$unused)
+    $centuries = [Math]::DivRem($yearOfEra, 100L, [ref]$unused)
+    $dayOfEra = ($yearOfEra * 365L) + $quarters - $centuries + $dayOfYear
+    $days = ($era * 146097L) + $dayOfEra - 719468L
+    $epoch = ($days * 86400L) + ([long]$hour * 3600L) + ([long]$minute * 60L) + [long]$second
+    if ($epoch -gt 253402300799L) { return $null }
+    return $epoch
+}
+
+function Format-SubagentDuration([long]$Seconds) {
+    $hours = [Math]::Floor($Seconds / 3600)
+    $minutes = [Math]::Floor(($Seconds % 3600) / 60)
+    $secondsLeft = $Seconds % 60
+    if ($hours -gt 0) { return ('{0}h{1:00}m{2:00}s' -f $hours, $minutes, $secondsLeft) }
+    if ($minutes -gt 0) { return ('{0}m{1:00}s' -f $minutes, $secondsLeft) }
+    return "${Seconds}s"
+}
+
+function Add-SubagentSegment(
+    [System.Collections.Generic.List[string]]$Backgrounds,
+    [System.Collections.Generic.List[string]]$Texts,
+    [string]$Background,
+    [string]$Text
+) {
+    [void]$Backgrounds.Add($Background)
+    [void]$Texts.Add($Text)
+}
+
+function Render-SubagentSegments(
+    [System.Collections.Generic.List[string]]$Backgrounds,
+    [System.Collections.Generic.List[string]]$Texts
+) {
+    if ($Backgrounds.Count -eq 0) { return '' }
+    if ($Cfg.VL_STYLE -ceq 'lean') {
+        $leanBackground = ''
+        if (-not [string]::IsNullOrEmpty([string]$Cfg.VL_LEAN_BG)) { $leanBackground = Get-Bg $Cfg.VL_LEAN_BG }
+        $out = ''
+        if (-not [string]::IsNullOrEmpty($leanBackground) -and -not [string]::IsNullOrEmpty([string]$Cfg.VL_LEAN_CAP_L)) {
+            $out = $Rst + (Get-Fg $Cfg.VL_LEAN_BG) + $Cfg.VL_LEAN_CAP_L
+        }
+        for ($i = 0; $i -lt $Backgrounds.Count; $i++) {
+            $out += $Rst + $leanBackground + (Get-Fg $Backgrounds[$i]) + $Texts[$i]
+            if ($i -lt ($Backgrounds.Count - 1)) { $out += $Rst + $leanBackground + $Cfg.VL_LEAN_SEP }
+        }
+        if (-not [string]::IsNullOrEmpty($leanBackground) -and -not [string]::IsNullOrEmpty([string]$Cfg.VL_LEAN_CAP_R)) {
+            $out += $Rst + (Get-Fg $Cfg.VL_LEAN_BG) + $Cfg.VL_LEAN_CAP_R
+        }
+        return $out + $Rst
+    }
+    $out = $Rst + (Get-Fg $Backgrounds[0]) + $Cfg.VL_CAP_L
+    for ($i = 0; $i -lt $Backgrounds.Count; $i++) {
+        $out += (Get-Bg $Backgrounds[$i]) + $Texts[$i]
+        if ($i -lt ($Backgrounds.Count - 1)) {
+            $out += (Get-Bg $Backgrounds[$i + 1]) + (Get-Fg $Backgrounds[$i]) + $Cfg.VL_SEP
+        }
+    }
+    return $out + $Rst + (Get-Fg $Backgrounds[$Backgrounds.Count - 1]) + $Cfg.VL_CAP_R + $Rst
+}
+
+function Invoke-SubagentMode([string]$InputText) {
+    $stream = Read-StrictJsonStream $InputText
+    if (-not $stream.Success -or $null -eq $stream.Last -or $stream.Last.Kind -cne 'object') { return }
+    $tasks = Get-StrictJsonMember $stream.Last 'tasks'
+    if ($null -eq $tasks -or $tasks.Kind -cne 'array' -or $tasks.Value.Count -gt 1024) { return }
+    $transcriptResult = Convert-StrictJsonScalar (Get-StrictJsonMember $stream.Last 'transcript_path') 16384
+    $transcript = ''
+    if ($transcriptResult.Valid -and $transcriptResult.Value.Length -le 4096) { $transcript = [string]$transcriptResult.Value }
+    $now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    $lines = New-Object 'System.Collections.Generic.List[string]'
+
+    foreach ($task in $tasks.Value) {
+        if ($null -eq $task -or $task.Kind -cne 'object') { continue }
+        $idResult = Convert-StrictJsonScalar (Get-StrictJsonMember $task 'id') 16384
+        if (-not $idResult.Valid -or [string]::IsNullOrEmpty([string]$idResult.Value)) { continue }
+        $id = [string]$idResult.Value
+        $fields = @{}
+        foreach ($fieldName in @('name','label','description','type','status','startTime','model','contextWindowSize','tokenCount')) {
+            $result = Convert-StrictJsonScalar (Get-StrictJsonMember $task $fieldName) 16384
+            if ($result.Valid) { $fields[$fieldName] = [string]$result.Value } else { $fields[$fieldName] = '' }
+        }
+        $role = ''
+        if ($fields.type -ceq 'local_agent') { $role = Get-SubagentRole $transcript $id }
+        $backgrounds = New-Object 'System.Collections.Generic.List[string]'
+        $texts = New-Object 'System.Collections.Generic.List[string]'
+        $segmentList = [string]$Cfg.VL_SUB_SEGMENTS
+        $segmentNames = @()
+        if (-not [string]::IsNullOrWhiteSpace($segmentList)) { $segmentNames = @([regex]::Split($segmentList.Trim(), '\s+')) }
+
+        foreach ($segmentName in $segmentNames) {
+            switch -CaseSensitive ($segmentName) {
+                'name' {
+                    $identity = if (-not [string]::IsNullOrEmpty($fields.name)) { $fields.name } else { $role }
+                    $detail = if (-not [string]::IsNullOrEmpty($fields.label)) { $fields.label } else { $fields.description }
+                    if (-not [string]::IsNullOrEmpty($fields.name) -and -not [string]::IsNullOrEmpty($role) -and $fields.name -cne $role) {
+                        $identity = $fields.name + ' (' + $role + ')'
+                    }
+                    if (-not [string]::IsNullOrEmpty($identity)) {
+                        $label = $identity
+                        if (-not [string]::IsNullOrEmpty($detail) -and $detail -cne $fields.name -and $detail -cne $role) { $label += ' ' + [char]0x00B7 + ' ' + $detail }
+                    } elseif (-not [string]::IsNullOrEmpty($detail)) { $label = $detail }
+                    else { $label = $fields.type }
+                    if ([string]::IsNullOrEmpty($label)) { break }
+                    switch -CaseSensitive ($fields.status) {
+                        { $_ -ceq 'running' -or $_ -ceq 'in_progress' -or $_ -ceq 'active' } {
+                            $color = if ([string]::IsNullOrEmpty([string]$Cfg.VL_FG_SUB_TEXT)) { $Cfg.VL_FG_TEXT } else { $Cfg.VL_FG_SUB_TEXT }
+                            break
+                        }
+                        { $_ -ceq 'completed' -or $_ -ceq 'success' -or $_ -ceq 'done' } {
+                            $color = if ([string]::IsNullOrEmpty([string]$Cfg.VL_FG_SUB_OK)) { $Cfg.VL_FG_OK } else { $Cfg.VL_FG_SUB_OK }
+                            break
+                        }
+                        { $_ -ceq 'failed' -or $_ -ceq 'error' -or $_ -ceq 'cancelled' } {
+                            $color = if ([string]::IsNullOrEmpty([string]$Cfg.VL_FG_SUB_HOT)) { $Cfg.VL_FG_HOT } else { $Cfg.VL_FG_SUB_HOT }
+                            break
+                        }
+                        default { $color = if ([string]::IsNullOrEmpty([string]$Cfg.VL_FG_SUB_DIM)) { $Cfg.VL_FG_DIM } else { $Cfg.VL_FG_SUB_DIM } }
+                    }
+                    $shown = Get-Trunc $label ([int]$Cfg.VL_NAME_MAX)
+                    $background = if ([string]::IsNullOrEmpty([string]$Cfg.VL_BG_SUB_NAME)) { $Cfg.VL_BG_DIR } else { $Cfg.VL_BG_SUB_NAME }
+                    Add-SubagentSegment $backgrounds $texts $background ($Bold + (Get-Fg $color) + ' ' + $shown + ' ' + $Norm)
+                    break
+                }
+                'model' {
+                    if ([string]::IsNullOrEmpty($fields.model)) { break }
+                    $background = if ([string]::IsNullOrEmpty([string]$Cfg.VL_BG_SUB_MODEL)) { $Cfg.VL_BG_MODEL } else { $Cfg.VL_BG_SUB_MODEL }
+                    Add-SubagentSegment $backgrounds $texts $background ($Bold + (Get-Fg $Cfg.VL_FG_TEXT) + ' ' + $G.Diamond + ' ' + (Get-SubagentModelShort $fields.model) + ' ' + $Norm)
+                    break
+                }
+                'ctx' {
+                    $token = 0L
+                    if (-not (Try-SubagentUnsigned $fields.tokenCount ([ref]$token))) { break }
+                    $tokenText = Format-Tok ($token.ToString($Invariant))
+                    $window = 0L
+                    $background = if ([string]::IsNullOrEmpty([string]$Cfg.VL_BG_SUB_CTX)) { $Cfg.VL_BG_CTX } else { $Cfg.VL_BG_SUB_CTX }
+                    if ((Try-SubagentUnsigned $fields.contextWindowSize ([ref]$window)) -and $window -gt 0) {
+                        $percentage = [long][Math]::Floor(($token * 100L) / $window)
+                        if ($percentage -gt 100) { $percentage = 100 }
+                        $bar = New-Bar ([int]$percentage) ([int]$Cfg.VL_BAR_WIDTH)
+                        Add-SubagentSegment $backgrounds $texts $background ((Get-Fg (Get-PctFg ([int]$percentage))) + ' ' + $Cfg.VL_CTX_GLYPH + ' ' + $bar + ' ' + $percentage + '% ' + (Get-Fg $Cfg.VL_FG_DIM) + $tokenText + ' ')
+                    } else {
+                        Add-SubagentSegment $backgrounds $texts $background ((Get-Fg $Cfg.VL_FG_DIM) + ' ' + $Cfg.VL_CTX_GLYPH + ' ' + $tokenText + ' ')
+                    }
+                    break
+                }
+                'elapsed' {
+                    if ([string]::IsNullOrEmpty($fields.startTime)) { break }
+                    $epoch = Get-SubagentEpoch $fields.startTime
+                    if ($null -eq $epoch -or $epoch -gt $now) { break }
+                    $background = if ([string]::IsNullOrEmpty([string]$Cfg.VL_BG_SUB_ELAPSED)) { $Cfg.VL_BG_DURATION } else { $Cfg.VL_BG_SUB_ELAPSED }
+                    Add-SubagentSegment $backgrounds $texts $background ((Get-Fg $Cfg.VL_FG_TEXT) + ' ' + [char]0x29D6 + ' ' + (Format-SubagentDuration ($now - [long]$epoch)) + ' ')
+                    break
+                }
+            }
+        }
+        if ($backgrounds.Count -eq 0) { continue }
+        $content = Render-SubagentSegments $backgrounds $texts
+        try { if ($StrictUtf8.GetByteCount($content) -gt 65536) { continue } } catch { continue }
+        $line = '{"id":' + (ConvertTo-StrictJsonString $id) + ',"content":' + (ConvertTo-StrictJsonString $content) + '}'
+        try { if (($StrictUtf8.GetByteCount($line) + 1) -gt 524288) { continue } } catch { continue }
+        [void]$lines.Add($line)
+    }
+    foreach ($line in $lines) { $OutputWriter.WriteLine($line) }
+}
+
+if ($SubagentMode) {
+    try { Invoke-SubagentMode $rawInput } catch { }
+    $OutputWriter.Flush()
+    $OutputWriter.Dispose()
+    exit 0
 }
 
 function ConvertTo-Epoch([string]$Raw) {

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -835,9 +835,20 @@ function Format-Tok([string]$Raw) {
     if ($Raw -notmatch '^[0-9]+$') { return $Raw }
     $n = 0L
     if (-not [long]::TryParse($Raw, $IntegerStyle, $Invariant, [ref]$n)) { return '0' }
-    if ($n -ge 1000000) { return ('{0}.{1}M' -f [math]::Floor($n / 1000000), [math]::Floor(($n % 1000000) / 100000)) }
-    if ($n -ge 1000) { return ('{0}.{1}k' -f [math]::Floor($n / 1000), [math]::Floor(($n % 1000) / 100)) }
-    return [string]$n
+    if ($n -ge 1000000) {
+        $scale = 1000000L
+        $tenthScale = 100000L
+        $suffix = 'M'
+    } elseif ($n -ge 1000) {
+        $scale = 1000L
+        $tenthScale = 100L
+        $suffix = 'k'
+    } else { return [string]$n }
+    $remainder = 0L
+    $whole = [Math]::DivRem($n, $scale, [ref]$remainder)
+    $unused = 0L
+    $tenth = [Math]::DivRem($remainder, $tenthScale, [ref]$unused)
+    return ('{0}.{1}{2}' -f $whole, $tenth, $suffix)
 }
 
 function Get-PctValue([string]$Raw, [ref]$Result) {

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -1518,7 +1518,8 @@ function Invoke-SubagentMode([string]$InputText) {
                     $window = 0L
                     $background = if ([string]::IsNullOrEmpty([string]$Cfg.VL_BG_SUB_CTX)) { $Cfg.VL_BG_CTX } else { $Cfg.VL_BG_SUB_CTX }
                     if ((Try-SubagentUnsigned $fields.contextWindowSize ([ref]$window)) -and $window -gt 0) {
-                        $percentage = [long][Math]::Floor(($token * 100L) / $window)
+                        $unused = 0L
+                        $percentage = [Math]::DivRem(($token * 100L), $window, [ref]$unused)
                         if ($percentage -gt 100) { $percentage = 100 }
                         $bar = New-Bar ([int]$percentage) ([int]$Cfg.VL_BAR_WIDTH)
                         Add-SubagentSegment $backgrounds $texts $background ((Get-Fg (Get-PctFg ([int]$percentage))) + ' ' + $Cfg.VL_CTX_GLYPH + ' ' + $bar + ' ' + $percentage + '% ' + (Get-Fg $Cfg.VL_FG_DIM) + $tokenText + ' ')

--- a/test/test-install-ps1.ps1
+++ b/test/test-install-ps1.ps1
@@ -15,7 +15,7 @@ $Installer = Join-Path $Repo 'install.ps1'
 $PowerShellExe = (Get-Process -Id $PID).Path
 $Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
 $StrictUtf8 = New-Object System.Text.UTF8Encoding($false, $true)
-$TempRoot = Join-Path ([IO.Path]::GetTempPath()) ('coralline install 測試 & (ps51)-' + [guid]::NewGuid().ToString('N'))
+$TempRoot = Join-Path ([IO.Path]::GetTempPath()) ('c 雪&(p)-' + [guid]::NewGuid().ToString('N'))
 $script:Pass = 0
 $script:Fail = 0
 $script:Blocked = 0
@@ -144,8 +144,13 @@ function Invoke-CapturedProcess(
     }
 }
 
-function Invoke-Installer([string]$Source, [string]$Install, [string]$Settings) {
-    $arguments = @(
+function Invoke-Installer(
+    [string]$Source,
+    [string]$Install,
+    [string]$Settings,
+    [string]$SubagentRows = ''
+) {
+    $argumentParts = @(
         '-NoLogo',
         '-NoProfile',
         '-NonInteractive',
@@ -154,7 +159,11 @@ function Invoke-Installer([string]$Source, [string]$Install, [string]$Settings) 
         '-SourceDirectory ' + (Quote-ProcessArgument $Source),
         '-InstallRoot ' + (Quote-ProcessArgument $Install),
         '-SettingsPath ' + (Quote-ProcessArgument $Settings)
-    ) -join ' '
+    )
+    if (-not [string]::IsNullOrEmpty($SubagentRows)) {
+        $argumentParts += '-SubagentRows ' + (Quote-ProcessArgument $SubagentRows)
+    }
+    $arguments = $argumentParts -join ' '
     $environment = @{
         CORALLINE_REPO = 'must-not-be-read'
         CORALLINE_REF = 'must-not-be-read'
@@ -212,6 +221,16 @@ function Get-DesiredValue([string]$Install) {
         ',"refreshInterval":1}'
 }
 
+function Get-DesiredSubagentCommand([string]$Install) {
+    return (Get-DesiredCommand $Install) + ' --subagent'
+}
+
+function Get-DesiredSubagentValue([string]$Install) {
+    return '{"type":"command","command":' +
+        (ConvertTo-TestJsonString (Get-DesiredSubagentCommand $Install)) +
+        '}'
+}
+
 function Get-FileSha256([string]$Path) {
     return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash
 }
@@ -260,12 +279,16 @@ function Get-BackupCount([string]$Directory, [string]$Pattern) {
     return @([IO.Directory]::GetFileSystemEntries($Directory, $Pattern)).Count
 }
 
-function Test-InvalidSettings([string]$Name, [string]$Text) {
+function Test-InvalidSettings(
+    [string]$Name,
+    [string]$Text,
+    [string]$SubagentRows = ''
+) {
     $paths = New-Paths ('invalid-' + $Name)
     [void][IO.Directory]::CreateDirectory($paths.Claude)
     Write-Utf8 $paths.Settings $Text
     $before = [IO.File]::ReadAllBytes($paths.Settings)
-    $run = Invoke-Installer $Repo $paths.Install $paths.Settings
+    $run = Invoke-Installer $Repo $paths.Install $paths.Settings $SubagentRows
     Check "$Name rejected" (-not $run.TimedOut -and $run.ExitCode -ne 0)
     Check "$Name settings unchanged" (
         [Convert]::ToBase64String($before) -ceq
@@ -378,6 +401,7 @@ try {
     )
 
     $desiredCommand = Get-DesiredCommand $main.Install
+    $desiredSubagentCommand = Get-DesiredSubagentCommand $main.Install
     $desiredValue = Get-DesiredValue $main.Install
     $settingsText = $StrictUtf8.GetString([IO.File]::ReadAllBytes($main.Settings))
     Check 'lossless raw settings merge' ($settingsText -ceq ($prefix + $desiredValue + $suffix))
@@ -396,6 +420,9 @@ try {
     Check 'settings command exact absolute trusted executable' ($managedObject.command -ceq $desiredCommand)
     Check 'settings command contains Bypass' ($managedObject.command.Contains('-ExecutionPolicy Bypass'))
     Check 'settings refreshInterval 1' ($managedObject.refreshInterval -eq 1)
+    Check 'ordinary install preserves missing subagent target' (
+        -not $settingsText.Contains('"subagentStatusLine"')
+    )
     Check 'config hash preserved' ((Get-FileSha256 $main.Config) -ceq $configHash)
 
     $preservedFiles = @(
@@ -515,6 +542,285 @@ try {
     Check 'fresh missing-settings install exit 0' ($noConfigRun.ExitCode -eq 0)
     Check 'installer never creates config' (-not [IO.File]::Exists($noConfig.Config))
     Check 'new settings has no backup' ((Get-BackupCount $noConfig.Claude 'settings.json.bak.*') -eq 0)
+    Check 'missing-settings default creates only main statusLine' (
+        $StrictUtf8.GetString([IO.File]::ReadAllBytes($noConfig.Settings)) -ceq
+        ('{"statusLine":' + (Get-DesiredValue $noConfig.Install) + '}')
+    )
+
+    $preserve = New-Paths 'subagent-preserve'
+    [void][IO.Directory]::CreateDirectory($preserve.Claude)
+    $preserveCustom = '{"owner":"user","refreshInterval":17}'
+    $preserveText = (
+        '{"statusLine":' + (Get-DesiredValue $preserve.Install) +
+        ',"subagentStatusLine":' + $preserveCustom +
+        ',"nested":{"subagentStatusLine":{"keep":"nested"}}}'
+    )
+    Write-Utf8 $preserve.Settings $preserveText
+    $preserveFirst = Invoke-Installer $Repo $preserve.Install $preserve.Settings
+    Check 'default preserve installs runtime' ($preserveFirst.ExitCode -eq 0)
+    Check 'default preserve keeps exact custom and nested subagent bytes' (
+        $StrictUtf8.GetString([IO.File]::ReadAllBytes($preserve.Settings)) -ceq $preserveText
+    )
+    Check 'runtime-only preserve creates no settings backup' (
+        (Get-BackupCount $preserve.Claude 'settings.json.bak.*') -eq 0
+    )
+    $preserveSnapshot = Get-ManagedSnapshot $preserve.Install $preserve.Settings
+    $preserveBackups = Get-BackupCount $preserve.Claude 'settings.json.bak.*'
+    Start-Sleep -Milliseconds 1200
+    $preserveSecond = Invoke-Installer (
+        $Repo
+    ) $preserve.Install $preserve.Settings 'preserve'
+    Check 'explicit preserve idempotent rerun reports no-op' (
+        $preserveSecond.ExitCode -eq 0 -and
+        $preserveSecond.Stdout -ceq "coralline is already up to date.`r`n"
+    )
+    Check 'explicit preserve rerun keeps settings and runtime timestamps' (
+        Test-SnapshotsEqual $preserveSnapshot (
+            Get-ManagedSnapshot $preserve.Install $preserve.Settings
+        )
+    )
+    Check 'explicit preserve rerun creates no backup' (
+        (Get-BackupCount $preserve.Claude 'settings.json.bak.*') -eq $preserveBackups
+    )
+
+    $variant = New-Paths 'subagent-case-variant'
+    [void][IO.Directory]::CreateDirectory($variant.Claude)
+    $variantText = (
+        '{"statusLine":' + (Get-DesiredValue $variant.Install) +
+        ',"SubagentStatus\u004cine":{"variant":"keep"},' +
+        '"nested":{"subagentStatusLine":{"keep":"nested"}}}'
+    )
+    Write-Utf8 $variant.Settings $variantText
+    $variantPreserve = Invoke-Installer (
+        $Repo
+    ) $variant.Install $variant.Settings 'preserve'
+    Check 'single decoded case variant preserve exit 0' ($variantPreserve.ExitCode -eq 0)
+    Check 'single decoded case variant preserve keeps exact bytes' (
+        $StrictUtf8.GetString([IO.File]::ReadAllBytes($variant.Settings)) -ceq $variantText
+    )
+    $variantOff = Invoke-Installer $Repo $variant.Install $variant.Settings 'off'
+    Check 'off ignores case variant and nested exact target' (
+        $variantOff.ExitCode -eq 0 -and
+        $variantOff.Stdout -ceq "coralline is already up to date.`r`n" -and
+        $StrictUtf8.GetString([IO.File]::ReadAllBytes($variant.Settings)) -ceq $variantText
+    )
+    $variantSnapshot = Get-ManagedSnapshot $variant.Install $variant.Settings
+    $variantBackups = Get-BackupCount $variant.Claude 'settings.json.bak.*'
+    $variantOn = Invoke-Installer $Repo $variant.Install $variant.Settings 'on'
+    Check 'on rejects a case variant instead of creating an ambiguous pair' (
+        $variantOn.ExitCode -ne 0 -and
+        $variantOn.Stderr.Contains('case-variant subagentStatusLine')
+    )
+    Check 'case-variant on rejection mutates no settings or runtime' (
+        Test-SnapshotsEqual $variantSnapshot (
+            Get-ManagedSnapshot $variant.Install $variant.Settings
+        )
+    )
+    Check 'case-variant on rejection creates no backup' (
+        (Get-BackupCount $variant.Claude 'settings.json.bak.*') -eq $variantBackups
+    )
+
+    $upperMode = New-Paths 'subagent-uppercase-mode'
+    $upperModeRun = Invoke-Installer (
+        $Repo
+    ) $upperMode.Install $upperMode.Settings 'ON'
+    Check 'SubagentRows values are exact lowercase' (
+        $upperModeRun.ExitCode -ne 0 -and
+        $upperModeRun.Stderr.Contains('SubagentRows')
+    )
+    Check 'invalid SubagentRows mode mutates nothing' (
+        -not [IO.Directory]::Exists($upperMode.Install) -and
+        -not [IO.File]::Exists($upperMode.Settings) -and
+        (Get-BackupCount $upperMode.Claude '*.bak.*') -eq 0
+    )
+
+    $onMissing = New-Paths 'subagent-on-missing-settings'
+    $onMissingRun = Invoke-Installer (
+        $Repo
+    ) $onMissing.Install $onMissing.Settings 'on'
+    $onMissingText = $StrictUtf8.GetString([IO.File]::ReadAllBytes($onMissing.Settings))
+    $onMissingExpected = (
+        '{"statusLine":' + (Get-DesiredValue $onMissing.Install) +
+        ',"subagentStatusLine":' + (Get-DesiredSubagentValue $onMissing.Install) + '}'
+    )
+    Check 'subagent on missing settings exit 0' ($onMissingRun.ExitCode -eq 0)
+    Check 'subagent on missing settings creates both managed members once' (
+        $onMissingText -ceq $onMissingExpected
+    )
+    $onMissingObject = $onMissingText | ConvertFrom-Json
+    $onMissingProperties = @(
+        $onMissingObject.PSObject.Properties |
+            Where-Object { $_.Name -ceq 'subagentStatusLine' }
+    )
+    $onMissingSubagent = $null
+    if ($onMissingProperties.Count -eq 1) {
+        $onMissingSubagent = $onMissingProperties[0].Value
+    }
+    $onMissingNames = @()
+    $onMissingCommand = ''
+    $onMissingType = ''
+    if ($null -ne $onMissingSubagent) {
+        $onMissingNames = @($onMissingSubagent.PSObject.Properties.Name | Sort-Object)
+        $onMissingCommand = [string]$onMissingSubagent.command
+        $onMissingType = [string]$onMissingSubagent.type
+    }
+    $expectedPowerShell = [IO.Path]::GetFullPath((Join-Path $PSHOME 'powershell.exe'))
+    $expectedRenderer = [IO.Path]::GetFullPath((Join-Path $onMissing.Install 'statusline.ps1'))
+    Check 'subagent command object has exactly type and command' (
+        ($onMissingNames -join ',') -ceq 'command,type' -and
+        $onMissingType -ceq 'command'
+    )
+    Check 'subagent command has no refreshInterval or extra properties' (
+        $onMissingNames.Count -eq 2 -and
+        -not ($onMissingNames -contains 'refreshInterval')
+    )
+    Check 'subagent command is exact native absolute command' (
+        $onMissingCommand -ceq (Get-DesiredSubagentCommand $onMissing.Install) -and
+        $onMissingCommand.StartsWith(
+            '"' + $expectedPowerShell + '" ',
+            [StringComparison]::Ordinal
+        ) -and
+        $onMissingCommand.Contains('-File "' + $expectedRenderer + '"')
+    )
+    Check 'subagent command appends literal --subagent' (
+        $onMissingCommand.EndsWith(' --subagent', [StringComparison]::Ordinal)
+    )
+    Check 'new settings with explicit on has no displaced-file backup' (
+        (Get-BackupCount $onMissing.Claude 'settings.json.bak.*') -eq 0
+    )
+    $onMissingSnapshot = Get-ManagedSnapshot $onMissing.Install $onMissing.Settings
+    $onMissingBackups = Get-BackupCount $onMissing.Claude 'settings.json.bak.*'
+    Start-Sleep -Milliseconds 1200
+    $onMissingSecond = Invoke-Installer (
+        $Repo
+    ) $onMissing.Install $onMissing.Settings 'on'
+    Check 'subagent on idempotent rerun reports no-op' (
+        $onMissingSecond.ExitCode -eq 0 -and
+        $onMissingSecond.Stdout -ceq "coralline is already up to date.`r`n"
+    )
+    Check 'subagent on idempotent rerun preserves timestamps' (
+        Test-SnapshotsEqual $onMissingSnapshot (
+            Get-ManagedSnapshot $onMissing.Install $onMissing.Settings
+        )
+    )
+    Check 'subagent on idempotent rerun creates no backup' (
+        (Get-BackupCount $onMissing.Claude 'settings.json.bak.*') -eq $onMissingBackups
+    )
+
+    $combined = New-Paths 'subagent-combined-plan'
+    [void][IO.Directory]::CreateDirectory($combined.Claude)
+    $combinedBefore = (
+        '{' + "`r`n" +
+        '  "statusLine": {"old":"main"},' + "`r`n" +
+        '  "subagentStatusLine": {"old":"sub","refreshInterval":88},' + "`r`n" +
+        '  "nested": {"subagentStatusLine":{"keep":true}}' + "`r`n" +
+        '}' + "`r`n"
+    )
+    Write-Utf8 $combined.Settings $combinedBefore
+    $combinedBeforeBytes = [IO.File]::ReadAllBytes($combined.Settings)
+    $combinedRun = Invoke-Installer $Repo $combined.Install $combined.Settings 'on'
+    $combinedExpected = (
+        '{' + "`r`n" +
+        '  "statusLine": ' + (Get-DesiredValue $combined.Install) + ',' + "`r`n" +
+        '  "subagentStatusLine": ' + (Get-DesiredSubagentValue $combined.Install) + ',' + "`r`n" +
+        '  "nested": {"subagentStatusLine":{"keep":true}}' + "`r`n" +
+        '}' + "`r`n"
+    )
+    $combinedBackups = @(
+        [IO.Directory]::GetFiles($combined.Claude, 'settings.json.bak.*')
+    )
+    Check 'combined main and subagent update exit 0' ($combinedRun.ExitCode -eq 0)
+    Check 'combined main and subagent values use one lossless plan' (
+        $StrictUtf8.GetString([IO.File]::ReadAllBytes($combined.Settings)) -ceq
+        $combinedExpected
+    )
+    Check 'combined settings change creates exactly one backup' ($combinedBackups.Count -eq 1)
+    Check 'combined settings backup contains both original values' (
+        $combinedBackups.Count -eq 1 -and
+        [Convert]::ToBase64String([IO.File]::ReadAllBytes($combinedBackups[0])) -ceq
+        [Convert]::ToBase64String($combinedBeforeBytes)
+    )
+
+    $offCases = @(
+        [pscustomobject]@{
+            Name = 'sole'
+            Before = "{`r`n  `"subagentStatusLine`" : {`"old`":1}`t`r`n}`n"
+            Expected = "{`r`n  `t`r`n`"statusLine`":__STATUS__}`n"
+        },
+        [pscustomobject]@{
+            Name = 'first'
+            Before = (
+                '{"subagentStatusLine":1 ' + "`t" + ',' + "`r`n" +
+                '  "keep":true,"statusLine":__STATUS__}'
+            )
+            Expected = "{`r`n  `"keep`":true,`"statusLine`":__STATUS__}"
+        },
+        [pscustomobject]@{
+            Name = 'middle'
+            Before = (
+                '{"keep":1, ' + "`r`n" +
+                '"subagentStatus\u004cine":2,' + "`t" + '"statusLine":__STATUS__}'
+            )
+            Expected = (
+                '{"keep":1, ' + "`r`n" + "`t" + '"statusLine":__STATUS__}'
+            )
+        },
+        [pscustomobject]@{
+            Name = 'last'
+            Before = (
+                '{"keep":1,"statusLine":__STATUS__ ' + "`t" + ',' + "`r`n" +
+                ' "subagentStatusLine":2 ' + "`r`n" + '}'
+            )
+            Expected = (
+                '{"keep":1,"statusLine":__STATUS__ ' + "`t" + ' ' + "`r`n" + '}'
+            )
+        }
+    )
+    foreach ($offCase in $offCases) {
+        $off = New-Paths ('subagent-off-' + $offCase.Name)
+        [void][IO.Directory]::CreateDirectory($off.Claude)
+        $caseDesired = Get-DesiredValue $off.Install
+        $caseBefore = ([string]$offCase.Before).Replace('__STATUS__', $caseDesired)
+        $caseExpected = ([string]$offCase.Expected).Replace('__STATUS__', $caseDesired)
+        Write-Utf8 $off.Settings $caseBefore
+        $caseRun = Invoke-Installer $Repo $off.Install $off.Settings 'off'
+        $caseActual = $StrictUtf8.GetString([IO.File]::ReadAllBytes($off.Settings))
+        $caseValid = $false
+        $caseExactAbsent = $false
+        try {
+            $caseObject = $caseActual | ConvertFrom-Json
+            $caseValid = $null -ne $caseObject
+            $caseExactAbsent = @(
+                $caseObject.PSObject.Properties |
+                    Where-Object { $_.Name -ceq 'subagentStatusLine' }
+            ).Count -eq 0
+        } catch {}
+        Check ('subagent off ' + $offCase.Name + ' exit 0') ($caseRun.ExitCode -eq 0)
+        Check ('subagent off ' + $offCase.Name + ' preserves lossless separators') (
+            $caseActual -ceq $caseExpected
+        )
+        Check ('subagent off ' + $offCase.Name + ' leaves valid JSON') (
+            $caseValid -and $caseExactAbsent
+        )
+        if ($offCase.Name -ceq 'last') {
+            $offSnapshot = Get-ManagedSnapshot $off.Install $off.Settings
+            $offBackups = Get-BackupCount $off.Claude 'settings.json.bak.*'
+            Start-Sleep -Milliseconds 1200
+            $offSecond = Invoke-Installer $Repo $off.Install $off.Settings 'off'
+            Check 'subagent off idempotent rerun reports no-op' (
+                $offSecond.ExitCode -eq 0 -and
+                $offSecond.Stdout -ceq "coralline is already up to date.`r`n"
+            )
+            Check 'subagent off idempotent rerun preserves timestamps' (
+                Test-SnapshotsEqual $offSnapshot (
+                    Get-ManagedSnapshot $off.Install $off.Settings
+                )
+            )
+            Check 'subagent off idempotent rerun creates no backup' (
+                (Get-BackupCount $off.Claude 'settings.json.bak.*') -eq $offBackups
+            )
+        }
+    }
 
     $expandedLimit = New-Paths 'expanded-settings-limit'
     $limitPrefix = '{"padding":"'
@@ -527,8 +833,10 @@ try {
     Write-Utf8 $expandedLimit.Settings $limitBuilder.ToString()
     [void]$limitBuilder.Clear()
     $expandedLimitHash = Get-FileSha256 $expandedLimit.Settings
-    $expandedLimitRun = Invoke-Installer $Repo $expandedLimit.Install $expandedLimit.Settings
-    Check 'post-merge settings size limit rejected' ($expandedLimitRun.ExitCode -ne 0)
+    $expandedLimitRun = Invoke-Installer (
+        $Repo
+    ) $expandedLimit.Install $expandedLimit.Settings 'on'
+    Check 'post-merge combined settings size limit rejected' ($expandedLimitRun.ExitCode -ne 0)
     Check 'post-merge size rejection preserves settings bytes' (
         (Get-FileSha256 $expandedLimit.Settings) -ceq $expandedLimitHash
     )
@@ -540,7 +848,10 @@ try {
     )
 
     $bom = New-Paths 'bom-settings'
-    Write-Utf8Bom $bom.Settings '{"keep":"雪","statusLine":null}'
+    $bomCustomSubagent = '{"custom":"保持","refreshInterval":17}'
+    Write-Utf8Bom $bom.Settings (
+        '{"keep":"雪","statusLine":null,"subagentStatusLine":' + $bomCustomSubagent + '}'
+    )
     $bomRun = Invoke-Installer $Repo $bom.Install $bom.Settings
     $bomBytes = [IO.File]::ReadAllBytes($bom.Settings)
     Check 'UTF-8 BOM settings install exit 0' ($bomRun.ExitCode -eq 0)
@@ -550,7 +861,10 @@ try {
     )
     Check 'UTF-8 BOM merge preserves unrelated content' (
         $StrictUtf8.GetString($bomBytes, 3, $bomBytes.Length - 3) -ceq
-        ('{"keep":"雪","statusLine":' + (Get-DesiredValue $bom.Install) + '}')
+        (
+            '{"keep":"雪","statusLine":' + (Get-DesiredValue $bom.Install) +
+            ',"subagentStatusLine":' + $bomCustomSubagent + '}'
+        )
     )
     $bomItem = Get-Item -LiteralPath $bom.Settings
     $bomSnapshot = (Get-FileSha256 $bom.Settings) + ':' + $bomItem.LastWriteTimeUtc.Ticks
@@ -569,10 +883,43 @@ try {
         (Get-BackupCount $bom.Claude 'settings.json.bak.*') -eq $bomBackups
     )
 
+    $bomOn = Invoke-Installer $Repo $bom.Install $bom.Settings 'on'
+    $bomOnBytes = [IO.File]::ReadAllBytes($bom.Settings)
+    Check 'UTF-8 BOM subagent on exit 0' ($bomOn.ExitCode -eq 0)
+    Check 'UTF-8 BOM retained for subagent on' (
+        $bomOnBytes[0] -eq 0xef -and $bomOnBytes[1] -eq 0xbb -and $bomOnBytes[2] -eq 0xbf
+    )
+    Check 'UTF-8 BOM subagent on replaces only exact target value' (
+        $StrictUtf8.GetString($bomOnBytes, 3, $bomOnBytes.Length - 3) -ceq
+        (
+            '{"keep":"雪","statusLine":' + (Get-DesiredValue $bom.Install) +
+            ',"subagentStatusLine":' + (Get-DesiredSubagentValue $bom.Install) + '}'
+        )
+    )
+    $bomOff = Invoke-Installer $Repo $bom.Install $bom.Settings 'off'
+    $bomOffBytes = [IO.File]::ReadAllBytes($bom.Settings)
+    Check 'UTF-8 BOM subagent off exit 0' ($bomOff.ExitCode -eq 0)
+    Check 'UTF-8 BOM retained for subagent off' (
+        $bomOffBytes[0] -eq 0xef -and $bomOffBytes[1] -eq 0xbb -and $bomOffBytes[2] -eq 0xbf
+    )
+    Check 'UTF-8 BOM subagent off removes only exact target member' (
+        $StrictUtf8.GetString($bomOffBytes, 3, $bomOffBytes.Length - 3) -ceq
+        ('{"keep":"雪","statusLine":' + (Get-DesiredValue $bom.Install) + '}')
+    )
+
     Test-InvalidSettings 'malformed' '{"x":'
     Test-InvalidSettings 'null-root' 'null'
     Test-InvalidSettings 'array-root' '[1,2,3]'
     Test-InvalidSettings 'duplicate-exact' '{"statusLine":1,"status\u004cine":2}'
+    Test-InvalidSettings (
+        'subagent-duplicate-exact'
+    ) '{"subagentStatusLine":1,"subagentStatus\u004cine":2}'
+    Test-InvalidSettings (
+        'subagent-case-collision'
+    ) '{"SubagentStatusLine":1,"subagentStatus\u004cine":2}'
+    Test-InvalidSettings (
+        'subagent-case-variant-on'
+    ) '{"SubagentStatus\u004cine":{"keep":true}}' 'on'
 
     . ([scriptblock]::Create((Get-InstallerTransactionFunctions)))
     $script:MaxSettingsBytes = 8MB
@@ -654,7 +1001,9 @@ try {
     $concurrentPlan = [pscustomobject]@{
         Existed = $true
         OriginalBytes = $plannedBytes
-        UpdatedBytes = $Utf8NoBom.GetBytes('{"value":"installer"}')
+        UpdatedBytes = $Utf8NoBom.GetBytes(
+            '{"statusLine":"installer","subagentStatusLine":"installer"}'
+        )
         Changed = $true
     }
     $concurrentBackup = Join-Path $concurrentRoot 'settings.json.bak'
@@ -668,7 +1017,7 @@ try {
     } catch {
         $concurrentRejected = $_.Exception.Message.Contains('before target mutation')
     }
-    Check 'pre-commit concurrent settings change rejected' $concurrentRejected
+    Check 'pre-commit concurrent combined settings change rejected' $concurrentRejected
     Check 'pre-commit concurrent settings bytes preserved' (
         [Convert]::ToBase64String([IO.File]::ReadAllBytes($concurrentSettings)) -ceq
         [Convert]::ToBase64String($concurrentBytes)
@@ -777,7 +1126,9 @@ try {
     $openHandleTemporary = Join-Path $openHandleRoot '.settings.json.tmp'
     $openHandleRestore = Join-Path $openHandleRoot '.settings.json.restore'
     $openHandleOriginal = $Utf8NoBom.GetBytes('{"value":"original"}')
-    $openHandleUpdated = $Utf8NoBom.GetBytes('{"value":"installer"}')
+    $openHandleUpdated = $Utf8NoBom.GetBytes(
+        '{"statusLine":"installer","subagentStatusLine":"installer"}'
+    )
     $openHandleExternal = $Utf8NoBom.GetBytes('{"value":"external-after-commit"}')
     [IO.File]::WriteAllBytes($openHandleSettings, $openHandleOriginal)
     $openHandlePlan = [pscustomobject]@{
@@ -811,7 +1162,7 @@ try {
         [Convert]::ToBase64String([IO.File]::ReadAllBytes($openHandleBackup)) -ceq
         [Convert]::ToBase64String($openHandleExternal)
     )
-    Check 'open settings handle leaves committed settings intact' (
+    Check 'open settings handle leaves combined committed settings intact' (
         [Convert]::ToBase64String([IO.File]::ReadAllBytes($openHandleSettings)) -ceq
         [Convert]::ToBase64String($openHandleUpdated)
     )
@@ -972,7 +1323,9 @@ try {
     )
 
     $settingsFinalPath = Join-Path $TempRoot 'settings-final-validation.json'
-    $settingsFinalExpected = $Utf8NoBom.GetBytes('{"value":"installer"}')
+    $settingsFinalExpected = $Utf8NoBom.GetBytes(
+        '{"statusLine":"installer","subagentStatusLine":"installer"}'
+    )
     $settingsFinalExternal = $Utf8NoBom.GetBytes('{"value":"external-before-success"}')
     [IO.File]::WriteAllBytes($settingsFinalPath, $settingsFinalExternal)
     $settingsFinalRejected = $false
@@ -983,8 +1336,8 @@ try {
     } catch {
         $settingsFinalRejected = $_.Exception.Message.Contains('changed concurrently')
     }
-    Check 'final settings byte validation rejects valid external content' $settingsFinalRejected
-    Check 'final settings byte validation preserves external content' (
+    Check 'final combined settings byte validation rejects valid external content' $settingsFinalRejected
+    Check 'final combined settings byte validation preserves external content' (
         [Convert]::ToBase64String([IO.File]::ReadAllBytes($settingsFinalPath)) -ceq
         [Convert]::ToBase64String($settingsFinalExternal)
     )
@@ -1113,6 +1466,14 @@ try {
         $null -ne $render.Stdout -and $render.StdoutBytes.Length -gt 0
     )
     Check 'registered command cmd.exe E2E no stderr' ($render.StderrBytes.Length -eq 0)
+    $subagentCmdArguments = '/d /s /c "' + $desiredSubagentCommand + '"'
+    $subagentRender = Invoke-CapturedProcess (
+        $env:ComSpec
+    ) $subagentCmdArguments $sample $renderEnvironment $fakeWorkspace 30000
+    Check 'subagent command cmd.exe E2E exit 0' ($subagentRender.ExitCode -eq 0)
+    Check 'subagent command cmd.exe E2E no stderr' (
+        $subagentRender.StderrBytes.Length -eq 0
+    )
     Check 'fake workspace executables never ran' (-not [IO.File]::Exists($marker))
     Check 'fake workspace executable untouched' (
         (Get-FileSha256 (Join-Path $fakeWorkspace 'powershell.exe')) -ceq $fakeExeHash
@@ -1130,7 +1491,10 @@ try {
         $Utf8NoBom
     )
     $runtimeBefore = Get-FileSha256 (Join-Path $rollback.Install 'themes\mono.conf')
-    $rollbackSettingsText = '{"keep":"original","statusLine":null}'
+    $rollbackSettingsText = (
+        '{"keep":"original","statusLine":null,' +
+        '"subagentStatusLine":{"custom":"original"}}'
+    )
     Write-Utf8 $rollback.Settings $rollbackSettingsText
     $rollbackSettingsBytes = [IO.File]::ReadAllBytes($rollback.Settings)
     $lock = [IO.File]::Open(
@@ -1140,7 +1504,9 @@ try {
         [IO.FileShare]::Read
     )
     try {
-        $rollbackRun = Invoke-Installer $rollbackSource $rollback.Install $rollback.Settings
+        $rollbackRun = Invoke-Installer (
+            $rollbackSource
+        ) $rollback.Install $rollback.Settings 'on'
     } finally {
         $lock.Dispose()
     }
@@ -1149,7 +1515,7 @@ try {
     Check 'settings failure restores previous runtime' (
         (Get-FileSha256 (Join-Path $rollback.Install 'themes\mono.conf')) -ceq $runtimeBefore
     )
-    Check 'settings failure leaves settings byte-identical' (
+    Check 'combined settings failure leaves both managed values byte-identical' (
         [Convert]::ToBase64String([IO.File]::ReadAllBytes($rollback.Settings)) -ceq
         [Convert]::ToBase64String($rollbackSettingsBytes)
     )
@@ -1180,7 +1546,7 @@ try {
         $canonicalTemp = [IO.Path]::GetFullPath($TempRoot)
         $canonicalSystemTemp = [IO.Path]::GetFullPath([IO.Path]::GetTempPath()).TrimEnd('\') + '\'
         if ($canonicalTemp.StartsWith($canonicalSystemTemp, [StringComparison]::OrdinalIgnoreCase) -and
-            [IO.Path]::GetFileName($canonicalTemp).StartsWith('coralline install 測試 & (ps51)-')) {
+            [IO.Path]::GetFileName($canonicalTemp).StartsWith('c 雪&(p)-')) {
             Remove-Item -LiteralPath $canonicalTemp -Recurse -Force
         } else {
             [Console]::Error.WriteLine("refusing unexpected test cleanup path: $canonicalTemp")

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -912,6 +912,7 @@ shell_quote "$CORALLINE_Q_VALUE"
     $ctxOnlyConfig = New-Config 'sub-ctx-only' @(('VL_SUB_SEGMENTS=' + (Quote-FromConfigure 'ctx')))
     foreach ($vector in @(
         [pscustomobject]@{ Name='floor'; Tok='1'; Win='3'; Show=$true; Needle='33%' },
+        [pscustomobject]@{ Name='large-exact-floor'; Tok='299999999999998'; Win='9999999999999934'; Show=$true; Needle='2%' },
         [pscustomobject]@{ Name='clamp'; Tok='9999999999999999'; Win='1'; Show=$true; Needle='100%' },
         [pscustomobject]@{ Name='zero-window'; Tok='1000'; Win='0'; Show=$true; Needle='1.0k' },
         [pscustomobject]@{ Name='invalid-window'; Tok='1000'; Win='10000000000000000'; Show=$true; Needle='1.0k' },

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -50,7 +50,8 @@ function Invoke-CapturedProcess(
     [string]$InputText,
     [hashtable]$Environment,
     [string]$WorkingDirectory,
-    [int]$TimeoutMs
+    [int]$TimeoutMs,
+    [byte[]]$InputBytes
 ) {
     $psi = New-Object System.Diagnostics.ProcessStartInfo
     $psi.FileName = $FileName
@@ -75,8 +76,8 @@ function Invoke-CapturedProcess(
         $stderr = New-Object System.IO.MemoryStream
         $outTask = $process.StandardOutput.BaseStream.CopyToAsync($stdout)
         $errTask = $process.StandardError.BaseStream.CopyToAsync($stderr)
-        $inputBytes = $Utf8NoBom.GetBytes($InputText)
-        if ($inputBytes.Length -gt 0) { $process.StandardInput.BaseStream.Write($inputBytes, 0, $inputBytes.Length) }
+        if ($null -eq $InputBytes) { $InputBytes = $Utf8NoBom.GetBytes($InputText) }
+        if ($InputBytes.Length -gt 0) { $process.StandardInput.BaseStream.Write($InputBytes, 0, $InputBytes.Length) }
         $process.StandardInput.Close()
         $timedOut = -not $process.WaitForExit($TimeoutMs)
         if ($timedOut) {
@@ -198,12 +199,60 @@ function Invoke-Statusline(
     return Invoke-CapturedProcess $PowerShellExe $psArgs $Json (Runtime-Environment $ConfigPath $ExtraEnvironment) $Repo $TimeoutMs
 }
 
+function Invoke-StatuslineBytes(
+    [byte[]]$Bytes,
+    [string]$ConfigPath,
+    [hashtable]$ExtraEnvironment,
+    [string]$Arguments,
+    [int]$TimeoutMs
+) {
+    $psArgs = '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + $Script + '"'
+    if (-not [string]::IsNullOrEmpty($Arguments)) { $psArgs += ' ' + $Arguments }
+    return Invoke-CapturedProcess $PowerShellExe $psArgs '' (Runtime-Environment $ConfigPath $ExtraEnvironment) $Repo $TimeoutMs $Bytes
+}
+
 function Invoke-BashStatusline([string]$Json, [string]$ConfigPath, [hashtable]$ExtraEnvironment) {
     $environment = Runtime-Environment $ConfigPath $ExtraEnvironment
     $runtimeScript = $BashScript
     if ($ExtraEnvironment.ContainsKey('CORALLINE_TEST_NOW') -and $null -ne $ExtraEnvironment.CORALLINE_TEST_NOW) { $runtimeScript = $script:StateBashScript }
     $args = '--noprofile --norc "' + (Forward-Path $runtimeScript) + '"'
     return Invoke-CapturedProcess $script:BashExe $args $Json $environment $Repo 10000
+}
+
+function Invoke-BashSubagent([string]$Json, [string]$ConfigPath, [hashtable]$ExtraEnvironment) {
+    $environment = Runtime-Environment $ConfigPath $ExtraEnvironment
+    $args = '--noprofile --norc "' + (Forward-Path $BashScript) + '" --subagent'
+    return Invoke-CapturedProcess $script:BashExe $args $Json $environment $Repo 10000
+}
+
+function Invoke-Subagent([string]$Json, [string]$ConfigPath, [hashtable]$ExtraEnvironment) {
+    return Invoke-Statusline $Json $ConfigPath $ExtraEnvironment '--subagent' 15000
+}
+
+function Get-SubagentRows($Run) {
+    $rows = New-Object 'System.Collections.Generic.List[object]'
+    if ([string]::IsNullOrEmpty($Run.Stdout)) { return }
+    foreach ($line in $Run.Stdout.Split(@("`n"), [System.StringSplitOptions]::RemoveEmptyEntries)) {
+        [void]$rows.Add(($line | ConvertFrom-Json -ErrorAction Stop))
+    }
+    return $rows.ToArray()
+}
+
+function New-SubagentNodePayload([int]$JunkCount) {
+    $builder = New-Object System.Text.StringBuilder
+    [void]$builder.Append('{"junk":[')
+    for ($i=0; $i -lt $JunkCount; $i++) {
+        if ($i -gt 0) { [void]$builder.Append(',') }
+        [void]$builder.Append('null')
+    }
+    [void]$builder.Append('],"tasks":[{"id":"node-cap","name":"node-cap"}]}')
+    return $builder.ToString()
+}
+
+function New-SubagentDepthPayload([int]$ArrayDepth) {
+    $open = (('[' * $ArrayDepth) -join '')
+    $close = ((']' * $ArrayDepth) -join '')
+    return '{"junk":' + $open + 'null' + $close + ',"tasks":[{"id":"depth-cap","name":"depth-cap"}]}'
 }
 
 function Check-Run([string]$Name, $Run) {
@@ -548,6 +597,9 @@ fi
     Check 'static source forbids Invoke-Expression' (-not $source.Contains('Invoke-Expression'))
     Check 'static source forbids dynamic ScriptBlock creation' (-not $source.Contains('ScriptBlock]::Create'))
     Check 'literal subagent route precedes stdin open' ($source.IndexOf("-ceq '--subagent'") -ge 0 -and $source.IndexOf("-ceq '--subagent'") -lt $source.IndexOf('OpenStandardInput'))
+    Check 'subagent byte cap precedes strict UTF-8 decode' ($source.IndexOf('$inputCap = 4194304') -ge 0 -and $source.IndexOf('$inputCap = 4194304') -lt $source.IndexOf('$StrictUtf8.GetString($inputBytes'))
+    Check 'subagent exits before main JSON parse and state paths' ($source.IndexOf('Invoke-SubagentMode $rawInput') -lt $source.IndexOf('ConvertFrom-Json -ErrorAction Stop') -and $source.IndexOf('Invoke-SubagentMode $rawInput') -lt $source.IndexOf('$AllStatePaths'))
+    Check 'subagent row and serialized-line caps are explicit' ($source.Contains('GetByteCount($content) -gt 65536') -and $source.Contains('GetByteCount($line) + 1) -gt 524288'))
     Check 'UNC lexical rejection precedes canonicalization' ($source.IndexOf("StartsWith('\\'") -ge 0 -and $source.IndexOf("StartsWith('\\'") -lt $source.IndexOf('GetFullPath($p)'))
     Check 'reparse validation precedes config read' ($source.IndexOf('Test-SafeRegularFile $Path') -lt $source.IndexOf('Read-StrictUtf8File $Path'))
     Check 'Bash oracle main extraction contains central scrub' ($bashSource.Contains('] | map(scrub) | join('))
@@ -668,6 +720,370 @@ fi
 eval "$(sed -n '/^shell_quote()/,/^}/p' "$CORALLINE_CONFIGURE")"
 shell_quote "$CORALLINE_Q_VALUE"
 '@
+
+    $subTask = [ordered]@{
+        id='row-1'
+        name='Builder'
+        label='Compile tests'
+        description='fallback detail'
+        type='local_agent'
+        status='running'
+        model='claude-haiku-4-5-20251001'
+        contextWindowSize='200000'
+        tokenCount='50000'
+    }
+    $subPayload = [ordered]@{ transcript_path=''; tasks=@($subTask) }
+    $subJson = Json $subPayload
+    $subDefault = Invoke-Subagent $subJson '' @{}
+    $subDefaultBash = Invoke-BashSubagent $subJson '' @{}
+    Check-Run 'WIN-PS1 subagent default' $subDefault
+    Check-Run 'WIN-PS1 Bash subagent default oracle' $subDefaultBash
+    Check-Exact 'WIN-PS1 default subagent row is byte exact to Bash' $subDefault $subDefaultBash
+    $subRows = @(Get-SubagentRows $subDefault)
+    Check 'WIN-PS1 compact row parses with exact id/content members' ($subRows.Count -eq 1 -and $subRows[0].id -ceq 'row-1' -and $subRows[0].content.Contains('Builder') -and $subRows[0].content.Contains('Haiku 4.5') -and $subRows[0].content.Contains('25%'))
+    Check 'WIN-PS1 row stdout is LF UTF-8 without BOM' ($subDefault.StdoutBytes.Length -gt 0 -and $subDefault.StdoutBytes[$subDefault.StdoutBytes.Length - 1] -eq 10 -and -not ($subDefault.StdoutBytes[0] -eq 0xEF -and $subDefault.StdoutBytes[1] -eq 0xBB -and $subDefault.StdoutBytes[2] -eq 0xBF))
+
+    foreach ($theme in @(Get-ChildItem -LiteralPath (Join-Path $Repo 'themes') -Filter '*.conf' -File | Sort-Object Name)) {
+        $themeConfig = New-Config ('sub-theme-' + $theme.BaseName) @(
+            ('. ' + (Quote-FromConfigure (Forward-Path $theme.FullName))),
+            ('VL_SUB_SEGMENTS=' + (Quote-FromConfigure 'name model ctx'))
+        )
+        $themePs = Invoke-Subagent $subJson $themeConfig @{}
+        $themeBash = Invoke-BashSubagent $subJson $themeConfig @{}
+        Check-Run ('WIN-PS1 theme ' + $theme.BaseName) $themePs
+        Check-Exact ('WIN-PS1 theme parity ' + $theme.BaseName) $themePs $themeBash
+    }
+
+    $themePath = Forward-Path (Join-Path $Repo 'themes\claude-coral.conf')
+    $subStyleCases = @(
+        [pscustomobject]@{ Name='ascii'; Lines=@('VL_ASCII=1') },
+        [pscustomobject]@{ Name='classic'; Lines=@('VL_STYLE=classic') },
+        [pscustomobject]@{ Name='bare-lean'; Lines=@('VL_STYLE=lean') },
+        [pscustomobject]@{ Name='fingerprint-retint'; Lines=@('VL_FG_OK=0,0,0') },
+        [pscustomobject]@{ Name='explicit-empty-name'; Lines=@("VL_BG_SUB_NAME=''") },
+        [pscustomobject]@{ Name='explicit-empty-ok'; Lines=@("VL_FG_SUB_OK=''"; 'VL_STYLE=classic') },
+        [pscustomobject]@{ Name='custom-order'; Lines=@(('VL_SUB_SEGMENTS=' + (Quote-FromConfigure 'ctx name model'))) }
+    )
+    foreach ($styleCase in $subStyleCases) {
+        $lines = @(('. ' + (Quote-FromConfigure $themePath))) + $styleCase.Lines
+        $config = New-Config ('sub-style-' + $styleCase.Name) $lines
+        $psRun = Invoke-Subagent $subJson $config @{}
+        $bashRun = Invoke-BashSubagent $subJson $config @{}
+        Check-Run ('WIN-PS1 style gate ' + $styleCase.Name) $psRun
+        Check-Exact ('WIN-PS1 style gate parity ' + $styleCase.Name) $psRun $bashRun
+    }
+
+    $nameOnlyConfig = New-Config 'sub-name-only' @(('VL_SUB_SEGMENTS=' + (Quote-FromConfigure 'name')))
+    $oldDoc = '{"tasks":[{"id":"old","name":"old"}]}'
+    $newDoc = '{"tasks":[{"id":"new","name":"new"}]}'
+    foreach ($validStream in @($oldDoc + $newDoc, $oldDoc + " `t`r`n" + $newDoc)) {
+        $run = Invoke-Subagent $validStream $nameOnlyConfig @{}
+        Check-Run 'WIN-PS1 valid concatenated stream' $run
+        $rows = @(Get-SubagentRows $run)
+        Check 'WIN-PS1 renders only the last complete JSON value' ($rows.Count -eq 1 -and $rows[0].id -ceq 'new')
+    }
+    $invalidStreams = @(
+        'x' + $newDoc,
+        $oldDoc + 'x' + $newDoc,
+        $newDoc + 'x',
+        '{"tasks":[',
+        $oldDoc + [char]12 + $newDoc,
+        $oldDoc + [char]11 + $newDoc,
+        $oldDoc + [char]0 + $newDoc,
+        '{"tasks":[],"tasks":[]}',
+        '{"tasks":[],"Tasks":[]}',
+        '{"tasks":[],"\u0074asks":[]}',
+        '{"tasks":[],"nested":{"id":1,"ID":2}}',
+        '{"tasks":[{"id":"x","id":"y"}]}'
+    )
+    $invalidIndex = 0
+    foreach ($invalidStream in $invalidStreams) {
+        $run = Invoke-Subagent $invalidStream $nameOnlyConfig @{}
+        Check-Run ('WIN-PS1 rejected stream ' + $invalidIndex) $run
+        Check ('WIN-PS1 rejected stream is silent ' + $invalidIndex) ($run.StdoutBytes.Length -eq 0)
+        $invalidIndex++
+    }
+    foreach ($noTasks in @('{"Tasks":[{"id":"x","name":"x"}]}','{"tasks":{}}','{"tasks":null}','[]','true')) {
+        $run = Invoke-Subagent $noTasks $nameOnlyConfig @{}
+        Check-Run 'WIN-PS1 exact tasks array gate' $run
+        Check 'WIN-PS1 non-array or case-variant tasks is silent' ($run.StdoutBytes.Length -eq 0)
+    }
+    $nodeCap = Invoke-Subagent (New-SubagentNodePayload 32762) $nameOnlyConfig @{}
+    Check-Run 'WIN-PS1 32768-node boundary' $nodeCap
+    Check 'WIN-PS1 32768 nodes retain the valid task' (@(Get-SubagentRows $nodeCap).Count -eq 1)
+    $nodeOver = Invoke-Subagent (New-SubagentNodePayload 32763) $nameOnlyConfig @{}
+    Check-Run 'WIN-PS1 32769-node boundary' $nodeOver
+    Check 'WIN-PS1 32769 nodes reject the entire input' ($nodeOver.StdoutBytes.Length -eq 0)
+    $depthCap = Invoke-Subagent (New-SubagentDepthPayload 127) $nameOnlyConfig @{}
+    Check-Run 'WIN-PS1 128-level nesting boundary' $depthCap
+    Check 'WIN-PS1 128-level nesting retains the valid task' (@(Get-SubagentRows $depthCap).Count -eq 1)
+    $depthOver = Invoke-Subagent (New-SubagentDepthPayload 128) $nameOnlyConfig @{}
+    Check-Run 'WIN-PS1 129-level nesting boundary' $depthOver
+    Check 'WIN-PS1 129-level nesting rejects the entire input' ($depthOver.StdoutBytes.Length -eq 0)
+    $mixedTasks = Invoke-Subagent '{"tasks":[null,1,[],{"id":"kept","name":"kept"},{}]}' $nameOnlyConfig @{}
+    Check-Run 'WIN-PS1 skips non-object tasks' $mixedTasks
+    Check 'WIN-PS1 non-object tasks leave the valid row' (@(Get-SubagentRows $mixedTasks).Count -eq 1)
+
+    $taskBuilder = New-Object System.Text.StringBuilder
+    [void]$taskBuilder.Append('{"tasks":[')
+    for ($i=0; $i -lt 1024; $i++) {
+        if ($i -gt 0) { [void]$taskBuilder.Append(',') }
+        [void]$taskBuilder.Append('{"id":"t')
+        [void]$taskBuilder.Append($i)
+        [void]$taskBuilder.Append('","name":"n"}')
+    }
+    [void]$taskBuilder.Append(']}')
+    $taskCap = Invoke-Subagent $taskBuilder.ToString() $nameOnlyConfig @{}
+    Check-Run 'WIN-PS1 1024-task boundary' $taskCap
+    Check 'WIN-PS1 1024 tasks render 1024 rows' (@(Get-SubagentRows $taskCap).Count -eq 1024)
+    [void]$taskBuilder.Remove($taskBuilder.Length - 2, 2)
+    [void]$taskBuilder.Append(',{"id":"over","name":"over"}]}')
+    $taskOver = Invoke-Subagent $taskBuilder.ToString() $nameOnlyConfig @{}
+    Check-Run 'WIN-PS1 1025-task boundary' $taskOver
+    Check 'WIN-PS1 1025 tasks reject the entire input' ($taskOver.StdoutBytes.Length -eq 0)
+
+    foreach ($fieldName in @('id','name','label','description','type','status','startTime','model','contextWindowSize','tokenCount')) {
+        foreach ($composite in @('{}','[]')) {
+            if ($fieldName -ceq 'id') { $raw = '{"tasks":[{"id":' + $composite + ',"name":"fallback"}]}' }
+            elseif ($fieldName -ceq 'name') { $raw = '{"tasks":[{"id":"scalar-test","name":' + $composite + ',"type":"fallback"}]}' }
+            else { $raw = '{"tasks":[{"id":"scalar-test","name":"fallback","' + $fieldName + '":' + $composite + '}]}' }
+            $run = Invoke-Subagent $raw $nameOnlyConfig @{}
+            Check-Run ('WIN-PS1 composite field ' + $fieldName) $run
+            if ($fieldName -ceq 'id') { Check ('WIN-PS1 composite id suppresses row ' + $composite) ($run.StdoutBytes.Length -eq 0) }
+            else { Check ('WIN-PS1 composite field degrades empty ' + $fieldName + $composite) (@(Get-SubagentRows $run).Count -eq 1) }
+        }
+    }
+    foreach ($compositeTranscript in @('{"transcript_path":{},"tasks":[{"id":"x","name":"x"}]}','{"transcript_path":[],"tasks":[{"id":"x","name":"x"}]}')) {
+        $run = Invoke-Subagent $compositeTranscript $nameOnlyConfig @{}
+        Check-Run 'WIN-PS1 composite transcript path' $run
+        Check 'WIN-PS1 composite transcript path only disables sidecar' (@(Get-SubagentRows $run).Count -eq 1)
+    }
+    foreach ($scalarCase in @(
+        [pscustomobject]@{ Raw='{"tasks":[{"id":7,"name":12}]}' ; Id='7'; Label='12' },
+        [pscustomobject]@{ Raw='{"tasks":[{"id":true,"name":false}]}' ; Id='true'; Label='false' },
+        [pscustomobject]@{ Raw='{"tasks":[{"id":"null-name","name":null,"type":"fallback"}]}' ; Id='null-name'; Label='fallback' }
+    )) {
+        $run = Invoke-Subagent $scalarCase.Raw $nameOnlyConfig @{}
+        Check-Run 'WIN-PS1 invariant scalar conversion' $run
+        $rows = @(Get-SubagentRows $run)
+        Check 'WIN-PS1 invariant scalar id and label' ($rows.Count -eq 1 -and $rows[0].id -ceq $scalarCase.Id -and (Plain $rows[0].content).Contains($scalarCase.Label))
+    }
+    $numberCanonicalRaw = '{"tasks":[{"id":1e999,"name":1e999},{"id":1e-999,"name":1e-999},{"id":123e999,"name":123e999},{"id":1.2300e999,"name":1.2300e999},{"id":1e1,"name":1e1},{"id":1.20e2,"name":1.20e2},{"id":0e-7,"name":0e-7},{"id":999999999999999999999999,"name":999999999999999999999999},{"id":12e999999998,"name":12e999999998},{"id":12e999999999,"name":12e999999999},{"id":-1e1000000000,"name":-1e1000000000},{"id":0e1000000000,"name":0e1000000000},{"id":1e-1147483646,"name":1e-1147483646},{"id":4e-1147483647,"name":4e-1147483647},{"id":5e-1147483647,"name":5e-1147483647},{"id":-5e-1147483647,"name":-5e-1147483647},{"id":1.5e-1147483646,"name":1.5e-1147483646},{"id":9.5e-1147483646,"name":9.5e-1147483646},{"id":0e-2000000000,"name":0e-2000000000}]}'
+    $numberCanonicalPs = Invoke-Subagent $numberCanonicalRaw $nameOnlyConfig @{}
+    $numberCanonicalBash = Invoke-BashSubagent $numberCanonicalRaw $nameOnlyConfig @{}
+    Check-Run 'WIN-PS1 exact decimal canonicalization' $numberCanonicalPs
+    Check-Run 'WIN-PS1 Bash exact decimal canonicalization oracle' $numberCanonicalBash
+    Check-Exact 'WIN-PS1 exact decimal canonicalization parity' $numberCanonicalPs $numberCanonicalBash
+    $numberCanonicalRows = @(Get-SubagentRows $numberCanonicalPs)
+    $numberCanonicalExpected = @('1E+999','1E-999','1.23E+1001','1.2300E+999','1E+1','120','0E-7','999999999999999999999999','1.2E+999999999','1.7976931348623157e+308','-1.7976931348623157e+308','0E+999999999','1E-1147483646','0E-1147483646','1E-1147483646','-1E-1147483646','2E-1147483646','1.0E-1147483645','0E-1147483646')
+    Check 'WIN-PS1 exact decimal canonicalization row count' ($numberCanonicalRows.Count -eq $numberCanonicalExpected.Count)
+    for ($i=0; $i -lt $numberCanonicalExpected.Count -and $i -lt $numberCanonicalRows.Count; $i++) {
+        Check ('WIN-PS1 exact decimal canonicalization ' + $i) ($numberCanonicalRows[$i].id -ceq $numberCanonicalExpected[$i] -and (Plain $numberCanonicalRows[$i].content).Contains($numberCanonicalExpected[$i]))
+    }
+
+    $escapedRaw = '{"tasks":[{"id":"quote\"\\id","name":"quote\" slash\\ esc\u001b[2J","status":true}]}'
+    $escapedRun = Invoke-Subagent $escapedRaw $nameOnlyConfig @{}
+    Check-Run 'WIN-PS1 quote backslash and ESC scrub' $escapedRun
+    $escapedRows = @(Get-SubagentRows $escapedRun)
+    Check 'WIN-PS1 JSON quoting round-trips id and label' ($escapedRows.Count -eq 1 -and $escapedRows[0].id -ceq "quote`"\id" -and (Plain $escapedRows[0].content).Contains("quote`" slash\ esc[2J"))
+    Check 'WIN-PS1 untrusted ESC cannot survive as CSI' (-not $escapedRows[0].content.Contains(([string][char]27 + '[2J')))
+
+    $asciiExact = 'a' * 16384
+    $asciiOver = $asciiExact + 'b'
+    $multiExact = ((Glyph 0x96EA) * 5461) + 'a'
+    $multiOver = $multiExact + 'b'
+    foreach ($boundary in @(
+        [pscustomobject]@{ Name='name-ascii'; Value=$asciiExact; Accepted=$true; Field='name' },
+        [pscustomobject]@{ Name='name-ascii-over'; Value=$asciiOver; Accepted=$false; Field='name' },
+        [pscustomobject]@{ Name='name-multibyte'; Value=$multiExact; Accepted=$true; Field='name' },
+        [pscustomobject]@{ Name='name-multibyte-over'; Value=$multiOver; Accepted=$false; Field='name' },
+        [pscustomobject]@{ Name='id-ascii'; Value=$asciiExact; Accepted=$true; Field='id' },
+        [pscustomobject]@{ Name='id-ascii-over'; Value=$asciiOver; Accepted=$false; Field='id' },
+        [pscustomobject]@{ Name='id-multibyte'; Value=$multiExact; Accepted=$true; Field='id' },
+        [pscustomobject]@{ Name='id-multibyte-over'; Value=$multiOver; Accepted=$false; Field='id' }
+    )) {
+        if ($boundary.Field -ceq 'id') { $payload = [ordered]@{ tasks=@([ordered]@{ id=$boundary.Value; name='n' }) } }
+        else { $payload = [ordered]@{ tasks=@([ordered]@{ id='field-bound'; name=$boundary.Value }) } }
+        $run = Invoke-Subagent (Json $payload) $nameOnlyConfig @{}
+        Check-Run ('WIN-PS1 field byte boundary ' + $boundary.Name) $run
+        Check ('WIN-PS1 field boundary acceptance ' + $boundary.Name) ((@((Get-SubagentRows $run)).Count -eq 1) -eq $boundary.Accepted)
+    }
+
+    $ctxOnlyConfig = New-Config 'sub-ctx-only' @(('VL_SUB_SEGMENTS=' + (Quote-FromConfigure 'ctx')))
+    foreach ($vector in @(
+        [pscustomobject]@{ Name='floor'; Tok='1'; Win='3'; Show=$true; Needle='33%' },
+        [pscustomobject]@{ Name='clamp'; Tok='9999999999999999'; Win='1'; Show=$true; Needle='100%' },
+        [pscustomobject]@{ Name='zero-window'; Tok='1000'; Win='0'; Show=$true; Needle='1.0k' },
+        [pscustomobject]@{ Name='invalid-window'; Tok='1000'; Win='10000000000000000'; Show=$true; Needle='1.0k' },
+        [pscustomobject]@{ Name='invalid-token'; Tok='10000000000000000'; Win='1'; Show=$false; Needle='' },
+        [pscustomobject]@{ Name='signed-token'; Tok='-1'; Win='3'; Show=$false; Needle='' }
+    )) {
+        $payload = [ordered]@{ tasks=@([ordered]@{ id=$vector.Name; tokenCount=$vector.Tok; contextWindowSize=$vector.Win }) }
+        $run = Invoke-Subagent (Json $payload) $ctxOnlyConfig @{}
+        Check-Run ('WIN-PS1 ctx numeric ' + $vector.Name) $run
+        $shown = @(Get-SubagentRows $run)
+        Check ('WIN-PS1 ctx numeric semantics ' + $vector.Name) (($shown.Count -eq 1) -eq $vector.Show)
+        if ($vector.Show) { Check ('WIN-PS1 ctx text ' + $vector.Name) ((Plain $shown[0].content).Contains($vector.Needle)) }
+    }
+    $numericCtx = Invoke-Subagent '{"tasks":[{"id":"numeric","tokenCount":1000,"contextWindowSize":2000}]}' $ctxOnlyConfig @{}
+    Check-Run 'WIN-PS1 numeric JSON context scalars' $numericCtx
+    Check 'WIN-PS1 numeric JSON context scalars use invariant digits' ((Plain (@(Get-SubagentRows $numericCtx)[0].content)).Contains('50%'))
+
+    $elapsedOnlyConfig = New-Config 'sub-elapsed-only' @(('VL_SUB_SEGMENTS=' + (Quote-FromConfigure 'elapsed')))
+    $epochNow = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    $fractionAtFieldCap = '1970-01-01T00:00:00.' + (('0' * 16363) -join '') + 'Z'
+    $fractionOverFieldCap = '1970-01-01T00:00:00.' + (('0' * 16364) -join '') + 'Z'
+    $elapsedVectors = @(
+        [pscustomobject]@{ Name='seconds'; Value=[string]($epochNow - 65); Show=$true },
+        [pscustomobject]@{ Name='milliseconds'; Value=[string](($epochNow - 65) * 1000); Show=$true },
+        [pscustomobject]@{ Name='iso'; Value=[DateTimeOffset]::FromUnixTimeSeconds($epochNow - 65).UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", $Invariant); Show=$true },
+        [pscustomobject]@{ Name='iso-year-zero'; Value='0000-01-01T00:00:00Z'; Show=$true },
+        [pscustomobject]@{ Name='iso-year-zero-leap-day'; Value='0000-02-29T00:00:00Z'; Show=$true },
+        [pscustomobject]@{ Name='iso-year-zero-bad-date'; Value='0000-02-30T00:00:00Z'; Show=$false },
+        [pscustomobject]@{ Name='iso-before-epoch'; Value='1969-12-31T23:59:59Z'; Show=$true },
+        [pscustomobject]@{ Name='iso-at-epoch'; Value='1970-01-01T00:00:00Z'; Show=$true },
+        [pscustomobject]@{ Name='iso-fraction-pre-epoch'; Value='1969-12-31T23:59:59.1Z'; Show=$true },
+        [pscustomobject]@{ Name='iso-fraction-year-zero'; Value='0000-02-29T00:00:00.123456789Z'; Show=$true },
+        [pscustomobject]@{ Name='iso-fraction-field-cap'; Value=$fractionAtFieldCap; Show=$true },
+        [pscustomobject]@{ Name='iso-fraction-over-field-cap'; Value=$fractionOverFieldCap; Show=$false },
+        [pscustomobject]@{ Name='iso-fraction-empty'; Value='2000-01-01T00:00:00.Z'; Show=$false },
+        [pscustomobject]@{ Name='iso-fraction-double-dot'; Value='2000-01-01T00:00:00.1.2Z'; Show=$false },
+        [pscustomobject]@{ Name='iso-fraction-nondigit'; Value='2000-01-01T00:00:00.12xZ'; Show=$false },
+        [pscustomobject]@{ Name='iso-fraction-offset'; Value='2000-01-01T00:00:00.123+00:00'; Show=$false },
+        [pscustomobject]@{ Name='iso-fraction-no-z'; Value='2000-01-01T00:00:00.123'; Show=$false },
+        [pscustomobject]@{ Name='iso-lowercase-t'; Value='2000-01-01t00:00:00Z'; Show=$false },
+        [pscustomobject]@{ Name='iso-lowercase-z'; Value='2000-01-01T00:00:00z'; Show=$false },
+        [pscustomobject]@{ Name='future'; Value=[string]($epochNow + 3600); Show=$false },
+        [pscustomobject]@{ Name='overflow'; Value='9999999999999999'; Show=$false },
+        [pscustomobject]@{ Name='too-many-digits'; Value='10000000000000000'; Show=$false },
+        [pscustomobject]@{ Name='bad-date'; Value='2026-02-30T00:00:00Z'; Show=$false }
+    )
+    foreach ($vector in $elapsedVectors) {
+        $run = Invoke-Subagent (Json ([ordered]@{ tasks=@([ordered]@{ id=$vector.Name; startTime=$vector.Value }) })) $elapsedOnlyConfig @{}
+        Check-Run ('WIN-PS1 elapsed ' + $vector.Name) $run
+        Check ('WIN-PS1 elapsed semantics ' + $vector.Name) ((@((Get-SubagentRows $run)).Count -eq 1) -eq $vector.Show)
+    }
+
+    $emptyTasksText = '{"tasks":[]}'
+    $exactCapBytes = $Utf8NoBom.GetBytes((' ' * (4194304 - $emptyTasksText.Length)) + $emptyTasksText)
+    $exactCapRun = Invoke-StatuslineBytes $exactCapBytes $nameOnlyConfig @{} '--subagent' 30000
+    Check-Run 'WIN-PS1 stdin exact 4194304 bytes' $exactCapRun
+    Check 'WIN-PS1 stdin exact cap is accepted silently' ($exactCapRun.StdoutBytes.Length -eq 0)
+    $overCapBytes = New-Object byte[] 4194305
+    [Array]::Copy($exactCapBytes, $overCapBytes, $exactCapBytes.Length)
+    $overCapBytes[$overCapBytes.Length - 1] = 0x20
+    $overCapRun = Invoke-StatuslineBytes $overCapBytes $nameOnlyConfig @{} '--subagent' 30000
+    Check-Run 'WIN-PS1 stdin cap plus one' $overCapRun
+    Check 'WIN-PS1 stdin cap plus one is silent' ($overCapRun.StdoutBytes.Length -eq 0)
+    $badUtf8Run = Invoke-StatuslineBytes ([byte[]]@(0x7B,0x22,0xC3,0x28,0x22,0x3A,0x31,0x7D)) $nameOnlyConfig @{} '--subagent' 5000
+    Check-Run 'WIN-PS1 malformed UTF-8 stdin' $badUtf8Run
+    Check 'WIN-PS1 malformed UTF-8 stdin is silent' ($badUtf8Run.StdoutBytes.Length -eq 0)
+
+    $contentExactConfig = New-Config 'sub-content-exact' @(
+        ('VL_SUB_SEGMENTS=' + (Quote-FromConfigure 'name')),
+        'VL_NOCOLOR=1',
+        ("VL_CAP_L='" + (('x' * 65512) -join '') + "'"),
+        "VL_CAP_R=''"
+    )
+    $contentExactRun = Invoke-Subagent '{"tasks":[{"id":"content-exact","name":"x"}]}' $contentExactConfig @{}
+    Check-Run 'WIN-PS1 content exact 65536 bytes' $contentExactRun
+    $contentExactRows = @(Get-SubagentRows $contentExactRun)
+    Check 'WIN-PS1 content exact cap renders untruncated' ($contentExactRows.Count -eq 1 -and $StrictUtf8.GetByteCount([string]$contentExactRows[0].content) -eq 65536)
+    $contentOverConfig = New-Config 'sub-content-over' @(
+        ('VL_SUB_SEGMENTS=' + (Quote-FromConfigure 'name')),
+        'VL_NOCOLOR=1',
+        ("VL_CAP_L='" + (('x' * 65513) -join '') + "'"),
+        "VL_CAP_R=''"
+    )
+    $contentOverRun = Invoke-Subagent '{"tasks":[{"id":"content-over","name":"x"}]}' $contentOverConfig @{}
+    Check-Run 'WIN-PS1 content cap plus one' $contentOverRun
+    Check 'WIN-PS1 content cap plus one suppresses row' ($contentOverRun.StdoutBytes.Length -eq 0)
+
+    $sidecarRoot = Join-Path $TempRoot 'subagent-sidecar'
+    [void][IO.Directory]::CreateDirectory($sidecarRoot)
+    $transcript = Join-Path $sidecarRoot 'session.jsonl'
+    Write-Utf8 $transcript ''
+    $sidecarDir = Join-Path $sidecarRoot 'session\subagents'
+    [void][IO.Directory]::CreateDirectory($sidecarDir)
+    $sidecar = Join-Path $sidecarDir 'agent-side.meta.json'
+    Write-Utf8 $sidecar '{"agentType":"Explore"}'
+    $sidePayload = [ordered]@{ transcript_path=(Forward-Path $transcript); tasks=@([ordered]@{ id='side'; name='Payload'; type='local_agent' }) }
+    $sideRun = Invoke-Subagent (Json $sidePayload) $nameOnlyConfig @{}
+    Check-Run 'WIN-PS1 sidecar positive' $sideRun
+    Check 'WIN-PS1 sidecar formula adds role beside payload name' ((Plain (@(Get-SubagentRows $sideRun)[0].content)).Contains('Payload (Explore)'))
+    foreach ($separatorPath in @((Forward-Path $transcript), $transcript)) {
+        $sidePayload.transcript_path = $separatorPath
+        $run = Invoke-Subagent (Json $sidePayload) $nameOnlyConfig @{}
+        Check 'WIN-PS1 sidecar accepts native and forward separators' ((Plain (@(Get-SubagentRows $run)[0].content)).Contains('Explore'))
+    }
+    foreach ($unsafeId in @('side:ads','side/slash','side\slash')) {
+        $sidePayload.tasks[0].id = $unsafeId
+        $run = Invoke-Subagent (Json $sidePayload) $nameOnlyConfig @{}
+        Check 'WIN-PS1 unsafe sidecar id keeps row but not metadata' (@(Get-SubagentRows $run).Count -eq 1 -and -not (Plain (@(Get-SubagentRows $run)[0].content)).Contains('Explore'))
+    }
+    $sidePayload.tasks[0].id = 'side'
+    $fallbackCases = @(
+        '\\server\share\session.jsonl',
+        '\\?\C:\session.jsonl',
+        'Registry::HKEY_CURRENT_USER\session.jsonl',
+        'C:\bad..\session.jsonl',
+        'C:\CON\session.jsonl',
+        'C:\carrier:stream.jsonl',
+        ('C:\' + ('x' * 4090) + '.jsonl'),
+        ((Split-Path -Path $transcript -Parent) + '\child\..\session.jsonl')
+    )
+    foreach ($badPath in $fallbackCases) {
+        $sidePayload.transcript_path = $badPath
+        $run = Invoke-Subagent (Json $sidePayload) $nameOnlyConfig @{}
+        Check-Run 'WIN-PS1 unsafe sidecar path fallback' $run
+        Check 'WIN-PS1 unsafe sidecar path uses payload identity' (-not (Plain (@(Get-SubagentRows $run)[0].content)).Contains('Explore'))
+    }
+    $sidePayload.transcript_path = Forward-Path $transcript
+    [IO.File]::WriteAllBytes($sidecar, (New-Object byte[] 65537))
+    $oversizedSide = Invoke-Subagent (Json $sidePayload) $nameOnlyConfig @{}
+    Check 'WIN-PS1 oversized sidecar falls back' (-not (Plain (@(Get-SubagentRows $oversizedSide)[0].content)).Contains('Explore'))
+    [IO.File]::WriteAllBytes($sidecar, [byte[]]@(0xC3,0x28))
+    $malformedSide = Invoke-Subagent (Json $sidePayload) $nameOnlyConfig @{}
+    Check 'WIN-PS1 malformed UTF-8 sidecar falls back' (-not (Plain (@(Get-SubagentRows $malformedSide)[0].content)).Contains('Explore'))
+    Write-Utf8 $sidecar '{"agentType":'
+    $badJsonSide = Invoke-Subagent (Json $sidePayload) $nameOnlyConfig @{}
+    Check 'WIN-PS1 malformed JSON sidecar falls back' (-not (Plain (@(Get-SubagentRows $badJsonSide)[0].content)).Contains('Explore'))
+    Write-Utf8 $sidecar '{"agentType":"Explore"}'
+
+    $junctionTarget = Join-Path $TempRoot 'subagent-junction-target'
+    $junctionLink = Join-Path $TempRoot 'subagent-junction-link'
+    [void][IO.Directory]::CreateDirectory($junctionTarget)
+    $junctionTranscript = Join-Path $junctionTarget 'session.jsonl'
+    Write-Utf8 $junctionTranscript ''
+    [void][IO.Directory]::CreateDirectory((Join-Path $junctionTarget 'session\subagents'))
+    Write-Utf8 (Join-Path $junctionTarget 'session\subagents\agent-side.meta.json') '{"agentType":"JunctionRole"}'
+    $mkSubJunction = Invoke-CapturedProcess $env:ComSpec ('/d /s /c "mklink /J ""' + $junctionLink + '"" ""' + $junctionTarget + '"""') '' @{} $Repo 5000
+    if ($mkSubJunction.ExitCode -eq 0) {
+        $sidePayload.transcript_path = Forward-Path (Join-Path $junctionLink 'session.jsonl')
+        $junctionRun = Invoke-Subagent (Json $sidePayload) $nameOnlyConfig @{}
+        Check 'WIN-PS1 reparse transcript path falls back' (-not (Plain (@(Get-SubagentRows $junctionRun)[0].content)).Contains('JunctionRole'))
+    } else { Blocked 'WIN-PS1 reparse transcript path' $mkSubJunction.Stderr }
+
+    $subSideEffectRoot = Join-Path $TempRoot 'subagent-no-main-side-effects'
+    $floatTarget = Join-Path $subSideEffectRoot 'float.txt'
+    $burnTarget = Join-Path $subSideEffectRoot 'burn.tsv'
+    $sideEffectConfig = New-Config 'sub-no-main-side-effects' @(
+        ('VL_SUB_SEGMENTS=' + (Quote-FromConfigure 'name')),
+        'VL_FLOAT=1',
+        ('VL_FLOAT_FILE=' + (Quote-FromConfigure (Forward-Path $floatTarget))),
+        'VL_SEGMENTS=git\ burn',
+        ('BURN_FILE=' + (Quote-FromConfigure (Forward-Path $burnTarget))),
+        'VL_LIMIT_SYNC=1'
+    )
+    $sideEffectRun = Invoke-Subagent '{"tasks":[{"id":"side-effect","name":"safe"}]}' $sideEffectConfig @{ CORALLINE_NO_SAMPLE=$null }
+    Check-Run 'WIN-PS1 subagent avoids main side effects' $sideEffectRun
+    Check 'WIN-PS1 subagent creates no float or state artifacts' (-not [IO.File]::Exists($floatTarget) -and -not [IO.File]::Exists($burnTarget) -and -not [IO.Directory]::Exists($burnTarget + '.d'))
+    $mainIdentityConfig = New-Config 'sub-main-identity' @('VL_SEGMENTS=model\ ctx','VL_CLOCK=off')
+    $mainIdentityPs = Invoke-Statusline (Json $basePayload) $mainIdentityConfig @{} '' 5000
+    $mainIdentityBash = Invoke-BashStatusline (Json $basePayload) $mainIdentityConfig @{}
+    Check-Run 'WIN-PS1 main fixture identity after subagent implementation' $mainIdentityPs
+    Check-Exact 'WIN-PS1 main fixture remains byte exact' $mainIdentityPs $mainIdentityBash
+
     $quotedSegments = Quote-FromConfigure 'dir git model ctx'
     Check 'real configure shell_quote emits escaped multi-word value' ($quotedSegments.Contains('\ '))
     $quotedConfig = New-Config 'configure-q-segments' @("VL_SEGMENTS=$quotedSegments", 'VL_CLOCK=off')

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -914,6 +914,9 @@ shell_quote "$CORALLINE_Q_VALUE"
         [pscustomobject]@{ Name='floor'; Tok='1'; Win='3'; Show=$true; Needle='33%' },
         [pscustomobject]@{ Name='large-exact-floor'; Tok='299999999999998'; Win='9999999999999934'; Show=$true; Needle='2%' },
         [pscustomobject]@{ Name='clamp'; Tok='9999999999999999'; Win='1'; Show=$true; Needle='100%' },
+        [pscustomobject]@{ Name='large-token-abbreviation'; Tok='9999999999999999'; Win='0'; Show=$true; Needle='9999999999.9M' },
+        [pscustomobject]@{ Name='below-million'; Tok='999999'; Win='0'; Show=$true; Needle='999.9k' },
+        [pscustomobject]@{ Name='at-million'; Tok='1000000'; Win='0'; Show=$true; Needle='1.0M' },
         [pscustomobject]@{ Name='zero-window'; Tok='1000'; Win='0'; Show=$true; Needle='1.0k' },
         [pscustomobject]@{ Name='invalid-window'; Tok='1000'; Win='10000000000000000'; Show=$true; Needle='1.0k' },
         [pscustomobject]@{ Name='invalid-token'; Tok='10000000000000000'; Win='1'; Show=$false; Needle='' },
@@ -1491,6 +1494,16 @@ fi
     $tokenRun = Invoke-Statusline (Json $missingTokens) $tokenConfig @{} '' 5000
     Check-Run 'missing token values' $tokenRun
     Check 'missing token values render zero' ((Plain $tokenRun.Stdout).Contains((Glyph 0x2191) + '0 ' + (Glyph 0x2193) + '0 cr:0 cw:0'))
+
+    $largeTokens = Clone-Object $basePayload
+    $largeTokens.context_window.total_input_tokens = '9999999999999999'
+    $largeTokenConfig = New-Config 'large-token-format' @('VL_SEGMENTS=ctx','VL_CLOCK=off')
+    $largeTokenPs = Invoke-Statusline (Json $largeTokens) $largeTokenConfig @{} '' 5000
+    $largeTokenBash = Invoke-BashStatusline (Json $largeTokens) $largeTokenConfig @{}
+    Check-Run 'large main token abbreviation' $largeTokenPs
+    Check-Run 'large main token abbreviation Bash reference' $largeTokenBash
+    Check-Exact 'large main token abbreviation remains byte exact' $largeTokenPs $largeTokenBash
+    Check 'large main token abbreviation uses integer quotient' ((Plain $largeTokenPs.Stdout).Contains('9999999999.9M'))
 
     $dirConfig = New-Config 'dir-only' @('VL_SEGMENTS=dir','VL_CLOCK=off','VL_PATH_DEPTH=4')
     foreach ($case in @(


### PR DESCRIPTION
## Summary

- implement native `statusline.ps1 --subagent` rows for Windows PowerShell 5.1
- add bounded strict JSON parsing, Bash-compatible valid scalar and timestamp semantics, native theme/config handling, and constrained transcript sidecar reads
- add `install.ps1 -SubagentRows preserve|on|off` to manage `subagentStatusLine` in the existing settings transaction
- update the English and Traditional Chinese installation surfaces and the PowerShell one-line bootstrap

## Why

PowerShell-only Windows installs previously rendered the main statusline natively but could not render themed subagent rows. This completes that protocol slice without adding Git Bash, jq, or another dependency.

## Safety and compatibility

- `preserve` is the installer default, so existing `subagentStatusLine` configuration remains byte-identical unless the user explicitly opts in or out.
- stdin, JSON nodes, nesting, tasks, scalar fields, sidecar files, rendered content, and serialized rows are bounded.
- duplicate and case-colliding JSON keys fail closed.
- transcript sidecars remain confined to validated local-drive paths and reject reparse components.
- the managed installer allowlist remains `statusline.ps1` plus the ten shipped themes.
- main-renderer state, polling, git, and float paths are bypassed in subagent mode.

## Verification

- `bash -n statusline.sh configure.sh`
- complete `test/*.sh` suite
- Windows PowerShell 5.1 installer suite: `pass=179 fail=0 blocked=0`
- Windows PowerShell 5.1 renderer suite: `pass=2025 fail=0 blocked=0`
- Windows PowerShell 5.1 one-line bootstrap parse check
- byte-identical English and Traditional Chinese bootstrap commands
- fresh security review: clean
- fresh completed-work verification: confirmed

One immediately preceding renderer run had a single existing WIN-02 128-writer stress process terminated by Windows. The exact unchanged sources reran clean at `2025/0/0`.