### PR TITLE
fix(state): restore cheap one-second Bash polling

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -367,12 +367,13 @@ fmt_eta() {  # → _ETA ; $1=seconds (mirrors fmt_countdown's d/h/m formatting)
   else                      printf -v _ETA '%dm' "$m"; fi
 }
 
-# ── Immutable burn / limit state ──────────────────────────────────────────────
-# State percentages are canonical integer milli-percent. Filenames, not file
-# contents or enumeration order, are the shared source of truth.
+# ── Mutable Bash burn / limit state ───────────────────────────────────────────
+# Bash owns the validated TSV history and compact limit directory sets. The
+# native immutable burn directory remains a separate, ignored namespace.
 state_pct() {  # → _SP_MILLI _SP_CANON; strict raw decimal, ties-to-even at .001
   local raw="$1" whole frac six keep rest milli LC_ALL=C
   _SP_MILLI=""; _SP_CANON=""
+  [ "${#raw}" -le 10 ] || return 1
   [[ "$raw" =~ ^(0|[1-9][0-9]?|100)(\.([0-9]{1,6}))?$ ]] || return 1
   whole="${BASH_REMATCH[1]}"; frac="${BASH_REMATCH[3]}"
   if [ "$whole" = 100 ]; then
@@ -392,9 +393,10 @@ state_pct() {  # → _SP_MILLI _SP_CANON; strict raw decimal, ties-to-even at .0
 state_epoch() {  # → _SE_VALUE _SE_PAD; $1=strict epoch $2=width (10 or 12)
   local raw="$1" width="$2" value
   _SE_VALUE=""; _SE_PAD=""
+  case "$width" in (10|12) ;; (*) return 1 ;; esac
+  [ "${#raw}" -le "$width" ] || return 1
   case "$raw" in (0|[1-9][0-9]*) ;; (*) return 1 ;; esac
   case "$raw" in (*[!0-9]*) return 1 ;; esac
-  [ "${#raw}" -le 12 ] || return 1
   value=$(( 10#$raw ))
   [ "$value" -ge 0 ] && [ "$value" -le 253402300799 ] || return 1
   [ "$width" != 10 ] || [ "$value" -le 9999999999 ] || return 1
@@ -403,9 +405,14 @@ state_epoch() {  # → _SE_VALUE _SE_PAD; $1=strict epoch $2=width (10 or 12)
 }
 
 state_payload_epoch() {  # → _SE_*; canonical ISO UTC or strict epoch only
-  local raw="$1" width="$2"
+  local raw="$1" width="$2" LC_ALL=C
+  [ "${#raw}" -le 27 ] || return 1
   case "$raw" in
-    (*T*) to_epoch "$raw" || return 1; state_epoch "$_EP" "$width" ;;
+    (*T*)
+      [[ "$raw" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]{1,6})?Z$ ]] || return 1
+      iso_epoch "$raw" || return 1
+      state_epoch "$_EP" "$width"
+      ;;
     (*) state_epoch "$raw" "$width" ;;
   esac
 }
@@ -443,7 +450,7 @@ state_drive_lower() {  # → _SDL
 state_abs_path() {  # → _SAP; lexical absolute path, including MSYS drive forms
   local p="$1" drive rest part out=""
   _SAP=""
-  [ -n "$p" ] || return 1
+  [ -n "$p" ] && [ "${#p}" -le 4096 ] || return 1
   p="${p//\\//}"
   case "$p" in
     (//*) return 1 ;;
@@ -491,7 +498,7 @@ state_store_path() {  # → _SS_BASE _SS_ROOT from configured base
   [ "$_SS_ROOT" != "$_SS_BASE" ] || _SS_ROOT="${_SS_BASE}.d"
 }
 
-state_same_path() {  # true for proven or platform-conservative store-root identity
+state_same_path() {  # true for proven or platform-conservative path identity
   local left="$1" right="$2" had_nocase=0 same=1
   [ "$left" = "$right" ] && return 0
   if [ -e "$left" ] && [ -e "$right" ] && [ "$left" -ef "$right" ]; then return 0; fi
@@ -507,21 +514,10 @@ state_same_path() {  # true for proven or platform-conservative store-root ident
   return 1
 }
 
-state_burn_name() {  # → _SBN_* for one strict live basename
-  local name="$1" pr ps pc LC_ALL=C
-  _SBN_RST=""; _SBN_SAMP=""; _SBN_PCT=""; _SBN_SLOT=""
-  [[ "$name" =~ ^b_([0-9]{12})_([0-9]{12})_((0[0-9]{2}|100)\.[0-9]{3})_([0-9]{4})$ ]] || return 1
-  pr="${BASH_REMATCH[1]}"; ps="${BASH_REMATCH[2]}"; pc="${BASH_REMATCH[3]}"
-  _SBN_RST=$(( 10#$pr )); _SBN_SAMP=$(( 10#$ps ))
-  [ "$_SBN_RST" -le 253402300799 ] && [ "$_SBN_SAMP" -le 253402300799 ] || return 1
-  _SBN_PCT=$(( 10#${pc:0:3} * 1000 + 10#${pc:4:3} ))
-  [ "$_SBN_PCT" -le 100000 ] || return 1
-  _SBN_SLOT="${BASH_REMATCH[5]}"
-}
-
 state_limit_name() {  # → _SLN_RST _SLN_PCT for one strict limit basename
   local name="$1" pr pc LC_ALL=C
   _SLN_RST=""; _SLN_PCT=""
+  [ "${#name}" -eq 18 ] || return 1
   [[ "$name" =~ ^([0-9]{10})_((0[0-9]{2}|100)\.[0-9]{3})$ ]] || return 1
   pr="${BASH_REMATCH[1]}"; pc="${BASH_REMATCH[2]}"
   _SLN_RST=$(( 10#$pr ))
@@ -529,620 +525,363 @@ state_limit_name() {  # → _SLN_RST _SLN_PCT for one strict limit basename
   [ "$_SLN_PCT" -le 100000 ] || return 1
 }
 
-state_scan() {  # one bounded pass: enumerate, retain, and load every gated store
-  # A single find | od | awk pass enumerates, retains, and loads every gated
-  # store. Two ceilings are enforced in-stream by awk rather than after the
-  # fact, so a store far past its raw cap makes awk exit, od die, and find
-  # stop enumerating instead of draining the whole directory; render cost
-  # stays bounded by those caps rather than by the size of the store. The
-  # globals produced here are exactly the ones state_gc, state_publish,
-  # state_select_limit and burn_eta_5h already consume.
-  local _fstat _bad _over _lbad _sent _rep_n _leg_n _cand_k _k5 _k7 _off _odst _num _pi _ok=0
-  local _FB_OUT=() _FB_SLICE=() _FB_TMP=() _S5=() _S7=() _SCAN_AWKV=()
-  local _SCAN_LEG=/dev/null _SCAN_BROOT="" _SCAN_L5ROOT="" _SCAN_L7ROOT="" _SCAN_NOFIND=0
-  _SB_RAW=0; _SB_CAND_TOTAL=0; _SB_CAND_NAMES=(); _SB_CAND_PATHS=()
-  _SB_REP_RSTS=(); _SB_REP_SAMPS=(); _SB_REP_PCTS=()
-  _LEG_RSTS=(); _LEG_SAMPS=(); _LEG_PCTS=()
-  _SL5_RAW=0; _SL5_CAND_TOTAL=0; _SL5_CAND_NAMES=(); _SL5_CAND_PATHS=()
-  _SL5_STORED_VALID=0; _SL5_STORED_RST=0; _SL5_STORED_PCT=0
-  _SL7_RAW=0; _SL7_CAND_TOTAL=0; _SL7_CAND_NAMES=(); _SL7_CAND_PATHS=()
-  _SL7_STORED_VALID=0; _SL7_STORED_RST=0; _SL7_STORED_PCT=0
-  _SB_DIR_COMPLETE=0; _SL5_COMPLETE=0; _SL7_COMPLETE=0; _LEG_COMPLETE=0
-  [ "$_STATE_BURN_GATE" = 1 ] || [ "$_STATE_RL5_GATE" = 1 ] || [ "$_STATE_RL7_GATE" = 1 ] || return 0
-  [ "${#_STATE_FIND_ARGS[@]}" -gt 0 ] || _SCAN_NOFIND=1
-  [ "$_STATE_LEGACY_READ" != 1 ] || _SCAN_LEG="$_SB_BASE"
-  [ "$_STATE_BURN_GATE" != 1 ] || _SCAN_BROOT="$_SB_ROOT/./"
-  [ "$_STATE_RL5_GATE" != 1 ] || _SCAN_L5ROOT="$_SL5_ROOT/./"
-  [ "$_STATE_RL7_GATE" != 1 ] || _SCAN_L7ROOT="$_SL7_ROOT/./"
+state_path_leaf() {  # $1=canonical path $2=f|d; caller validated ancestors
+  local path="$1" kind="$2"
+  [ ! -L "$path" ] || return 1
+  if [ -e "$path" ]; then
+    case "$kind" in (f) [ -f "$path" ] ;; (d) [ -d "$path" ] ;; (*) return 1 ;; esac
+  fi
+}
 
-  # The awk source is hoisted out of the process substitution below: bash 3.2
-  # cannot scan a process-substitution body this large, and test-burn.sh evals
-  # this whole block out of the file, so the program must stay free of single
-  # quotes and must not live in a separate file.
-  local _SCAN_PROG='
-    function pct_milli(raw,   pp, parts, whole, frac, six, keep, rest, milli) {
-      if (raw !~ /^(0|[1-9][0-9]?|100)(\.[0-9]{1,6})?$/) return -1
-      parts = split(raw, pp, ".")
-      whole = pp[1]
-      frac = (parts == 2 ? pp[2] : "")
-      if (whole == "100" && frac ~ /[1-9]/) return -1
-      six = substr(frac "000000", 1, 6)
-      keep = substr(six, 1, 3) + 0; rest = substr(six, 4, 3) + 0
-      milli = (whole + 0) * 1000 + keep
-      if (rest > 500 || (rest == 500 && milli % 2 == 1)) milli++
-      if (milli < 0 || milli > 100000) return -1
-      return milli
-    }
-    function epoch_ok(raw) {
-      if (raw !~ /^(0|[1-9][0-9]*)$/ || length(raw) > 12) return 0
-      if (length(raw) == 12 && raw > "253402300799") return 0
-      return 1
-    }
-    function pmark(n) {
-      if (length(n) != 40) return 0
-      if (n !~ /^b_[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]_(0[0-9][0-9]|100)\.[0-9][0-9][0-9]_[0-9][0-9][0-9][0-9]$/) return 0
-      mrst = substr(n, 3, 12) + 0; msamp = substr(n, 16, 12) + 0
-      if (mrst > 253402300799 || msamp > 253402300799) return 0
-      mpct = (substr(n, 29, 3) + 0) * 1000 + (substr(n, 33, 3) + 0)
-      if (mpct > 100000) return 0
-      return 1
-    }
-    function lmark(n) {
-      if (length(n) != 18) return 0
-      if (n !~ /^[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]_(0[0-9][0-9]|100)\.[0-9][0-9][0-9]$/) return 0
-      qrst = substr(n, 1, 10) + 0
-      qpct = (substr(n, 12, 3) + 0) * 1000 + (substr(n, 16, 3) + 0)
-      if (qpct > 100000) return 0
-      return 1
-    }
-    function qsort(a, lo, hi,   i, j, mid, t) {
-      while (lo < hi) {
-        i = lo; j = hi; mid = a[int((lo + hi) / 2)] ""
-        while (i <= j) {
-          while (a[i] "" < mid) i++
-          while (a[j] "" > mid) j--
-          if (i <= j) { t = a[i]; a[i] = a[j]; a[j] = t; i++; j-- }
-        }
-        if (j - lo < hi - i) { qsort(a, lo, j); lo = i } else { qsort(a, i, hi); hi = j }
-      }
-    }
-    function addcand(n) { ncand++; if (ncand <= 128) cand[ncand] = n }
-    function flushgrp(   j, rep) {
-      if (gn == 0) return
-      rep = 1
-      for (j = 2; j <= gn; j++) if (gpct[j] > gpct[rep]) rep = j
-      for (j = 1; j <= gn; j++) if (j != rep) addcand(gnam[j])
-      nrep++
-      rnam[nrep] = gnam[rep]; rrst[nrep] = grst[rep]
-      rsam[nrep] = gsam[rep]; rpct[nrep] = gpct[rep]
-      gn = 0; gkey = ""
-    }
-    function markchild(w, rest,   par) {
-      par = substr(rest, 1, index(rest, "/") - 1)
-      if (w == 5) {
-        c5n++
-        if (c5n > 512) { over = 1; return }
-        if (par in pl5) pl5[par] = 0
-      } else {
-        c7n++
-        if (c7n > 512) { over = 1; return }
-        if (par in pl7) pl7[par] = 0
-      }
-    }
-    function burnent(nm, cls) {
-      braw++
-      if (braw > 4096) { over = 1; return }
-      if (cls != 1) return
-      if (!pmark(nm)) return
-      bn++; bnam[bn] = nm
-      plb[nm] = (msamp <= now + 300 && mrst >= msamp && mrst <= now + maxahead) ? 1 : 0
-    }
-    function limitent(w, nm, cls) {
-      if (w == 5) { raw5++; if (raw5 > 512) { over = 1; return } }
-      else { raw7++; if (raw7 > 512) { over = 1; return } }
-      if (cls != 2) return
-      if (!lmark(nm)) return
-      if (w == 5) {
-        n5++; e5[n5] = nm; r5[nm] = qrst; v5[nm] = qpct
-        pl5[nm] = (qrst > now && qrst <= now + maxahead) ? 1 : 0
-      } else {
-        n7++; e7[n7] = nm; r7[nm] = qrst; v7[nm] = qpct
-        pl7[nm] = (qrst > now && qrst <= now + max7) ? 1 : 0
-      }
-    }
-    function emit(p, cls,   rest) {
-      if (over) return
-      if (blen > 0 && p == broot0) return
-      if (l5len > 0 && p == l5root0) return
-      if (l7len > 0 && p == l7root0) return
-      comb++
-      if (comb > 5120) { over = 1; return }
-      if (blen > 0 && substr(p, 1, blen) == broot) {
-        rest = substr(p, blen + 1)
-        if (index(rest, "/") > 0) return
-      }
-      if (l5len > 0 && substr(p, 1, l5len) == l5root) {
-        rest = substr(p, l5len + 1)
-        if (index(rest, "/") > 0) { markchild(5, rest); return }
-      }
-      if (l7len > 0 && substr(p, 1, l7len) == l7root) {
-        rest = substr(p, l7len + 1)
-        if (index(rest, "/") > 0) { markchild(7, rest); return }
-      }
-      if (blen > 0 && substr(p, 1, blen) == broot) { burnent(substr(p, blen + 1), cls); return }
-      if (l5len > 0 && substr(p, 1, l5len) == l5root) { limitent(5, substr(p, l5len + 1), cls); return }
-      if (l7len > 0 && substr(p, 1, l7len) == l7root) { limitent(7, substr(p, l7len + 1), cls); return }
-      bad = 1
-    }
-    function flushrun() {
-      if (runn > 0) emit(runp, runn)
-      runn = 0; runp = ""
-    }
-    function pathrec(p) {
-      if (p == "/dev/null") { flushrun(); sawend = 1; seg = 2; return }
-      if (substr(p, 1, 1) != "/") { bad = 1; return }
-      if (runn > 0 && p == runp) { runn++; return }
-      flushrun()
-      runp = p; runn = 1
-    }
-    function legrec(   f, nf, sample, reset, pctm, slot) {
-      lrows++
-      if (lrows > 4096) { lbad = 1; return }
-      if (!rascii) { lrec = ""; llen = 0; rascii = 1; return }
-      nf = split(lrec, f, "\t")
-      if (nf == 3 && epoch_ok(f[1]) && epoch_ok(f[3])) {
-        sample = f[1] + 0; reset = f[3] + 0; pctm = pct_milli(f[2])
-        if (pctm >= 0 && sample <= now + 300 && reset >= sample && reset <= now + maxahead) {
-          lval++
-          slot = ((lval - 1) % 512) + 1
-          kr[slot] = reset; ks[slot] = sample; kp[slot] = pctm
-        }
-      }
-      lrec = ""; llen = 0; rascii = 1
-    }
-    BEGIN {
-      seg = 1; rascii = 1; runn = 0
-      blen = length(broot); l5len = length(l5root); l7len = length(l7root)
-      broot0 = substr(broot, 1, blen - 1)
-      l5root0 = substr(l5root, 1, l5len - 1)
-      l7root0 = substr(l7root, 1, l7len - 1)
-      if (nofind) { seg = 2; sawend = 1 }
-      for (i = 1; i < 256; i++) ch[i] = sprintf("%c", i)
-    }
-    {
-      for (i = 1; i <= NF; i++) {
-        b = $i + 0
-        if (seg == 1) {
-          if (b == 0) {
-            pathrec(prec); prec = ""; plen = 0
-            if (over) { exit 0 }
-          } else {
-            plen++
-            if (plen > 65536) { bad = 1; exit 0 }
-            prec = prec ch[b]
-          }
-        } else {
-          lbytes++
-          if (lbytes > 1048576) { lbad = 1; exit 0 }
-          if (b == 10) { legrec(); if (lbad) { exit 0 }; continue }
-          llen++
-          if (llen > 4096) { lbad = 1; exit 0 }
-          if (b == 9 || b == 46 || (b >= 48 && b <= 57)) lrec = lrec ch[b]
-          else rascii = 0
-        }
-      }
-    }
-    END {
-      if (seg == 1) { flushrun(); if (plen > 0) bad = 1 }
-      else if (!lbad && llen > 0) legrec()
-      qsort(bnam, 1, bn)
-      gn = 0; gkey = ""
-      for (i = 1; i <= bn; i++) {
-        nm = bnam[i]
-        pmark(nm)
-        if (plb[nm] != 1) { flushgrp(); addcand(nm); continue }
-        key = mrst "_" msamp
-        if (key != gkey) { flushgrp(); gkey = key }
-        gn++; gnam[gn] = nm; grst[gn] = mrst; gsam[gn] = msamp; gpct[gn] = mpct
-      }
-      flushgrp()
-      keep = nrep - trim; if (keep < 0) keep = 0
-      for (i = 1; i <= keep; i++) addcand(rnam[i])
-      qsort(e5, 1, n5); qsort(e7, 1, n7)
-      w5 = ""; for (i = 1; i <= n5; i++) if (pl5[e5[i]] == 1) w5 = e5[i]
-      w7 = ""; for (i = 1; i <= n7; i++) if (pl7[e7[i]] == 1) w7 = e7[i]
-      nc5 = 0; k5 = 0
-      for (i = 1; i <= n5; i++) if (e5[i] != w5) { nc5++; if (nc5 <= 128) { k5++; cd5[k5] = e5[i] } }
-      nc7 = 0; k7 = 0
-      for (i = 1; i <= n7; i++) if (e7[i] != w7) { nc7++; if (nc7 <= 128) { k7++; cd7[k7] = e7[i] } }
-      sv5 = 0; sr5 = 0; sp5 = 0
-      if (w5 != "") { sv5 = 1; sr5 = r5[w5]; sp5 = v5[w5] }
-      sv7 = 0; sr7 = 0; sp7 = 0
-      if (w7 != "") { sv7 = 1; sr7 = r7[w7]; sp7 = v7[w7] }
-      if (lbad) lval = 0
-      lfirst = lval - 511; if (lfirst < 1) lfirst = 1
-      # v0.11 append order can contain same-second cache-lag rows whose pct
-      # decreases. Sort the capped source by the estimator key so the Bash merge
-      # always takes its constant-time tail-append path.
-      nleg = 0
-      for (i = lfirst; i <= lval; i++) {
-        sl = ((i - 1) % 512) + 1; nleg++
-        lout[nleg] = sprintf("%012d_%012d_%06d_%04d", kr[sl], ks[sl], kp[sl], nleg)
-      }
-      qsort(lout, 1, nleg)
-      k = (ncand < 128 ? ncand : 128)
-      printf "SENT %d\n", (sawend ? 1 : 0)
-      printf "BAD %d\n", (bad ? 1 : 0)
-      printf "OVER %d\n", (over ? 1 : 0)
-      printf "LBAD %d\n", (lbad ? 1 : 0)
-      printf "RAW %d\n", braw
-      printf "CTOTAL %d\n", ncand
-      printf "REPN %d\n", nrep
-      printf "LEGN %d\n", nleg
-      printf "S5 %d %d %d %d %d %d\n", raw5, nc5, sv5, sr5, sp5, k5
-      printf "S7 %d %d %d %d %d %d\n", raw7, nc7, sv7, sr7, sp7, k7
-      for (i = 1; i <= k; i++) printf "%s\n", cand[i]
-      for (i = 1; i <= nleg; i++)
-        printf "%d %d %d\n", substr(lout[i], 1, 12) + 0, substr(lout[i], 14, 12) + 0, substr(lout[i], 27, 6) + 0
-      for (i = 1; i <= nrep; i++) printf "%d %d %d\n", rrst[i], rsam[i], rpct[i]
-      for (i = 1; i <= k5; i++) printf "%s\n", cd5[i]
-      for (i = 1; i <= k7; i++) printf "%s\n", cd7[i]
-      printf "EOD\n"
-    }
-  '
+state_path_parent() {  # every existing ancestor of one canonical path is non-link
+  local parent="${1%/*}"
+  [ -n "$parent" ] || parent=/
+  state_no_symlink_path "$parent" && [ "$_SNP" = "$parent" ]
+}
 
-  # One controller shell, exactly as before this file grew a second pass: the
-  # process substitution below is the only shell forked per render, and find, od
-  # and awk are plain members of its pipeline, so the shell reaps all three and
-  # PIPESTATUS carries find's and od's exit codes out as trailer lines.
-  #
-  # /dev/null is find's last path operand, so it is enumerated after every root
-  # and its record is the in-band end-of-enumeration sentinel; everything the od
-  # stream carries after it is legacy TSV. It gets its own -path branch (one
-  # print) rather than falling into the catch-all, because the catch-all prints
-  # three times and the classification below only learns a run length once the
-  # *next* record arrives — nothing follows the sentinel. No store path can
-  # collide with it: roots end in .d and their entries carry the root prefix.
-  #
-  # od reads the enumeration by name, not from its stdin: BSD od switches
-  # operands with freopen(path, "r", stdin), which closes fd 0 before opening
-  # the path, so a /dev/stdin operand always dies with EBADF. The pipe is
-  # therefore duplicated onto fd 8 and named as /dev/fd/8 — freopen then
-  # closes only the throwaway /dev/null on fd 0 — which both BSD and GNU od
-  # open like any other file.
-  #
-  # Type and size are read at enumeration time and carried out-of-band as the
-  # number of times find repeats a path: 1 = zero-byte regular file (a live burn
-  # marker), 2 = directory (a limit entry), 3 = anything else (symlink, non-empty
-  # file, …). -P makes -type f/-type d false for symlinks, so the multiplicity
-  # reproduces the [ -f ] && [ ! -L ] && [ ! -s ] and [ -d ] && [ ! -L ] trust
-  # checks without a second stat pass or a second process. Dropping -mindepth 1
-  # to let /dev/null through also admits the depth-0 root records, which awk
-  # discards by comparing against the same roots it is given via -v.
-  _SCAN_AWKV=( -v "now=$NOW" -v "maxahead=$RL_MAX_5H" -v "max7=$RL_MAX_7D" \
-               -v "trim=$BURN_TRIM" -v "nofind=$_SCAN_NOFIND" -v "broot=$_SCAN_BROOT" \
-               -v "l5root=$_SCAN_L5ROOT" -v "l7root=$_SCAN_L7ROOT" )
-  exec 9< <(
-    if [ "${#_STATE_FIND_ARGS[@]}" -gt 0 ]; then
-      LC_ALL=C find -P "${_STATE_FIND_ARGS[@]}" /dev/null -maxdepth 2 \( -path /dev/null -print0 -o -type f -size 0 -print0 -o -type d -print0 -print0 -o -print0 -print0 -print0 \) 2>/dev/null | LC_ALL=C od -An -v -tu1 -- /dev/fd/8 "$_SCAN_LEG" 8<&0 0</dev/null 2>/dev/null | LC_ALL=C awk "${_SCAN_AWKV[@]}" "$_SCAN_PROG"
-      _st=("${PIPESTATUS[@]}")
-      printf 'FSTAT %s\nODSTAT %s\n' "${_st[0]}" "${_st[1]}"
-    else
-      LC_ALL=C od -An -v -tu1 -- "$_SCAN_LEG" 2>/dev/null | LC_ALL=C awk "${_SCAN_AWKV[@]}" "$_SCAN_PROG"
-      _st=("${PIPESTATUS[@]}")
-      printf 'FSTAT 0\nODSTAT %s\n' "${_st[0]}"
+state_path_object() {  # $1=canonical path $2=f|d; absent is allowed
+  state_path_parent "$1" && state_path_leaf "$1" "$2"
+}
+
+state_paths_validate() {  # six canonical paths are safe, distinct state objects
+  local bbase="$1" broot="$2" fbase="$3" froot="$4" sbase="$5" sroot="$6"
+  local bp="${bbase%/*}" fp="${fbase%/*}" sp="${sbase%/*}" i j collision=0 had_nocase=0
+  local paths=("$bbase" "$broot" "$fbase" "$froot" "$sbase" "$sroot") kinds=(f d f d f d)
+  [ -n "$bp" ] || bp=/; [ -n "$fp" ] || fp=/; [ -n "$sp" ] || sp=/
+  state_path_parent "$bbase" || return 1
+  [ "$fp" = "$bp" ] || state_path_parent "$fbase" || return 1
+  if [ "$sp" != "$bp" ] && [ "$sp" != "$fp" ]; then state_path_parent "$sbase" || return 1; fi
+  for ((i=0; i<6; i++)); do state_path_leaf "${paths[$i]}" "${kinds[$i]}" || return 1; done
+  case "${OSTYPE:-}" in
+    (darwin*|mingw*|msys*)
+      shopt -q nocasematch && had_nocase=1
+      shopt -s nocasematch
+      for ((i=0; i<6 && collision==0; i++)); do
+        for ((j=i+1; j<6; j++)); do [[ "${paths[$i]}" == "${paths[$j]}" ]] && { collision=1; break; }; done
+      done
+      [ "$had_nocase" = 1 ] || shopt -u nocasematch
+      ;;
+    (*)
+      for ((i=0; i<6 && collision==0; i++)); do
+        for ((j=i+1; j<6; j++)); do [ "${paths[$i]}" = "${paths[$j]}" ] && { collision=1; break; }; done
+      done
+      ;;
+  esac
+  [ "$collision" = 0 ] || return 1
+  for ((i=0; i<6; i++)); do
+    for ((j=i+1; j<6; j++)); do
+      if [ -e "${paths[$i]}" ] && [ -e "${paths[$j]}" ] && [ "${paths[$i]}" -ef "${paths[$j]}" ]; then return 1; fi
+    done
+  done
+}
+
+state_paths_check() {  # → _SPC_*; configured namespaces canonical, distinct, non-link
+  state_store_path "$_STATE_BURN_CFG" || return 1
+  _SPC_BBASE=$_SS_BASE; _SPC_BROOT=$_SS_ROOT
+  state_store_path "$_STATE_RL5_CFG" || return 1
+  _SPC_5BASE=$_SS_BASE; _SPC_5ROOT=$_SS_ROOT
+  state_store_path "$_STATE_RL7_CFG" || return 1
+  _SPC_7BASE=$_SS_BASE; _SPC_7ROOT=$_SS_ROOT
+  state_paths_validate "$_SPC_BBASE" "$_SPC_BROOT" "$_SPC_5BASE" "$_SPC_5ROOT" "$_SPC_7BASE" "$_SPC_7ROOT"
+}
+
+state_paths_revalidate() {  # every mutation rechecks the cached canonical identities
+  [ "${_STATE_PATHS_OK:-0}" = 1 ] || return 1
+  state_paths_validate "$_SB_BASE" "$_SB_ROOT" "$_SL5_BASE" "$_SL5_ROOT" "$_SL7_BASE" "$_SL7_ROOT"
+}
+
+state_gate() {  # canonicalize one render's values and state namespaces
+  _STATE_MUTATE=1; [ "${CORALLINE_NO_SAMPLE:-0}" = 1 ] && _STATE_MUTATE=0
+  case "$CORALLINE_BURN_WINDOW" in (''|*[!0-9]*) CORALLINE_BURN_WINDOW=600 ;; esac
+  [ "${#CORALLINE_BURN_WINDOW}" -le 5 ] && [ "$CORALLINE_BURN_WINDOW" -ge 60 ] 2>/dev/null \
+    && [ "$CORALLINE_BURN_WINDOW" -le 86400 ] 2>/dev/null || CORALLINE_BURN_WINDOW=600
+  case "$BURN_TRIM" in (''|*[!0-9]*) BURN_TRIM=1500 ;; esac
+  [ "${#BURN_TRIM}" -le 4 ] && [ "$BURN_TRIM" -ge 1 ] 2>/dev/null \
+    && [ "$BURN_TRIM" -le 3000 ] 2>/dev/null || BURN_TRIM=1500
+
+  _CUR5_VALID=0; _CUR7_VALID=0; _CUR_BURN_VALID=0
+  _CUR5_PCT=0; _CUR5_CANON=""; _CUR5_TSV=""; _CUR5_RST=0
+  _CUR7_PCT=0; _CUR7_CANON=""; _CUR7_TSV=""; _CUR7_RST=0
+  _CUR_BURN_SAMP=0; _CUR_BURN_PCT=0; _CUR_BURN_TSV=""; _CUR_BURN_RST=0
+  if state_pct "$fh_pct"; then
+    _CUR5_PCT=$_SP_MILLI; _CUR5_CANON=$_SP_CANON
+    printf -v _CUR5_TSV '%d.%03d' $(( _CUR5_PCT / 1000 )) $(( _CUR5_PCT % 1000 ))
+    if state_payload_epoch "$fh_rst" 10; then
+      _CUR5_RST=$_SE_VALUE
+      [ "$_CUR5_RST" -gt "$NOW" ] && [ "$_CUR5_RST" -le $(( NOW + RL_MAX_5H )) ] && _CUR5_VALID=1
     fi
-  )
-  IFS=$'\n' read -r -d '' -a _FB_OUT <&9 || true
-  # The brace group scopes the guard: `exec 9<&- 2>/dev/null` has no command
-  # word, so its redirection would stick for the rest of the process and silence
-  # every later diagnostic. Wrapping it keeps the close permanent and the
-  # silence temporary — one close error swallowed, nothing else.
-  { exec 9<&-; } 2>/dev/null || true
+  fi
+  if state_pct "$wd_pct"; then
+    _CUR7_PCT=$_SP_MILLI; _CUR7_CANON=$_SP_CANON
+    printf -v _CUR7_TSV '%d.%03d' $(( _CUR7_PCT / 1000 )) $(( _CUR7_PCT % 1000 ))
+    if state_payload_epoch "$wd_rst" 10; then
+      _CUR7_RST=$_SE_VALUE
+      [ "$_CUR7_RST" -gt "$NOW" ] && [ "$_CUR7_RST" -le $(( NOW + RL_MAX_7D )) ] && _CUR7_VALID=1
+    fi
+  fi
+  if [ "$_CUR5_VALID" = 1 ] && state_epoch "$NOW" 12; then
+    _CUR_BURN_SAMP=$_SE_VALUE; _CUR_BURN_RST=$_CUR5_RST
+    _CUR_BURN_PCT=$_CUR5_PCT; _CUR_BURN_TSV=$_CUR5_TSV; _CUR_BURN_VALID=1
+  fi
 
-  [ "${#_FB_OUT[@]}" -ge 13 ] || return 0
-  case "${_FB_OUT[0]}"  in ("SENT "*)   _sent="${_FB_OUT[0]#SENT }" ;;     (*) return 0 ;; esac
-  case "${_FB_OUT[1]}"  in ("BAD "*)    _bad="${_FB_OUT[1]#BAD }" ;;       (*) return 0 ;; esac
-  case "${_FB_OUT[2]}"  in ("OVER "*)   _over="${_FB_OUT[2]#OVER }" ;;     (*) return 0 ;; esac
-  case "${_FB_OUT[3]}"  in ("LBAD "*)   _lbad="${_FB_OUT[3]#LBAD }" ;;     (*) return 0 ;; esac
-  case "${_FB_OUT[4]}"  in ("RAW "*)    _SB_RAW="${_FB_OUT[4]#RAW }" ;;    (*) return 0 ;; esac
-  case "${_FB_OUT[5]}"  in ("CTOTAL "*) _SB_CAND_TOTAL="${_FB_OUT[5]#CTOTAL }" ;; (*) return 0 ;; esac
-  case "${_FB_OUT[6]}"  in ("REPN "*)   _rep_n="${_FB_OUT[6]#REPN }" ;;    (*) return 0 ;; esac
-  case "${_FB_OUT[7]}"  in ("LEGN "*)   _leg_n="${_FB_OUT[7]#LEGN }" ;;    (*) return 0 ;; esac
-  case "${_FB_OUT[8]}"  in ("S5 "*)     _S5=( ${_FB_OUT[8]#S5 } ) ;;       (*) return 0 ;; esac
-  case "${_FB_OUT[9]}"  in ("S7 "*)     _S7=( ${_FB_OUT[9]#S7 } ) ;;      (*) return 0 ;; esac
-  [ "${#_S5[@]}" -eq 6 ] && [ "${#_S7[@]}" -eq 6 ] || return 0
-  _num="$_SB_RAW$_SB_CAND_TOTAL$_rep_n$_leg_n"
-  for _off in "${_S5[@]}" "${_S7[@]}"; do _num="$_num$_off"; done
-  case "$_num" in (''|*[!0-9]*) _SB_RAW=0; _SB_CAND_TOTAL=0; return 0 ;; esac
-
-  _cand_k=$_SB_CAND_TOTAL; [ "$_cand_k" -gt 128 ] && _cand_k=128
-  _k5="${_S5[5]}"; _k7="${_S7[5]}"
-  # EOD is awk's own terminator: it is the last thing END prints, so seeing it in
-  # the expected slot proves awk ran to completion rather than being killed.
-  _off=$(( 10 + _cand_k + _leg_n + _rep_n + _k5 + _k7 ))
-  [ "${#_FB_OUT[@]}" -eq $(( _off + 3 )) ] || { _SB_RAW=0; _SB_CAND_TOTAL=0; return 0; }
-  [ "${_FB_OUT[$_off]}" = EOD ] || { _SB_RAW=0; _SB_CAND_TOTAL=0; return 0; }
-  case "${_FB_OUT[$(( _off + 1 ))]}" in
-    ("FSTAT "*) _fstat="${_FB_OUT[$(( _off + 1 ))]#FSTAT }" ;;
-    (*) _SB_RAW=0; _SB_CAND_TOTAL=0; return 0 ;;
-  esac
-  case "${_FB_OUT[$(( _off + 2 ))]}" in
-    ("ODSTAT "*) _odst="${_FB_OUT[$(( _off + 2 ))]#ODSTAT }" ;;
-    (*) _SB_RAW=0; _SB_CAND_TOTAL=0; return 0 ;;
-  esac
-
-  _off=10
-  if [ "$_cand_k" -gt 0 ]; then
-    _SB_CAND_NAMES=("${_FB_OUT[@]:$_off:$_cand_k}")
-    # Literal concatenation, not ${a[@]/#/...}: bash 5.2's default
-    # patsub_replacement expands & in the replacement, corrupting roots
-    # that contain an ampersand.
-    _SB_CAND_PATHS=()
-    for ((_pi=0; _pi<_cand_k; _pi++)); do _SB_CAND_PATHS[_pi]="$_SB_ROOT/${_SB_CAND_NAMES[$_pi]}"; done
+  _STATE_BURN_CFG="$BURN_FILE"; _STATE_RL5_CFG="$RL5H_FILE"; _STATE_RL7_CFG="$RL7D_FILE"
+  _SB_BASE=""; _SB_ROOT=""; _SL5_BASE=""; _SL5_ROOT=""; _SL7_BASE=""; _SL7_ROOT=""
+  _STATE_PATHS_OK=0; _STATE_BURN_SAFE=0; _STATE_RL5_SAFE=0; _STATE_RL7_SAFE=0
+  if state_paths_check; then
+    _SB_BASE=$_SPC_BBASE; _SB_ROOT=$_SPC_BROOT
+    _SL5_BASE=$_SPC_5BASE; _SL5_ROOT=$_SPC_5ROOT
+    _SL7_BASE=$_SPC_7BASE; _SL7_ROOT=$_SPC_7ROOT
+    _STATE_PATHS_OK=1; _STATE_BURN_SAFE=1; _STATE_RL5_SAFE=1; _STATE_RL7_SAFE=1
   fi
-  _off=$(( _off + _cand_k ))
-  if [ "$_leg_n" -gt 0 ]; then
-    _FB_SLICE=("${_FB_OUT[@]:$_off:$_leg_n}")
-    _LEG_RSTS=("${_FB_SLICE[@]%% *}")
-    _FB_TMP=("${_FB_SLICE[@]#* }")
-    _LEG_SAMPS=("${_FB_TMP[@]%% *}")
-    _LEG_PCTS=("${_FB_TMP[@]##* }")
-  fi
-  _off=$(( _off + _leg_n ))
-  if [ "$_rep_n" -gt 0 ]; then
-    _FB_SLICE=("${_FB_OUT[@]:$_off:$_rep_n}")
-    _SB_REP_RSTS=("${_FB_SLICE[@]%% *}")
-    _FB_TMP=("${_FB_SLICE[@]#* }")
-    _SB_REP_SAMPS=("${_FB_TMP[@]%% *}")
-    _SB_REP_PCTS=("${_FB_TMP[@]##* }")
-  fi
-  _off=$(( _off + _rep_n ))
-  if [ "$_k5" -gt 0 ]; then
-    _SL5_CAND_NAMES=("${_FB_OUT[@]:$_off:$_k5}")
-    _SL5_CAND_PATHS=()
-    for ((_pi=0; _pi<_k5; _pi++)); do _SL5_CAND_PATHS[_pi]="$_SL5_ROOT/${_SL5_CAND_NAMES[$_pi]}"; done
-  fi
-  _off=$(( _off + _k5 ))
-  if [ "$_k7" -gt 0 ]; then
-    _SL7_CAND_NAMES=("${_FB_OUT[@]:$_off:$_k7}")
-    _SL7_CAND_PATHS=()
-    for ((_pi=0; _pi<_k7; _pi++)); do _SL7_CAND_PATHS[_pi]="$_SL7_ROOT/${_SL7_CAND_NAMES[$_pi]}"; done
-  fi
-  _SL5_RAW="${_S5[0]}"; _SL5_CAND_TOTAL="${_S5[1]}"; _SL5_STORED_VALID="${_S5[2]}"
-  _SL5_STORED_RST="${_S5[3]}"; _SL5_STORED_PCT="${_S5[4]}"
-  _SL7_RAW="${_S7[0]}"; _SL7_CAND_TOTAL="${_S7[1]}"; _SL7_STORED_VALID="${_S7[2]}"
-  _SL7_STORED_RST="${_S7[3]}"; _SL7_STORED_PCT="${_S7[4]}"
-
-  # The two sources stay independently trusted even though one od now reads both.
-  # od takes its operands in order, so the enumeration is fully delivered before
-  # the legacy TSV is ever opened, and the sentinel certifies that delivery: no
-  # /dev/null record means od died mid-enumeration, so fail closed. That lets the
-  # directory flags rest on the enumeration alone — an unreadable or unopenable
-  # legacy TSV must not freeze the limit stores, exactly as when the legacy
-  # reader was its own pipeline. find itself exiting nonzero still fails closed.
-  [ "$_bad" = 0 ] && [ "$_over" = 0 ] && [ "$_sent" = 1 ] && [ "$_fstat" = 0 ] && _ok=1
-  [ "$_ok" = 1 ] && [ "$_SB_DIR_PREOK" = 1 ] && _SB_DIR_COMPLETE=1
-  [ "$_ok" = 1 ] && [ "$_SL5_DIR_PREOK" = 1 ] && _SL5_COMPLETE=1
-  [ "$_ok" = 1 ] && [ "$_SL7_DIR_PREOK" = 1 ] && _SL7_COMPLETE=1
-  # Every deliberate in-stream stop by awk also sets over, bad, or lbad, and
-  # this condition already rejects all three, so od's exit status only gates
-  # the legacy source when the teardown was not awk's own doing.
-  if [ "$_bad" = 0 ] && [ "$_over" = 0 ] && [ "$_lbad" = 0 ] && [ "$_sent" = 1 ] \
-     && [ "$_LEG_PREOK" = 1 ] \
-     && [ "$_odst" = 0 ]; then _LEG_COMPLETE=1
-  else _LEG_RSTS=(); _LEG_SAMPS=(); _LEG_PCTS=(); fi
+  _STATE_RL5_VALID=0; _STATE_RL5_RST=0; _STATE_RL5_PCT=0
+  _STATE_RL7_VALID=0; _STATE_RL7_RST=0; _STATE_RL7_PCT=0
+  _STATE_READY=1
 }
 
-state_revalidate_burn() {
-  local path="$1" name="$2"
-  [ "$path" = "$_SB_ROOT/$name" ] || return 1
-  state_no_symlink_path "$_SB_ROOT" || return 1
-  [ "$_SNP" = "$_SB_ROOT" ] && [ -d "$_SB_ROOT" ] || return 1
-  state_burn_name "$name" || return 1
-  [ -f "$path" ] && [ ! -L "$path" ] && [ ! -s "$path" ]
+burn_sample() {  # append one canonical validated 5h row; $1=sample $2=pct $3=reset
+  local parent
+  _BURN_APPENDED=0
+  [ "${_STATE_MUTATE:-0}" = 1 ] && [ "${_STATE_BURN_SAFE:-0}" = 1 ] \
+    && [ "${_CUR_BURN_VALID:-0}" = 1 ] || return 0
+  [ "$1" = "$_CUR_BURN_SAMP" ] && [ "$2" = "$_CUR_BURN_TSV" ] && [ "$3" = "$_CUR_BURN_RST" ] || return 0
+  parent="${_SB_BASE%/*}"; [ -n "$parent" ] || parent=/
+  if [ ! -d "$parent" ]; then
+    state_paths_revalidate || return 0
+    mkdir -p "$parent" 2>/dev/null || return 0
+  fi
+  state_paths_revalidate || return 0
+  printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$_SB_BASE" 2>/dev/null && _BURN_APPENDED=1
 }
 
-state_revalidate_limit() {
-  local root="$1" path="$2" name="$3"
-  [ "$path" = "$root/$name" ] || return 1
-  state_no_symlink_path "$root" || return 1
-  [ "$_SNP" = "$root" ] && [ -d "$root" ] || return 1
-  state_limit_name "$name" || return 1
-  [ -d "$path" ] && [ ! -L "$path" ]
+rl_dir() {  # → _RLD from a canonical configured base
+  state_store_path "$1" || { _RLD=""; return 1; }
+  _RLD=$_SS_ROOT
 }
 
-state_gc() {
-  local i limit path name id idx resolved_b=0 resolved_5=0 resolved_7=0
-  local rm_paths=() rm_ids=() rm_indexes=()
-  _SB_REMOVED=0; _SL5_REMOVED=0; _SL7_REMOVED=0
-  if [ "$_STATE_MUTATE" = 1 ] && [ "$_SB_COMPLETE" = 1 ]; then
-    limit=${#_SB_CAND_PATHS[@]}; [ "$limit" -gt 128 ] && limit=128
-    for ((i=0; i<limit; i++)); do
-      path="${_SB_CAND_PATHS[$i]}"; name="${_SB_CAND_NAMES[$i]}"
-      if [ ! -e "$path" ] && [ ! -L "$path" ]; then resolved_b=$(( resolved_b + 1 ))
-      elif state_revalidate_burn "$path" "$name"; then
-        idx=${#rm_paths[@]}; rm_paths[$idx]="$path"; rm_ids[$idx]=b; rm_indexes[$idx]=$i
-      fi
-    done
+state_limit_root_ok() {  # $1=canonical base $2=canonical root; read-only local check
+  [ "${_STATE_PATHS_OK:-0}" = 1 ] || return 1
+  if [ "$1" = "$_SL5_BASE" ] && [ "$2" = "$_SL5_ROOT" ]; then :
+  elif [ "$1" = "$_SL7_BASE" ] && [ "$2" = "$_SL7_ROOT" ]; then :
+  else return 1; fi
+  state_path_parent "$1" && state_path_leaf "$1" f && state_path_leaf "$2" d
+}
+
+state_dir_empty() {  # exact limit entries are empty directories
+  local child
+  for child in "$1"/* "$1"/.[!.]* "$1"/..?*; do
+    [ -e "$child" ] || [ -L "$child" ] || continue
+    return 1
+  done
+  return 0
+}
+
+state_limit_entry_ok() {  # $1=base $2=root $3=path $4=name
+  [ "$3" = "$2/$4" ] || return 1
+  state_limit_root_ok "$1" "$2" || return 1
+  state_limit_name "$4" || return 1
+  state_no_symlink_path "$3" || return 1
+  [ "$_SNP" = "$3" ] && [ -d "$3" ] && [ ! -L "$3" ] && state_dir_empty "$3"
+}
+
+rl_sample() {  # $1=canonical base $2=pct_milli $3=reset
+  local base="$1" pct="$2" rst="$3" root name path
+  [ "${_STATE_MUTATE:-0}" = 1 ] || return 0
+  if [ "$base" = "${_SL5_BASE:-}" ]; then
+    [ "${_STATE_RL5_SAFE:-0}" = 1 ] && [ "${_CUR5_VALID:-0}" = 1 ] \
+      && [ "$pct" = "$_CUR5_PCT" ] && [ "$rst" = "$_CUR5_RST" ] || return 0
+    root=$_SL5_ROOT
+  elif [ "$base" = "${_SL7_BASE:-}" ]; then
+    [ "${_STATE_RL7_SAFE:-0}" = 1 ] && [ "${_CUR7_VALID:-0}" = 1 ] \
+      && [ "$pct" = "$_CUR7_PCT" ] && [ "$rst" = "$_CUR7_RST" ] || return 0
+    root=$_SL7_ROOT
+  else return 0; fi
+  state_limit_root_ok "$base" "$root" || return 0
+  if [ ! -d "$root" ]; then
+    state_paths_revalidate || return 0
+    mkdir -p "$root" 2>/dev/null || return 0
+    state_limit_root_ok "$base" "$root" || return 0
   fi
-  if [ "$_STATE_MUTATE" = 1 ] && [ "$_SL5_COMPLETE" = 1 ]; then
-    limit=${#_SL5_CAND_PATHS[@]}; [ "$limit" -gt 128 ] && limit=128
-    for ((i=0; i<limit; i++)); do
-      path="${_SL5_CAND_PATHS[$i]}"; name="${_SL5_CAND_NAMES[$i]}"
-      if [ ! -e "$path" ] && [ ! -L "$path" ]; then resolved_5=$(( resolved_5 + 1 ))
-      elif state_revalidate_limit "$_SL5_ROOT" "$path" "$name"; then
-        idx=${#rm_paths[@]}; rm_paths[$idx]="$path"; rm_ids[$idx]=5; rm_indexes[$idx]=$i
-      fi
-    done
+  printf -v name '%010d_%03d.%03d' "$rst" $(( pct / 1000 )) $(( pct % 1000 ))
+  state_limit_name "$name" || return 0
+  path="$root/$name"
+  state_no_symlink_path "$path" && [ "$_SNP" = "$path" ] || return 0
+  if [ -e "$path" ] || [ -L "$path" ]; then
+    state_limit_entry_ok "$base" "$root" "$path" "$name" >/dev/null 2>&1 || true
+    return 0
   fi
-  if [ "$_STATE_MUTATE" = 1 ] && [ "$_SL7_COMPLETE" = 1 ]; then
-    limit=${#_SL7_CAND_PATHS[@]}; [ "$limit" -gt 128 ] && limit=128
-    for ((i=0; i<limit; i++)); do
-      path="${_SL7_CAND_PATHS[$i]}"; name="${_SL7_CAND_NAMES[$i]}"
-      if [ ! -e "$path" ] && [ ! -L "$path" ]; then resolved_7=$(( resolved_7 + 1 ))
-      elif state_revalidate_limit "$_SL7_ROOT" "$path" "$name"; then
-        idx=${#rm_paths[@]}; rm_paths[$idx]="$path"; rm_ids[$idx]=7; rm_indexes[$idx]=$i
-      fi
-    done
-  fi
-  if [ "${#rm_paths[@]}" -gt 0 ]; then rm -df -- "${rm_paths[@]}" 2>/dev/null || true; fi
-  for ((i=0; i<${#rm_paths[@]}; i++)); do
-    path="${rm_paths[$i]}"; id="${rm_ids[$i]}"
-    if [ ! -e "$path" ] && [ ! -L "$path" ]; then
-      case "$id" in (b) resolved_b=$(( resolved_b + 1 )) ;; (5) resolved_5=$(( resolved_5 + 1 )) ;; (7) resolved_7=$(( resolved_7 + 1 )) ;; esac
+  state_paths_revalidate || return 0
+  state_no_symlink_path "$path" && [ "$_SNP" = "$path" ] && [ ! -e "$path" ] && [ ! -L "$path" ] || return 0
+  mkdir "$path" 2>/dev/null || true
+}
+
+rl_latest() {  # $1=canonical base $2=max secs ahead $3=mutate → _LL_*
+  local base="$1" max="$2" mutate="${3:-0}" root path name raw=0 complete=1 hi="" i cut gc=0 LC_ALL=C
+  local names=() paths=() resets=() pcts=()
+  _LL_VALID=0; _LL_PCT=""; _LL_PCT_MILLI=0; _LL_RST=""
+  case "$max" in (''|*[!0-9]*) return 0 ;; esac
+  [ "${#max}" -le 6 ] && [ "$max" -ge 1 ] 2>/dev/null || return 0
+  rl_dir "$base" || return 0; root=$_RLD
+  state_limit_root_ok "$base" "$root" || return 0
+  [ -d "$root" ] || return 0
+  cut=$(( NOW + max ))
+  for path in "$root"/*; do
+    [ -e "$path" ] || [ -L "$path" ] || continue
+    raw=$(( raw + 1 )); if [ "$raw" -gt 512 ]; then complete=0; break; fi
+    name=${path##*/}
+    state_limit_name "$name" || continue
+    [ -d "$path" ] && [ ! -L "$path" ] && state_dir_empty "$path" || continue
+    i=${#names[@]}; names[$i]="$name"; paths[$i]="$path"; resets[$i]=$_SLN_RST; pcts[$i]=$_SLN_PCT
+    if [ "$_SLN_RST" -gt "$NOW" ] && [ "$_SLN_RST" -le "$cut" ]; then
+      [ -n "$hi" ] && [[ "$name" < "$hi" ]] || hi="$name"
     fi
   done
-  _SB_REMOVED=$resolved_b; _SL5_REMOVED=$resolved_5; _SL7_REMOVED=$resolved_7
-  _SB_CLEAN=0; _SL5_CLEAN=0; _SL7_CLEAN=0
-  [ "$_SB_CAND_TOTAL" -eq "$resolved_b" ] && _SB_CLEAN=1
-  [ "$_SL5_CAND_TOTAL" -eq "$resolved_5" ] && _SL5_CLEAN=1
-  [ "$_SL7_CAND_TOTAL" -eq "$resolved_7" ] && _SL7_CLEAN=1
+  [ "$complete" = 1 ] || return 0
+  if [ -n "$hi" ]; then
+    for ((i=0; i<${#names[@]}; i++)); do
+      if [ "${names[$i]}" = "$hi" ] && state_limit_entry_ok "$base" "$root" "${paths[$i]}" "$hi"; then
+        _LL_VALID=1; _LL_RST=${resets[$i]}; _LL_PCT_MILLI=${pcts[$i]}
+        printf -v _LL_PCT '%03d.%03d' $(( _LL_PCT_MILLI / 1000 )) $(( _LL_PCT_MILLI % 1000 ))
+        break
+      fi
+    done
+  fi
+  [ "$mutate" = 1 ] || return 0
+  for ((i=0; i<${#names[@]}; i++)); do [ "${names[$i]}" = "$hi" ] || { gc=1; break; }; done
+  [ "$gc" = 1 ] || return 0
+  state_paths_revalidate && state_limit_root_ok "$base" "$root" || return 0
+  for ((i=0; i<${#names[@]}; i++)); do
+    [ "${names[$i]}" = "$hi" ] && continue
+    state_limit_entry_ok "$base" "$root" "${paths[$i]}" "${names[$i]}" || continue
+    rmdir "${paths[$i]}" 2>/dev/null || true
+  done
 }
 
-state_select_limit() {  # $1=5|7, includes the current canonical payload value
-  local which="$1" valid=0 rst=0 pct=0 crst cpct
-  if [ "$which" = 5 ]; then
-    if [ "$_SL5_COMPLETE" = 1 ] && [ "$_SL5_STORED_VALID" = 1 ]; then valid=1; rst=$_SL5_STORED_RST; pct=$_SL5_STORED_PCT; fi
-    if [ "$_CUR5_VALID" = 1 ]; then crst=$_CUR5_RST; cpct=$_CUR5_PCT
-    else crst=0; cpct=0; fi
-  else
-    if [ "$_SL7_COMPLETE" = 1 ] && [ "$_SL7_STORED_VALID" = 1 ]; then valid=1; rst=$_SL7_STORED_RST; pct=$_SL7_STORED_PCT; fi
-    if [ "$_CUR7_VALID" = 1 ]; then crst=$_CUR7_RST; cpct=$_CUR7_PCT
-    else crst=0; cpct=0; fi
-  fi
-  if [ "$crst" -gt 0 ] && { [ "$valid" -eq 0 ] || [ "$crst" -gt "$rst" ] || { [ "$crst" -eq "$rst" ] && [ "$cpct" -gt "$pct" ]; }; }; then
+rl_choose() {  # $1=5|7; merge canonical current value with the read-only high-water
+  local which="$1" valid="$_LL_VALID" rst="${_LL_RST:-0}" pct="$_LL_PCT_MILLI" crst cpct cvalid
+  if [ "$which" = 5 ]; then cvalid=$_CUR5_VALID; crst=$_CUR5_RST; cpct=$_CUR5_PCT
+  else cvalid=$_CUR7_VALID; crst=$_CUR7_RST; cpct=$_CUR7_PCT; fi
+  if [ "$cvalid" = 1 ] && { [ "$valid" = 0 ] || [ "$crst" -gt "$rst" ] || { [ "$crst" -eq "$rst" ] && [ "$cpct" -gt "$pct" ]; }; }; then
     valid=1; rst=$crst; pct=$cpct
   fi
   if [ "$which" = 5 ]; then _STATE_RL5_VALID=$valid; _STATE_RL5_RST=$rst; _STATE_RL5_PCT=$pct
   else _STATE_RL7_VALID=$valid; _STATE_RL7_RST=$rst; _STATE_RL7_PCT=$pct; fi
 }
 
-state_publish() {
-  local raw_post i slot name path
-  local mkdir_paths=()
-  _PUB_BURN=0; _PUB5=0; _PUB7=0
-  if [ "$_STATE_MUTATE" = 1 ] && [ "$_SB_COMPLETE" = 1 ] && [ "$_SB_CLEAN" = 1 ] && [ "$_CUR_BURN_VALID" = 1 ]; then
-    raw_post=$(( _SB_RAW - _SB_REMOVED ))
-    [ "$raw_post" -lt 3968 ] && _PUB_BURN=1
-  fi
-  if [ "$_STATE_MUTATE" = 1 ] && [ "$_SL5_COMPLETE" = 1 ] && [ "$_SL5_CLEAN" = 1 ] && [ "$_CUR5_VALID" = 1 ]; then
-    raw_post=$(( _SL5_RAW - _SL5_REMOVED )); [ "$raw_post" -lt 384 ] && _PUB5=1
-  fi
-  if [ "$_STATE_MUTATE" = 1 ] && [ "$_SL7_COMPLETE" = 1 ] && [ "$_SL7_CLEAN" = 1 ] && [ "$_CUR7_VALID" = 1 ]; then
-    raw_post=$(( _SL7_RAW - _SL7_REMOVED )); [ "$raw_post" -lt 384 ] && _PUB7=1
-  fi
-  if [ "$_PUB_BURN" = 1 ] && [ ! -d "$_SB_ROOT" ]; then
-    state_no_symlink_path "$_SB_ROOT" && mkdir_paths[${#mkdir_paths[@]}]="$_SB_ROOT" || _PUB_BURN=0
-  fi
-  if [ "$_PUB5" = 1 ]; then
-    printf -v name '%010d_%03d.%03d' "$_CUR5_RST" $(( _CUR5_PCT / 1000 )) $(( _CUR5_PCT % 1000 ))
-    _PUB5_PATH="$_SL5_ROOT/$name"
-    state_no_symlink_path "$_PUB5_PATH" && mkdir_paths[${#mkdir_paths[@]}]="$_PUB5_PATH" || _PUB5=0
-  fi
-  if [ "$_PUB7" = 1 ]; then
-    printf -v name '%010d_%03d.%03d' "$_CUR7_RST" $(( _CUR7_PCT / 1000 )) $(( _CUR7_PCT % 1000 ))
-    _PUB7_PATH="$_SL7_ROOT/$name"
-    state_no_symlink_path "$_PUB7_PATH" && mkdir_paths[${#mkdir_paths[@]}]="$_PUB7_PATH" || _PUB7=0
-  fi
-  if [ "${#mkdir_paths[@]}" -gt 0 ]; then mkdir -p -- "${mkdir_paths[@]}" 2>/dev/null || true; fi
-  if [ "$_PUB5" = 1 ]; then state_revalidate_limit "$_SL5_ROOT" "$_PUB5_PATH" "${_PUB5_PATH##*/}" || _PUB5=0; fi
-  if [ "$_PUB7" = 1 ]; then state_revalidate_limit "$_SL7_ROOT" "$_PUB7_PATH" "${_PUB7_PATH##*/}" || _PUB7=0; fi
-  if [ "$_PUB_BURN" = 1 ]; then
-    state_no_symlink_path "$_SB_ROOT" || _PUB_BURN=0
-    [ "$_SNP" = "$_SB_ROOT" ] && [ -d "$_SB_ROOT" ] && [ ! -L "$_SB_ROOT" ] || _PUB_BURN=0
-  fi
-  if [ "$_PUB_BURN" = 1 ]; then
-    set -C
-    for ((slot=0; slot<32; slot++)); do
-      printf -v name 'b_%012d_%012d_%03d.%03d_%04d' "$_CUR_BURN_RST" "$_CUR_BURN_SAMP" \
-        $(( _CUR_BURN_PCT / 1000 )) $(( _CUR_BURN_PCT % 1000 )) "$slot"
-      path="$_SB_ROOT/$name"
-      if { : > "$path"; } 2>/dev/null; then _PUB_BURN_PATH="$path"; break; fi
-      [ -e "$path" ] || [ -L "$path" ] || break
-    done
-    set +C
-  fi
-}
-
-state_est_insert() {  # insert one observation into _EST_* ordered by reset/sample/pct
-  local rst="$1" samp="$2" pct="$3" key i j n LC_ALL=C
-  printf -v key '%012d_%012d_%06d' "$rst" "$samp" "$pct"
-  n=${#_EST_KEYS[@]}; j=$n
-  while [ "$j" -gt 0 ] && [[ "$key" < "${_EST_KEYS[$((j-1))]}" ]]; do
-    _EST_KEYS[$j]="${_EST_KEYS[$((j-1))]}"; _EST_RSTS[$j]="${_EST_RSTS[$((j-1))]}"
-    _EST_SAMPS[$j]="${_EST_SAMPS[$((j-1))]}"; _EST_PCTS[$j]="${_EST_PCTS[$((j-1))]}"; j=$(( j - 1 ))
-  done
-  _EST_KEYS[$j]="$key"; _EST_RSTS[$j]="$rst"; _EST_SAMPS[$j]="$samp"; _EST_PCTS[$j]="$pct"
-}
-
-burn_eta_5h() {  # → _B5_STATE _B5_ETA _B5_RATE _B5_TTR from complete state snapshot
-  local i n maxrst=0 rst samp pct last_key="" last_samp=-1 last_pct=0
-  local a b ct cutoff fc_t=0 fc_p=-1 lc_t=0 lc_p=-1 ncross=0 anycross=0
-  local minspan span delta latest_pct=0
-  local mi mj mn mm
+burn_eta_5h() {  # → _B5_* from canonical TSV; $1=allow trim/heal mutation
+  local mutate="${1:-0}" src=/dev/null tmp="" write_tmp=0 out="" rc state span delta latest ttr
   _B5_STATE=warming; _B5_ETA=inf; _B5_RATE="0.0000000000"; _B5_TTR=0
-  [ "$_SB_COMPLETE" = 1 ] || return 0
-  for ((i=0; i<${#_SB_REP_RSTS[@]}; i++)); do [ "${_SB_REP_RSTS[$i]}" -gt "$maxrst" ] && maxrst="${_SB_REP_RSTS[$i]}"; done
-  for ((i=0; i<${#_LEG_RSTS[@]}; i++)); do [ "${_LEG_RSTS[$i]}" -gt "$maxrst" ] && maxrst="${_LEG_RSTS[$i]}"; done
-  [ "$_CUR_BURN_VALID" != 1 ] || [ "$_CUR_BURN_RST" -le "$maxrst" ] || maxrst=$_CUR_BURN_RST
-  [ "$maxrst" -gt 0 ] || return 0
-  _EST_KEYS=(); _EST_RSTS=(); _EST_SAMPS=(); _EST_PCTS=()
-  # state_scan key-sorts both live and retained legacy rows, so feed the
-  # insertion sort a merged sequence: every production insert lands at the tail
-  # in constant time. Direct callers with out-of-order arrays stay correct via
-  # the old insertion fallback. Ties take the live element first, matching
-  # the old order (inserts landed after equal keys, and live rows were
-  # inserted before legacy ones).
-  mi=0; mj=0; mn=${#_SB_REP_RSTS[@]}; mm=${#_LEG_RSTS[@]}
-  while :; do
-    while [ "$mi" -lt "$mn" ] && [ "${_SB_REP_RSTS[$mi]}" -ne "$maxrst" ]; do mi=$((mi+1)); done
-    while [ "$mj" -lt "$mm" ] && [ "${_LEG_RSTS[$mj]}" -ne "$maxrst" ]; do mj=$((mj+1)); done
-    if [ "$mi" -lt "$mn" ] && [ "$mj" -lt "$mm" ]; then
-      if [ "${_LEG_SAMPS[$mj]}" -lt "${_SB_REP_SAMPS[$mi]}" ] || { [ "${_LEG_SAMPS[$mj]}" -eq "${_SB_REP_SAMPS[$mi]}" ] && [ "${_LEG_PCTS[$mj]}" -lt "${_SB_REP_PCTS[$mi]}" ]; }; then
-        state_est_insert "${_LEG_RSTS[$mj]}" "${_LEG_SAMPS[$mj]}" "${_LEG_PCTS[$mj]}"; mj=$((mj+1))
-      else
-        state_est_insert "${_SB_REP_RSTS[$mi]}" "${_SB_REP_SAMPS[$mi]}" "${_SB_REP_PCTS[$mi]}"; mi=$((mi+1))
-      fi
-    elif [ "$mi" -lt "$mn" ]; then
-      state_est_insert "${_SB_REP_RSTS[$mi]}" "${_SB_REP_SAMPS[$mi]}" "${_SB_REP_PCTS[$mi]}"; mi=$((mi+1))
-    elif [ "$mj" -lt "$mm" ]; then
-      state_est_insert "${_LEG_RSTS[$mj]}" "${_LEG_SAMPS[$mj]}" "${_LEG_PCTS[$mj]}"; mj=$((mj+1))
-    else break; fi
-  done
-  [ "$_CUR_BURN_VALID" != 1 ] || [ "$_CUR_BURN_RST" -ne "$maxrst" ] || state_est_insert "$_CUR_BURN_RST" "$_CUR_BURN_SAMP" "$_CUR_BURN_PCT"
-  _SER_SAMPS=(); _SER_PCTS=(); n=${#_EST_KEYS[@]}
-  for ((i=0; i<n; i++)); do
-    rst="${_EST_RSTS[$i]}"; samp="${_EST_SAMPS[$i]}"; pct="${_EST_PCTS[$i]}"
-    key="${rst}_${samp}_${pct}"
-    [ "$key" = "$last_key" ] && continue
-    last_key="$key"
-    if [ "$samp" -ne "$last_samp" ]; then
-      _SER_SAMPS[${#_SER_SAMPS[@]}]="$samp"; _SER_PCTS[${#_SER_PCTS[@]}]="$pct"; last_samp=$samp
-    elif [ "$pct" -gt "${_SER_PCTS[$(( ${#_SER_PCTS[@]} - 1 ))]}" ]; then
-      _SER_PCTS[$(( ${#_SER_PCTS[@]} - 1 ))]="$pct"
-    fi
-  done
-  n=${#_SER_SAMPS[@]}; [ "$n" -gt 0 ] || return 0
-  latest_pct="${_SER_PCTS[$((n-1))]}"; _B5_TTR=$(( maxrst - NOW )); [ "$_B5_TTR" -lt 0 ] && _B5_TTR=0
-  cutoff=$(( NOW - CORALLINE_BURN_WINDOW )); minspan=$(( CORALLINE_BURN_WINDOW / 10 ))
-  for ((i=1; i<n; i++)); do
-    a=$(( ${_SER_PCTS[$((i-1))]} / 1000 )); b=$(( ${_SER_PCTS[$i]} / 1000 ))
-    if [ "$b" -gt "$a" ]; then
-      anycross=1; ct="${_SER_SAMPS[$i]}"
-      if [ "$ct" -ge "$cutoff" ] && [ "$ct" -le "$NOW" ]; then
-        if [ "$fc_p" -lt 0 ]; then fc_t=$ct; fc_p=$b; fi
-        lc_t=$ct; lc_p=$b; ncross=$(( ncross + 1 ))
-      fi
-    fi
-  done
-  if [ "$ncross" -ge 2 ] && [ "$lc_t" -gt "$fc_t" ] && [ "$lc_p" -gt "$fc_p" ] && [ $(( lc_t - fc_t )) -ge "$minspan" ]; then
-    span=$(( lc_t - fc_t )); delta=$(( lc_p - fc_p ))
-    state_rate10 $(( delta * 10000000000 )) "$span"; _B5_RATE="$_RATE10"
-    state_round_even $(( (100000 - latest_pct) * span )) $(( delta * 1000 ))
-    _B5_ETA=$_RE; _B5_STATE=active
-  elif [ "$anycross" -eq 1 ] && [ "$ncross" -eq 0 ]; then _B5_STATE=idle
+  if [ "${_STATE_BURN_SAFE:-0}" = 1 ] && state_path_object "$_SB_BASE" f; then src=$_SB_BASE; fi
+  if [ "$mutate" = 1 ] && [ "$src" != /dev/null ]; then
+    tmp="$_SB_BASE.$$.tmp"
+    if state_paths_revalidate && state_no_symlink_path "$tmp" && [ "$_SNP" = "$tmp" ] \
+       && [ ! -e "$tmp" ] && [ ! -L "$tmp" ]; then write_tmp=1; fi
   fi
+  out=$(LC_ALL=C awk -F '\t' -v now="$NOW" -v win="$CORALLINE_BURN_WINDOW" \
+    -v trim="$BURN_TRIM" -v maxahead="$RL_MAX_5H" -v mutate="$write_tmp" -v tmp="$tmp" \
+    -v curvalid="${_CUR_BURN_VALID:-0}" -v csamp="${_CUR_BURN_SAMP:-0}" \
+    -v cpct="${_CUR_BURN_PCT:-0}" -v crst="${_CUR_BURN_RST:-0}" '
+    function epoch(raw, value) {
+      if (length(raw) < 1 || length(raw) > 12 || raw !~ /^(0|[1-9][0-9]*)$/) return -1
+      if (length(raw) == 12 && raw > "253402300799") return -1
+      value = raw + 0
+      if (value < 0 || value > 253402300799) return -1
+      return value
+    }
+    function pct_milli(raw, parts, whole, frac, six, keep, rest, milli) {
+      if (length(raw) < 1 || length(raw) > 10) return -1
+      if (raw ~ /^[0-9][0-9][0-9]\.[0-9][0-9][0-9]$/) {
+        whole = substr(raw, 1, 3) + 0; frac = substr(raw, 5, 3)
+        if (whole > 100 || (whole == 100 && frac ~ /[1-9]/)) return -1
+      } else {
+        if (raw !~ /^(0|[1-9][0-9]?|100)(\.[0-9]{1,6})?$/) return -1
+        parts = split(raw, pp, "."); whole = pp[1]; frac = (parts == 2 ? pp[2] : "")
+        if (whole == "100" && frac ~ /[1-9]/) return -1
+      }
+      six = substr(frac "000000", 1, 6); keep = substr(six, 1, 3) + 0; rest = substr(six, 4, 3) + 0
+      milli = (whole + 0) * 1000 + keep
+      if (rest > 500 || (rest == 500 && milli % 2 == 1)) milli++
+      if (milli < 0 || milli > 100000) return -1
+      return milli
+    }
+    function canon(m) { return sprintf("%d.%03d", int(m / 1000), m % 1000) }
+    function add_obs(r, s, p, key, at) {
+      key = r SUBSEP s
+      if (!(key in pos)) { at = ++n; pos[key] = at; rs[at] = r; sm[at] = s; pc[at] = p }
+      else { at = pos[key]; if (p > pc[at]) pc[at] = p }
+    }
+    {
+      physical++; bytes += length($0) + 1
+      if (physical > 4096 || bytes > 1048576 || length($0) > 4096) { incomplete = 1; exit }
+      nf = split($0, f, "\t")
+      if (nf != 3) next
+      s = epoch(f[1]); p = pct_milli(f[2]); r = epoch(f[3])
+      if (s < 0 || p < 0 || r < 0) next
+      if (s > now + 300 || r < s || r > now + maxahead) { heal = 1; next }
+      add_obs(r, s, p)
+    }
+    END {
+      if (incomplete) { print "incomplete"; exit }
+      if (mutate && (physical > trim || heal)) {
+        lo = n - trim + 1; if (lo < 1) lo = 1
+        printf "%s", "" > tmp
+        for (i = lo; i <= n; i++) printf "%.0f\t%s\t%.0f\n", sm[i], canon(pc[i]), rs[i] >> tmp
+        close(tmp)
+      }
+      if (curvalid) add_obs(crst + 0, csamp + 0, cpct + 0)
+      maxrst = 0
+      for (i = 1; i <= n; i++) if (rs[i] > maxrst) maxrst = rs[i]
+      if (maxrst <= 0) { print "warming 0 0 0 0"; exit }
+      m = 0
+      for (i = 1; i <= n; i++) if (rs[i] == maxrst) {
+        sk = sm[i] ""
+        if (!(sk in spos)) { j = ++m; spos[sk] = j; ss[j] = sm[i]; sp[j] = pc[i] }
+        else { j = spos[sk]; if (pc[i] > sp[j]) sp[j] = pc[i] }
+      }
+      if (m == 0) { print "warming 0 0 0 0"; exit }
+      latest = sp[m]; ttr = maxrst - now; if (ttr < 0) ttr = 0
+      cutoff = now - win; minspan = int(win / 10)
+      fc_t = 0; fc_p = -1; lc_t = 0; lc_p = -1; ncross = 0; anycross = 0
+      for (i = 2; i <= m; i++) {
+        a = int(sp[i-1] / 1000); b = int(sp[i] / 1000)
+        if (b > a) {
+          anycross = 1; ct = ss[i]
+          if (ct >= cutoff && ct <= now) {
+            if (fc_p < 0) { fc_t = ct; fc_p = b }
+            lc_t = ct; lc_p = b; ncross++
+          }
+        }
+      }
+      if (ncross >= 2 && lc_t > fc_t && lc_p > fc_p && (lc_t - fc_t) >= minspan)
+        printf "active %.0f %.0f %.0f %.0f\n", lc_t - fc_t, lc_p - fc_p, latest, ttr
+      else if (anycross && ncross == 0) printf "idle 0 0 %.0f %.0f\n", latest, ttr
+      else printf "warming 0 0 %.0f %.0f\n", latest, ttr
+    }
+  ' "$src" 2>/dev/null); rc=$?
+
+  if [ -n "$tmp" ] && [ -f "$tmp" ] && [ ! -L "$tmp" ]; then
+    if [ "$rc" -eq 0 ] && state_paths_revalidate && state_no_symlink_path "$tmp" && [ "$_SNP" = "$tmp" ]; then
+      mv -f "$tmp" "$_SB_BASE" 2>/dev/null || true
+    elif state_paths_revalidate && state_no_symlink_path "$tmp" && [ "$_SNP" = "$tmp" ]; then
+      rm -f "$tmp" 2>/dev/null || true
+    fi
+  fi
+  [ "$rc" -eq 0 ] || return 0
+  read -r state span delta latest ttr <<EOF
+$out
+EOF
+  case "$state" in
+    (active)
+      case "$span$delta$latest$ttr" in (''|*[!0-9]*) return 0 ;; esac
+      [ "$span" -gt 0 ] && [ "$delta" -gt 0 ] || return 0
+      state_rate10 $(( delta * 10000000000 )) "$span"; _B5_RATE=$_RATE10
+      state_round_even $(( (100000 - latest) * span )) $(( delta * 1000 )) || return 0
+      _B5_STATE=active; _B5_ETA=$_RE; _B5_TTR=$ttr
+      ;;
+    (idle|warming)
+      case "$ttr" in (''|*[!0-9]*) ttr=0 ;; esac
+      _B5_STATE=$state; _B5_TTR=$ttr
+      ;;
+  esac
 }
 
 burn_eta_7d() {  # → _B7_*; $1=pct_milli $2=reset epoch
@@ -1152,12 +891,16 @@ burn_eta_7d() {  # → _B7_*; $1=pct_milli $2=reset epoch
   _B7_TTR=$(( rst - NOW )); [ "$_B7_TTR" -lt 0 ] && _B7_TTR=0
   elapsed=$(( NOW - (rst - 604800) ))
   [ "$pct" -gt 0 ] && [ "$elapsed" -ge 1 ] && [ "$elapsed" -le "$RL_MAX_7D" ] || return 0
-  state_rate10 $(( pct * 10000000 )) "$elapsed"; _B7_RATE="$_RATE10"
+  state_rate10 $(( pct * 10000000 )) "$elapsed"; _B7_RATE=$_RATE10
   state_round_even $(( (100000 - pct) * elapsed )) "$pct"; _B7_ETA=$_RE
 }
 
 burn_estimate() {  # → _BURN_STATE _BURN_LABEL _BURN_ETA _BURN_RATE _BURN_TTR
   local f5=0 f7=0
+  burn_eta_5h "${_STATE_MUTATE:-0}"
+  if [ "$VL_LIMIT_SYNC" = 1 ] && [ "${_STATE_RL7_VALID:-0}" = 1 ]; then burn_eta_7d "$_STATE_RL7_PCT" "$_STATE_RL7_RST"
+  elif [ "${_CUR7_VALID:-0}" = 1 ]; then burn_eta_7d "$_CUR7_PCT" "$_CUR7_RST"
+  else burn_eta_7d "" ""; fi
   [ "$_B5_ETA" != inf ] && f5=1
   [ "$_B7_ETA" != inf ] && f7=1
   if [ "$f5" = 1 ] && { [ "$f7" = 0 ] || [ "$_B5_ETA" -le "$_B7_ETA" ]; }; then
@@ -1168,100 +911,6 @@ burn_estimate() {  # → _BURN_STATE _BURN_LABEL _BURN_ETA _BURN_RATE _BURN_TTR
     _BURN_ETA=inf; _BURN_RATE="0.0000000000"; _BURN_TTR=0; _BURN_LABEL=""
     if [ "$_B5_STATE" = idle ]; then _BURN_STATE=idle; else _BURN_STATE=warming; fi
   fi
-}
-
-state_prepare() {  # one state snapshot/GC/publication/estimate pass per render
-  local root i
-  _STATE_MUTATE=1; [ "${CORALLINE_NO_SAMPLE:-0}" = 1 ] && _STATE_MUTATE=0
-  RL_MAX_5H=21600; RL_MAX_7D=691200
-  case "$CORALLINE_BURN_WINDOW" in (''|*[!0-9]*) CORALLINE_BURN_WINDOW=600 ;; esac
-  [ "${#CORALLINE_BURN_WINDOW}" -le 5 ] && [ "$CORALLINE_BURN_WINDOW" -ge 60 ] 2>/dev/null \
-    && [ "$CORALLINE_BURN_WINDOW" -le 86400 ] 2>/dev/null || CORALLINE_BURN_WINDOW=600
-  case "$BURN_TRIM" in (''|*[!0-9]*) BURN_TRIM=1500 ;; esac
-  [ "${#BURN_TRIM}" -le 4 ] && [ "$BURN_TRIM" -ge 1 ] 2>/dev/null \
-    && [ "$BURN_TRIM" -le 3000 ] 2>/dev/null || BURN_TRIM=1500
-
-  _CUR5_VALID=0; _CUR7_VALID=0; _CUR_BURN_VALID=0
-  if state_pct "$fh_pct"; then
-    _CUR5_PCT=$_SP_MILLI
-    if state_payload_epoch "$fh_rst" 10; then
-      _CUR5_RST=$_SE_VALUE; _CUR5_RST_PAD=$_SE_PAD
-      [ "$_CUR5_RST" -gt "$NOW" ] && [ "$_CUR5_RST" -le $(( NOW + RL_MAX_5H )) ] && _CUR5_VALID=1
-    fi
-  fi
-  if state_pct "$wd_pct"; then
-    _CUR7_PCT=$_SP_MILLI
-    if state_payload_epoch "$wd_rst" 10; then
-      _CUR7_RST=$_SE_VALUE; _CUR7_RST_PAD=$_SE_PAD
-      [ "$_CUR7_RST" -gt "$NOW" ] && [ "$_CUR7_RST" -le $(( NOW + RL_MAX_7D )) ] && _CUR7_VALID=1
-    fi
-  fi
-  if [ "$_CUR5_VALID" = 1 ]; then
-    state_epoch "$NOW" 12
-    _CUR_BURN_SAMP=$_SE_VALUE; _CUR_BURN_SAMP_PAD=$_SE_PAD
-    _CUR_BURN_RST=$_CUR5_RST; _CUR_BURN_PCT=$_CUR5_PCT
-    [ "$_CUR_BURN_SAMP" -le $(( NOW + 300 )) ] && [ "$_CUR_BURN_RST" -ge "$_CUR_BURN_SAMP" ] && _CUR_BURN_VALID=1
-  fi
-
-  _SB_RAW=0; _SL5_RAW=0; _SL7_RAW=0
-  _STATE_FIND_ARGS=(); _STATE_LEGACY_READ=0
-  _SB_DIR_PREOK=1; _SL5_DIR_PREOK=1; _SL7_DIR_PREOK=1; _LEG_PREOK=1
-  _SB_DIR_COMPLETE=0; _SL5_COMPLETE=0; _SL7_COMPLETE=0; _LEG_COMPLETE=0; _SB_COMPLETE=0
-
-  if [ "$_STATE_BURN_GATE" = 1 ]; then
-    if state_store_path "$BURN_FILE"; then _SB_BASE=$_SS_BASE; _SB_ROOT=$_SS_ROOT
-    else _SB_DIR_PREOK=0; _LEG_PREOK=0; fi
-    if [ "$_SB_DIR_PREOK" = 1 ]; then
-      state_no_symlink_path "$_SB_ROOT" || _SB_DIR_PREOK=0
-      if [ "$_SB_DIR_PREOK" = 1 ] && { [ -e "$_SB_ROOT" ] || [ -L "$_SB_ROOT" ]; }; then
-        [ -d "$_SB_ROOT" ] && [ ! -L "$_SB_ROOT" ] || _SB_DIR_PREOK=0
-        [ "$_SB_DIR_PREOK" = 0 ] || _STATE_FIND_ARGS[${#_STATE_FIND_ARGS[@]}]="$_SB_ROOT/."
-      fi
-      state_no_symlink_path "$_SB_BASE" || _LEG_PREOK=0
-      if [ "$_LEG_PREOK" = 1 ] && { [ -e "$_SB_BASE" ] || [ -L "$_SB_BASE" ]; }; then
-        [ -f "$_SB_BASE" ] && [ ! -L "$_SB_BASE" ] || _LEG_PREOK=0
-        [ "$_LEG_PREOK" = 0 ] || _STATE_LEGACY_READ=1
-      fi
-    fi
-  fi
-  if [ "$_STATE_RL5_GATE" = 1 ]; then
-    if state_store_path "$RL5H_FILE"; then _SL5_ROOT=$_SS_ROOT; else _SL5_DIR_PREOK=0; fi
-    if [ "$_SL5_DIR_PREOK" = 1 ]; then
-      state_no_symlink_path "$_SL5_ROOT" || _SL5_DIR_PREOK=0
-      if [ "$_SL5_DIR_PREOK" = 1 ] && { [ -e "$_SL5_ROOT" ] || [ -L "$_SL5_ROOT" ]; }; then
-        [ -d "$_SL5_ROOT" ] && [ ! -L "$_SL5_ROOT" ] || _SL5_DIR_PREOK=0
-        [ "$_SL5_DIR_PREOK" = 0 ] || _STATE_FIND_ARGS[${#_STATE_FIND_ARGS[@]}]="$_SL5_ROOT/."
-      fi
-    fi
-  fi
-  if [ "$_STATE_RL7_GATE" = 1 ]; then
-    if state_store_path "$RL7D_FILE"; then _SL7_ROOT=$_SS_ROOT; else _SL7_DIR_PREOK=0; fi
-    if [ "$_SL7_DIR_PREOK" = 1 ]; then
-      state_no_symlink_path "$_SL7_ROOT" || _SL7_DIR_PREOK=0
-      if [ "$_SL7_DIR_PREOK" = 1 ] && { [ -e "$_SL7_ROOT" ] || [ -L "$_SL7_ROOT" ]; }; then
-        [ -d "$_SL7_ROOT" ] && [ ! -L "$_SL7_ROOT" ] || _SL7_DIR_PREOK=0
-        [ "$_SL7_DIR_PREOK" = 0 ] || _STATE_FIND_ARGS[${#_STATE_FIND_ARGS[@]}]="$_SL7_ROOT/."
-      fi
-    fi
-  fi
-  if [ "$_STATE_BURN_GATE" = 1 ] && [ "$_STATE_RL5_GATE" = 1 ] && state_same_path "$_SB_ROOT" "$_SL5_ROOT"; then _SB_DIR_PREOK=0; _SL5_DIR_PREOK=0; fi
-  if [ "$_STATE_BURN_GATE" = 1 ] && [ "$_STATE_RL7_GATE" = 1 ] && state_same_path "$_SB_ROOT" "$_SL7_ROOT"; then _SB_DIR_PREOK=0; _SL7_DIR_PREOK=0; fi
-  if [ "$_STATE_RL5_GATE" = 1 ] && [ "$_STATE_RL7_GATE" = 1 ] && state_same_path "$_SL5_ROOT" "$_SL7_ROOT"; then _SL5_DIR_PREOK=0; _SL7_DIR_PREOK=0; fi
-
-  state_scan
-  if [ "$_STATE_BURN_GATE" = 1 ]; then [ "$_SB_DIR_COMPLETE" = 1 ] && [ "$_LEG_COMPLETE" = 1 ] && _SB_COMPLETE=1; fi
-  if [ "$_SB_COMPLETE" != 1 ]; then _SB_CAND_NAMES=(); _SB_CAND_PATHS=(); _SB_CAND_TOTAL=0; _SB_REP_RSTS=(); _SB_REP_SAMPS=(); _SB_REP_PCTS=(); fi
-  if [ "$_SL5_COMPLETE" != 1 ]; then _SL5_CAND_NAMES=(); _SL5_CAND_PATHS=(); _SL5_CAND_TOTAL=0; _SL5_STORED_VALID=0; fi
-  if [ "$_SL7_COMPLETE" != 1 ]; then _SL7_CAND_NAMES=(); _SL7_CAND_PATHS=(); _SL7_CAND_TOTAL=0; _SL7_STORED_VALID=0; fi
-  state_gc
-  state_select_limit 5; state_select_limit 7
-  state_publish
-  burn_eta_5h
-  if [ "$VL_LIMIT_SYNC" = 1 ] && [ "$_STATE_RL7_VALID" = 1 ]; then burn_eta_7d "$_STATE_RL7_PCT" "$_STATE_RL7_RST"
-  elif [ "$_CUR7_VALID" = 1 ]; then burn_eta_7d "$_CUR7_PCT" "$_CUR7_RST"
-  else burn_eta_7d "" ""; fi
-  burn_estimate
-  _STATE_READY=1
 }
 
 seg_burn() {  # range-to-empty ETA until the binding 5h/7d limit hits 100% at the recent burn rate
@@ -1958,9 +1607,9 @@ _SEG_SCAN=" $VL_SEGMENTS $VL_SEGMENTS2 $VL_SEGMENTS3 "
 [ "$VL_FLOAT" = "1" ] && _SEG_SCAN="$_SEG_SCAN$VL_FLOAT_SEGMENTS "
 case "$_SEG_SCAN" in *" git "*|*" stash "*|*" project "*) read_git ;; esac
 
-# Burn and synced limits share one bounded snapshot. The disabled/default path
-# never opens the controller; CORALLINE_NO_SAMPLE keeps the same reads but makes
-# GC, publication, healing, and root creation impossible.
+# The disabled/default path performs no state work. Enabled paths canonicalize
+# values and namespaces once, then use the released TSV/compact-directory flow.
+# CORALLINE_NO_SAMPLE keeps every read but forbids all state mutation.
 _STATE_READY=0; _STATE_BURN_GATE=0; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0
 case "$_SEG_SCAN" in (*" burn "*) _STATE_BURN_GATE=1 ;; esac
 if [ "$VL_LIMIT_SYNC" = 1 ]; then
@@ -1968,7 +1617,17 @@ if [ "$VL_LIMIT_SYNC" = 1 ]; then
   case "$_SEG_SCAN" in (*" limit7d "*|*" burn "*) _STATE_RL7_GATE=1 ;; esac
 fi
 if [ "$_STATE_BURN_GATE" = 1 ] || [ "$_STATE_RL5_GATE" = 1 ] || [ "$_STATE_RL7_GATE" = 1 ]; then
-  state_prepare
+  state_gate
+  if [ "$_STATE_MUTATE" = 1 ]; then
+    [ "$_STATE_BURN_GATE" != 1 ] || burn_sample "$_CUR_BURN_SAMP" "$_CUR_BURN_TSV" "$_CUR_BURN_RST"
+    [ "$_STATE_RL5_GATE" != 1 ] || rl_sample "${_SL5_BASE:-}" "$_CUR5_PCT" "$_CUR5_RST"
+    [ "$_STATE_RL7_GATE" != 1 ] || rl_sample "${_SL7_BASE:-}" "$_CUR7_PCT" "$_CUR7_RST"
+  fi
+  if [ "$VL_LIMIT_SYNC" = 1 ]; then
+    if [ "$_STATE_RL5_GATE" = 1 ]; then rl_latest "${_SL5_BASE:-}" "$RL_MAX_5H" "$_STATE_MUTATE"; rl_choose 5; fi
+    if [ "$_STATE_RL7_GATE" = 1 ]; then rl_latest "${_SL7_BASE:-}" "$RL_MAX_7D" "$_STATE_MUTATE"; rl_choose 7; fi
+  fi
+  case "$_SEG_SCAN" in (*" burn "*) burn_estimate ;; esac
 fi
 
 # Defensive ANSI stripper (the VL_NOCOLOR path should already emit none) → _PLAIN.

--- a/statusline.sh
+++ b/statusline.sh
@@ -809,6 +809,17 @@ burn_eta_5h() {  # → _B5_* from canonical TSV; $1=allow trim/heal mutation
       if (!(key in pos)) { at = ++n; pos[key] = at; rs[at] = r; sm[at] = s; pc[at] = p }
       else { at = pos[key]; if (p > pc[at]) pc[at] = p }
     }
+    function qsort(a, lo, hi, i, j, mid, t) {
+      while (lo < hi) {
+        i = lo; j = hi; mid = a[int((lo + hi) / 2)] + 0
+        while (i <= j) {
+          while (a[i] + 0 < mid) i++
+          while (a[j] + 0 > mid) j--
+          if (i <= j) { t = a[i]; a[i] = a[j]; a[j] = t; i++; j-- }
+        }
+        if (j - lo < hi - i) { qsort(a, lo, j); lo = i } else { qsort(a, i, hi); hi = j }
+      }
+    }
     {
       physical++; bytes += length($0) + 1
       if (physical > 4096 || bytes > 1048576 || length($0) > 4096) { incomplete = 1; exit }
@@ -833,18 +844,21 @@ burn_eta_5h() {  # → _B5_* from canonical TSV; $1=allow trim/heal mutation
       if (maxrst <= 0) { print "warming 0 0 0 0"; exit }
       m = 0
       for (i = 1; i <= n; i++) if (rs[i] == maxrst) {
-        sk = sm[i] ""
-        if (!(sk in spos)) { j = ++m; spos[sk] = j; ss[j] = sm[i]; sp[j] = pc[i] }
-        else { j = spos[sk]; if (pc[i] > sp[j]) sp[j] = pc[i] }
+        sk = sprintf("%.0f", sm[i])
+        if (!(sk in sample_pct)) { order[++m] = sm[i]; sample_pct[sk] = pc[i] }
+        else if (pc[i] > sample_pct[sk]) sample_pct[sk] = pc[i]
       }
       if (m == 0) { print "warming 0 0 0 0"; exit }
-      latest = sp[m]; ttr = maxrst - now; if (ttr < 0) ttr = 0
+      qsort(order, 1, m)
+      sk = sprintf("%.0f", order[m]); latest = sample_pct[sk]
+      ttr = maxrst - now; if (ttr < 0) ttr = 0
       cutoff = now - win; minspan = int(win / 10)
       fc_t = 0; fc_p = -1; lc_t = 0; lc_p = -1; ncross = 0; anycross = 0
       for (i = 2; i <= m; i++) {
-        a = int(sp[i-1] / 1000); b = int(sp[i] / 1000)
+        psk = sprintf("%.0f", order[i-1]); sk = sprintf("%.0f", order[i])
+        a = int(sample_pct[psk] / 1000); b = int(sample_pct[sk] / 1000)
         if (b > a) {
-          anycross = 1; ct = ss[i]
+          anycross = 1; ct = order[i]
           if (ct >= cutoff && ct <= now) {
             if (fc_p < 0) { fc_t = ct; fc_p = b }
             lc_t = ct; lc_p = b; ncross++
@@ -858,7 +872,7 @@ burn_eta_5h() {  # → _B5_* from canonical TSV; $1=allow trim/heal mutation
     }
   ' "$src" 2>/dev/null); rc=$?
 
-  if [ -n "$tmp" ] && [ -f "$tmp" ] && [ ! -L "$tmp" ]; then
+  if [ "$write_tmp" = 1 ] && [ -f "$tmp" ] && [ ! -L "$tmp" ]; then
     if [ "$rc" -eq 0 ] && state_paths_revalidate && state_no_symlink_path "$tmp" && [ "$_SNP" = "$tmp" ]; then
       mv -f "$tmp" "$_SB_BASE" 2>/dev/null || true
     elif state_paths_revalidate && state_no_symlink_path "$tmp" && [ "$_SNP" = "$tmp" ]; then

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Immutable burn / limit state regressions. Helpers are extracted live from the
-# runtime so the parser, estimator, and trust-boundary tests cannot drift.
+# Mutable Bash burn / limit state regressions. Helpers are extracted live from
+# statusline.sh so validation, estimators, and trust-boundary checks cannot drift.
 set -u
 HERE=$(cd "$(dirname "$0")" && pwd)
 SCRIPT="$HERE/../statusline.sh"
@@ -13,7 +13,8 @@ ok() { printf 'ok    %s\n' "$1"; pass=$((pass + 1)); }
 bad() { printf 'FAIL  %s — %s\n' "$1" "$2"; fail=$((fail + 1)); }
 eq() { [ "$2" = "$3" ] && ok "$1" || bad "$1" "want=$3 got=$2"; }
 true_case() { local name="$1"; shift; if "$@"; then ok "$name"; else bad "$name" "condition failed"; fi; }
-count_entries() {
+file_bytes() { if [ -f "$1" ]; then wc -c < "$1" | tr -d ' '; else printf '0\n'; fi; }
+entry_count() {
   _COUNT=0
   [ -d "$1" ] || return 0
   for _CE in "$1"/* "$1"/.[!.]* "$1"/..?*; do
@@ -21,13 +22,15 @@ count_entries() {
     _COUNT=$(( _COUNT + 1 ))
   done
 }
-first_name() {
-  _FIRST=""
-  for _FN in "$1"/*; do [ -e "$_FN" ] || continue; _FIRST=${_FN##*/}; break; done
+snapshot_tree() {
+  local path="$1" archive="$2" parent base
+  parent=${path%/*}; base=${path##*/}; [ -n "$parent" ] || parent=/
+  (cd "$parent" && COPYFILE_DISABLE=1 LC_ALL=C tar -cf "$archive" "$base") 2>/dev/null
 }
+old_mtimes() { find "$1" -exec touch -t 202001010000 {} + 2>/dev/null; }
 
-# Pull the production implementations. The state block ends immediately before
-# seg_burn; delete that opening line so eval sees complete function definitions.
+# Pull production implementations. Every extracted function closes at column 0.
+eval "$(sed -n '/^iso_epoch() {/,/^}/p' "$SCRIPT")"
 eval "$(sed -n '/^to_epoch() {/,/^}/p' "$SCRIPT")"
 eval "$(sed -n '/^fmt_eta() {/,/^}/p' "$SCRIPT")"
 eval "$(sed -n '/^state_pct() {/,/^seg_burn() {/p' "$SCRIPT" | sed '$d')"
@@ -41,8 +44,9 @@ CORALLINE_BURN_WINDOW=600
 BURN_TRIM=1500
 VL_LIMIT_SYNC=0
 CORALLINE_NO_SAMPLE=0
+BASH_BIN=${BASH:-bash}
 
-# Strict percent grammar and exact decimal ties-to-even canonicalization.
+# Strict payload canonicalization. Oversized input is rejected before regex or arithmetic.
 pct_case() {
   if state_pct "$2"; then eq "$1 milli" "$_SP_MILLI" "$3"; eq "$1 canonical" "$_SP_CANON" "$4"
   else bad "$1" "unexpected rejection"; fi
@@ -50,536 +54,465 @@ pct_case() {
 pct_reject() { if state_pct "$2"; then bad "$1" "accepted as $_SP_CANON"; else ok "$1"; fi; }
 pct_case 'pct zero' '0' 0 '000.000'
 pct_case 'pct integer' '41' 41000 '041.000'
-pct_case 'pct six decimals' '41.200000' 41200 '041.200'
-pct_case 'pct even midpoint stays' '1.2345' 1234 '001.234'
-pct_case 'pct odd midpoint rises' '1.2355' 1236 '001.236'
-pct_case 'pct below midpoint' '1.234499' 1234 '001.234'
-pct_case 'pct above midpoint' '1.234501' 1235 '001.235'
+pct_case 'pct midpoint even' '1.2345' 1234 '001.234'
+pct_case 'pct midpoint odd' '1.2355' 1236 '001.236'
 pct_case 'pct carry to 100' '99.9995' 100000 '100.000'
-pct_case 'pct exact 100' '100.000000' 100000 '100.000'
-for _BAD_PCT in -0 00 01 +1 ' 1' '1 ' 100.000001 1,2 1e2 NaN Infinity 1.1234567 .5; do
+for _BAD_PCT in -0 00 01 +1 ' 1' '1 ' 100.000001 101 1,2 1e2 NaN Infinity 1.1234567 .5 12345678901; do
   pct_reject "pct rejects $_BAD_PCT" "$_BAD_PCT"
 done
+printf -v _LONG_PCT '%5000s' ''; _LONG_PCT=${_LONG_PCT// /9}
+pct_reject 'pct rejects oversized printable value' "$_LONG_PCT"
 
-# Strict epochs: no signs, decimals, leading zeroes, or overflow.
 state_epoch 0 12; eq 'epoch zero' "$_SE_PAD" '000000000000'
 state_epoch 253402300799 12; eq 'epoch max' "$_SE_VALUE" '253402300799'
 state_epoch 9999999999 10; eq 'limit epoch max' "$_SE_PAD" '9999999999'
-for _BAD_EP in -0 +1 01 1.0 253402300800 10000000000; do
+for _BAD_EP in -0 +1 01 1.0 253402300800 10000000000 9999999999999; do
   if state_epoch "$_BAD_EP" 10; then bad "epoch rejects $_BAD_EP" "accepted $_SE_PAD"; else ok "epoch rejects $_BAD_EP"; fi
 done
+state_payload_epoch '2026-07-31T12:34:56Z' 10 && ok 'canonical ISO epoch accepted' || bad 'canonical ISO epoch accepted' rejected
+for _BAD_ISO in '2026-07-31 12:34:56Z' '2026-07-31T12:34:56+00:00' '2026-07-31T12:34:56.1234567Z'; do
+  if state_payload_epoch "$_BAD_ISO" 10; then bad "ISO rejects $_BAD_ISO" accepted; else ok "ISO rejects $_BAD_ISO"; fi
+done
 
-# Exact rational midpoint-to-even and fixed ten-decimal rates.
 state_round_even 5 2; eq 'round-even 2.5 to even' "$_RE" 2
 state_round_even 7 2; eq 'round-even 3.5 to even' "$_RE" 4
-state_round_even 4 3; eq 'round-even below half' "$_RE" 1
-state_round_even 5 3; eq 'round-even above half' "$_RE" 2
 state_rate10 10000000000 3; eq 'rate non-divisible' "$_RATE10" '0.3333333333'
 state_rate10 19999999999 2; eq 'rate rounding carry' "$_RATE10" '1.0000000000'
 
-# Store derivation and MSYS/native-drive path identity are lexical and fork-free.
-PWD_SAVE=$PWD
+# Lexical path normalization and strict limit basename parsing stay fork-free.
+_PWD_SAVE=$PWD
 cd "$TMPD"
 state_store_path relative.tsv; eq 'relative store root' "$_SS_ROOT" "$TMPD/relative.d"
 state_store_path C:/tmp/state.tsv; eq 'native drive store root' "$_SS_ROOT" '/c/tmp/state.d'
 state_store_path 'C:\tmp\state.tsv'; eq 'backslash drive store root' "$_SS_ROOT" '/c/tmp/state.d'
-state_store_path /c/tmp/state.tsv; eq 'MSYS drive store root' "$_SS_ROOT" '/c/tmp/state.d'
-cd "$PWD_SAVE"
+cd "$_PWD_SAVE"
+state_limit_name '0001015900_041.200'; eq 'limit name reset' "$_SLN_RST" 1015900; eq 'limit name pct' "$_SLN_PCT" 41200
+for _BAD_NAME in '1015900_041.200' '0001015900_41.200' '0001015900_101.000' '0001015900_041.200x' '1+1_041.200' 'x[$(touch${IFS}pwn)]_041.200'; do
+  if state_limit_name "$_BAD_NAME" 2>/dev/null; then bad "limit name rejects $_BAD_NAME" accepted; else ok "limit name rejects $_BAD_NAME"; fi
+done
 
-reset_state_case() {
-  local root="$1"
-  rm -rf "$root"; mkdir -p "$root"
-  BURN_FILE="$root/burn.tsv"; RL5H_FILE="$root/limit5.tsv"; RL7D_FILE="$root/limit7.tsv"
-  NOW=1000000; fh_pct=41.2; fh_rst=1015900; wd_pct=30; wd_rst=1345600
-  CORALLINE_BURN_WINDOW=600; BURN_TRIM=1500; VL_LIMIT_SYNC=1; CORALLINE_NO_SAMPLE=0
-  _STATE_BURN_GATE=1; _STATE_RL5_GATE=1; _STATE_RL7_GATE=1; _STATE_READY=0
-}
-
-# Store-root identity covers exact strings, existing filesystem objects, and the
-# conservative Darwin/MSYS case rule without leaking nocasematch state.
-true_case 'same-path exact string' state_same_path "$TMPD/missing-root" "$TMPD/missing-root"
+true_case 'same-path exact' state_same_path "$TMPD/missing" "$TMPD/missing"
 mkdir -p "$TMPD/same-object"
-true_case 'same-path existing filesystem object' state_same_path "$TMPD/same-object" "$TMPD/same-object/."
+true_case 'same-path filesystem identity' state_same_path "$TMPD/same-object" "$TMPD/same-object/."
 _NCM_WAS=0; shopt -q nocasematch && _NCM_WAS=1
 shopt -u nocasematch
-case "${OSTYPE:-}" in
-  (darwin*|mingw*|msys*) true_case 'same-path conservatively folds platform case' state_same_path "$TMPD/Missing-Root" "$TMPD/missing-root" ;;
-  (*) if state_same_path "$TMPD/Missing-Root" "$TMPD/missing-root"; then bad 'same-path keeps case-sensitive spellings distinct' 'reported same path'; else ok 'same-path keeps case-sensitive spellings distinct'; fi ;;
-esac
+state_same_path "$TMPD/Missing" "$TMPD/missing" >/dev/null 2>&1 || true
 if shopt -q nocasematch; then bad 'same-path restores disabled nocasematch' 'left enabled'; else ok 'same-path restores disabled nocasematch'; fi
 shopt -s nocasematch
-state_same_path "$TMPD/Missing-Root" "$TMPD/missing-root" >/dev/null 2>&1 || true
+state_same_path "$TMPD/Missing" "$TMPD/missing" >/dev/null 2>&1 || true
 if shopt -q nocasematch; then ok 'same-path preserves enabled nocasematch'; else bad 'same-path preserves enabled nocasematch' 'left disabled'; fi
 [ "$_NCM_WAS" = 1 ] || shopt -u nocasematch
 
-# A case-only 5h/7d root alias must fail both stores closed before retention or
-# publication. Run the physical alias regression only when the volume proves it.
-CASE="$TMPD/case-root-collision"; reset_state_case "$CASE"; _STATE_BURN_GATE=0
-RL5H_FILE="$CASE/State/limit.tsv"; RL7D_FILE="$CASE/state/limit.tsv"
-mkdir -p "$CASE/State/limit.d/0001015900_040.000" "$CASE/State/limit.d/0001345600_029.000"
-if [ -d "$CASE/state/limit.d" ] && [ "$CASE/State/limit.d" -ef "$CASE/state/limit.d" ]; then
-  state_prepare
-  eq 'case-only alias marks 5h incomplete' "$_SL5_COMPLETE" 0
-  eq 'case-only alias marks 7d incomplete' "$_SL7_COMPLETE" 0
-  true_case 'case-only alias preserves canonical 5h entry' test -d "$CASE/State/limit.d/0001015900_040.000"
-  true_case 'case-only alias preserves canonical 7d entry' test -d "$CASE/State/limit.d/0001345600_029.000"
-  count_entries "$CASE/State/limit.d"; eq 'case-only alias publishes nothing' "$_COUNT" 2
-else
-  ok 'case-only 5h/7d alias unavailable on case-sensitive volume'
-fi
+unit_gate() {  # $1=root $2=now $3=5h pct $4=5h reset $5=7d pct $6=7d reset $7=read-only
+  local root="$1"
+  NOW="$2"; fh_pct="$3"; fh_rst="$4"; wd_pct="$5"; wd_rst="$6"; CORALLINE_NO_SAMPLE="$7"
+  BURN_FILE="$root/burn.tsv"; RL5H_FILE="$root/limit5.tsv"; RL7D_FILE="$root/limit7.tsv"
+  _STATE_BURN_GATE=1; _STATE_RL5_GATE=1; _STATE_RL7_GATE=1
+  VL_LIMIT_SYNC=1; CORALLINE_BURN_WINDOW=600; BURN_TRIM=1500
+  state_gate
+}
 
-# A cold render publishes immutable zero-byte burn entries and limit directories.
-CASE="$TMPD/publication"; reset_state_case "$CASE"; state_prepare
-first_name "$CASE/burn.d"; eq 'burn strict live name' "$_FIRST" 'b_000001015900_000001000000_041.200_0000'
-true_case 'burn entry zero-byte regular file' test ! -s "$CASE/burn.d/$_FIRST"
-true_case 'limit5 canonical directory' test -d "$CASE/limit5.d/0001015900_041.200"
-true_case 'limit7 canonical directory' test -d "$CASE/limit7.d/0001345600_030.000"
-true_case 'new runtime never creates legacy burn TSV' test ! -e "$CASE/burn.tsv"
-for _L in "$CASE/burn.d"/*; do case ${_L##*/} in l_*) bad 'no l_* entries' "found ${_L##*/}" ;; esac; done
-ok 'no l_* entries'
+# Canonical TSV writes remain readable by the native PowerShell legacy parser.
+CASE="$TMPD/sample"; mkdir -p "$CASE"
+unit_gate "$CASE" 1000000 41.2 1015900 30 1345600 0
+burn_sample "$_CUR_BURN_SAMP" "$_CUR_BURN_TSV" "$_CUR_BURN_RST"
+IFS= read -r _ROW < "$CASE/burn.tsv"
+eq 'burn sample canonical TSV row' "$_ROW" $'1000000\t41.200\t1015900'
+eq 'burn sample appended once' "$_BURN_APPENDED" 1
 
-# Same-second collisions consume deterministic slots and never overwrite.
-state_prepare
-true_case 'same-second slot 0001 committed' test -f "$CASE/burn.d/b_000001015900_000001000000_041.200_0001"
-i=0
-while [ "$i" -lt 32 ]; do printf -v _S '%04d' "$i"; : > "$CASE/burn.d/b_000001015900_000001000000_041.200_$_S"; i=$((i + 1)); done
-count_entries "$CASE/burn.d"; _BEFORE=$_COUNT
-_SB_RAW=0; _SB_REMOVED=0; _SB_COMPLETE=1; _SB_CLEAN=1; _SL5_COMPLETE=0; _SL7_COMPLETE=0; _STATE_MUTATE=1
-state_publish; count_entries "$CASE/burn.d"; eq '32 occupied slots skip without growth' "$_COUNT" "$_BEFORE"
+run5h() {  # $1=fixture $2=now $3=mutate
+  local root="$TMPD/run5h" trim="$BURN_TRIM"
+  rm -rf "$root"; mkdir -p "$root"
+  unit_gate "$root" "$2" '' '' '' '' 1
+  BURN_TRIM=$trim
+  printf '%b' "$1" > "$BURN_FILE"
+  _CUR_BURN_VALID=0
+  burn_eta_5h "$3"
+}
 
-# Legacy TSV is a permanent bounded read-only source, never append/trim/heal.
-CASE="$TMPD/legacy"; reset_state_case "$CASE"; fh_pct=8
-printf '999640\t6\t1015900\n999700\t7\t1015900\n999940\t8\t1015900\n1000000\t8\t1015900\n9999999\t99\t99999999\n' > "$BURN_FILE"
-cp "$BURN_FILE" "$CASE/legacy.before"
-state_prepare
-cmp -s "$BURN_FILE" "$CASE/legacy.before" && ok 'legacy bytes preserved under mutation' || bad 'legacy bytes preserved under mutation' 'content changed'
-eq 'legacy estimator active' "$_B5_STATE" active
-eq 'legacy estimator eta' "$_B5_ETA" 22080
-true_case 'live samples publish only into .d' test -d "$CASE/burn.d"
-
-# Store roots may contain any byte except / and NUL. bash 5.2's default
-# patsub_replacement expands & in a substitution replacement, so candidate
-# paths must be built by literal concatenation: a root with an ampersand
-# must still GC its stale duplicate for real, not just account for it.
-CASE="$TMPD/amp&root"; reset_state_case "$CASE"
-mkdir -p "$CASE/burn.d"
-: > "$CASE/burn.d/b_000001015900_000001000000_006.000_0000"
-: > "$CASE/burn.d/b_000001015900_000001000000_005.000_0001"
-state_prepare
-true_case 'ampersand root keeps duplicate winner' test -f "$CASE/burn.d/b_000001015900_000001000000_006.000_0000"
-true_case 'ampersand root deletes stale duplicate' test ! -e "$CASE/burn.d/b_000001015900_000001000000_005.000_0001"
-eq 'ampersand root removal accounted once' "$_SB_REMOVED" 1
-
-# Exact estimator contract: same-second maximum, rational rate/ETA, and reset isolation.
-NOW=1000360; CORALLINE_BURN_WINDOW=600; _SB_COMPLETE=1; _CUR_BURN_VALID=0
-_SB_REP_RSTS=(1015900 1015900 1015900 1015900)
-_SB_REP_SAMPS=(1000000 1000060 1000300 1000360)
-_SB_REP_PCTS=(6000 7000 8000 8000)
-_LEG_RSTS=(); _LEG_SAMPS=(); _LEG_PCTS=()
-burn_eta_5h
+# Released 5h estimator behavior: active, warming, idle, reset isolation, fractions, jitter.
+run5h '1000000\t6\t1015900\n1000060\t7\t1015900\n1000300\t8\t1015900\n1000360\t8\t1015900\n' 1000360 0
 eq '5h active state' "$_B5_STATE" active
-eq '5h exact eta' "$_B5_ETA" 22080
-eq '5h exact rate' "$_B5_RATE" '0.0041666667'
-eq '5h ttr' "$_B5_TTR" 15540
-_SB_REP_RSTS=(1015900 1015900 1015900 1015900 1015900)
-_SB_REP_SAMPS=(1000000 1000060 1000060 1000300 1000360)
-_SB_REP_PCTS=(6000 6500 7000 8000 8000)
-burn_eta_5h; eq 'same-second maximum is order-independent' "$_B5_ETA" 22080
-_SB_REP_RSTS=(1010000 1010000 1015900 1015900 1015900 1015900)
-_SB_REP_SAMPS=(1000060 1000180 1000000 1000120 1000300 1000360)
-_SB_REP_PCTS=(50000 51000 6000 7000 8000 8000)
-burn_eta_5h; eq 'latest reset isolates old windows' "$_B5_ETA" 16560
+eq '5h active eta' "$_B5_ETA" 22080
+eq '5h active rate' "$_B5_RATE" '0.0041666667'
+eq '5h active ttr' "$_B5_TTR" 15540
 
-# Migration shape: 1500 live representatives plus 512 same-reset legacy rows,
-# all legacy older than every live sample. Series must be built in bounded
-# work, not by per-row insertion into the full live array.
-NOW=1000360; CORALLINE_BURN_WINDOW=600; _SB_COMPLETE=1; _CUR_BURN_VALID=0
-_SB_REP_RSTS=(); _SB_REP_SAMPS=(); _SB_REP_PCTS=()
-for ((i=0; i<1500; i++)); do
-  _samp=$((998861 + i))
-  _SB_REP_RSTS[i]=1015900; _SB_REP_SAMPS[i]=$_samp
-  if [ "$_samp" -lt 1000000 ]; then _SB_REP_PCTS[i]=6000
-  elif [ "$_samp" -lt 1000300 ]; then _SB_REP_PCTS[i]=7000
-  else _SB_REP_PCTS[i]=8000; fi
-done
-_LEG_RSTS=(); _LEG_SAMPS=(); _LEG_PCTS=()
-for ((i=0; i<512; i++)); do
-  _LEG_RSTS[i]=1015900; _LEG_SAMPS[i]=$((998300 + i)); _LEG_PCTS[i]=5000
-done
-_STEPS=0
-set -o functrace
-trap '_STEPS=$((_STEPS+1))' DEBUG
-burn_eta_5h
-trap - DEBUG
-set +o functrace
-eq 'migration backlog state' "$_B5_STATE" active
-eq 'migration backlog series includes legacy' "${#_SER_SAMPS[@]}" 2012
-eq 'migration backlog exact eta' "$_B5_ETA" 27600
-eq 'migration backlog exact rate' "$_B5_RATE" '0.0033333333'
-eq 'migration backlog ttr' "$_B5_TTR" 15540
-[ "$_STEPS" -le 200000 ] && ok 'migration backlog bounded work' || bad 'migration backlog bounded work' "steps=$_STEPS"
-_LEG_RSTS=(); _LEG_SAMPS=(); _LEG_PCTS=()
+run5h '1000000\t6.125\t1015900\n1000060\t7.125\t1015900\n1000300\t8.125\t1015900\n1000360\t8.125\t1015900\n' 1000360 0
+eq '5h fractional pct exact eta' "$_B5_ETA" 22050
 
-NOW=1000000; burn_eta_7d 30000 1345600
+run5h '1000000\t6\t1015900\n1000060\t6.500\t1015900\n1000060\t7\t1015900\n1000300\t8\t1015900\n1000360\t8\t1015900\n' 1000360 0
+eq 'same-second maximum keeps slope' "$_B5_ETA" 22080
+
+run5h '1000000\t6\t1015900\n1000060\t50\t1010000\n1000120\t7\t1015900\n1000180\t51\t1010000\n1000300\t8\t1015900\n1000360\t8\t1015900\n' 1000360 0
+eq 'latest reset isolates old windows' "$_B5_ETA" 16560
+
+run5h '1000050\t10\t1015900\n1000150\t11\t1015900\n1000380\t13\t1015900\n1000398\t12\t1015900\n1000399\t14\t1015900\n1000400\t16\t1015900\n' 1000400 0
+eq 'cache-lag jitter stays bounded' "$_B5_ETA" 4200
+
+run5h '1000000\t6\t1015900\n1000010\t7\t1015900\n1001200\t7\t1015900\n' 1001200 0
+eq '5h idle state' "$_B5_STATE" idle
+run5h '1000000\t6\t1015900\n1000060\t7\t1015900\n' 1000100 0
+eq '5h warming state' "$_B5_STATE" warming
+run5h '1000000\t80\t1004000\n1000060\t81\t1004000\n1000120\t1\t1019000\n1000180\t2\t1019000\n' 1000200 0
+eq '5h reset rollover warms' "$_B5_STATE" warming
+
+# Sentinel healing and physical-row trim occur only when mutation is allowed.
+run5h '1000000\t6\t1015900\n1000060\t7\t1015900\n1000300\t8\t1015900\n9999000\t99\t99999999\n' 1000360 1
+eq 'burn sentinel ignored for estimate' "$_B5_ETA" 22080
+if grep -q 99999999 "$BURN_FILE"; then bad 'burn sentinel healed on mutable read' present; else ok 'burn sentinel healed on mutable read'; fi
+
+BURN_TRIM=3
+run5h '1\t6\t9\n2\t6\t9\n3\t7\t9\n4\t7\t9\n5\t8\t9\n' 6 1
+eq '5h trim physical rowcount' "$(wc -l < "$BURN_FILE" | tr -d ' ')" 3
+IFS=$'\t' read -r _FIRST _ _ < "$BURN_FILE"; eq '5h trim first kept' "$_FIRST" 3
+BURN_TRIM=3
+run5h '1\t6\t9\n1\t6.100\t9\n1\t6.200\t9\n2\t7\t9\n2\t7.100\t9\n2\t7.200\t9\n' 3 1
+eq 'resize burst collapses same-second rows' "$(wc -l < "$BURN_FILE" | tr -d ' ')" 2
+BURN_TRIM=1500
+
+# Stateless 7d estimator keeps exact rational semantics.
+NOW=1000000
+burn_eta_7d 30000 1345600
 eq '7d exact eta' "$_B7_ETA" 604800
 eq '7d exact rate' "$_B7_RATE" '0.0001157407'
 eq '7d ttr' "$_B7_TTR" 345600
 burn_eta_7d 0 1345600; eq '7d zero pct is infinite' "$_B7_ETA" inf
-_B5_STATE=active; _B5_ETA=5000; _B5_RATE=x; _B5_TTR=9000
-_B7_ETA=5000; _B7_RATE=y; _B7_TTR=9000
-burn_estimate; eq 'binding ETA tie chooses 5h' "$_BURN_LABEL" 5h
 
-# Renderer consumes the precomputed result and never triggers state I/O itself.
+# Compact limit directory high-water: reset first, pct second, malformed entries ignored.
+CASE="$TMPD/highwater"; mkdir -p "$CASE"
+unit_gate "$CASE" 1000000 15 1015900 30 1345600 0
+mkdir -p "$_SL5_ROOT/0001015800_090.000" "$_SL5_ROOT/0001015900_010.000" "$_SL5_ROOT/0001015900_020.000"
+rl_latest "$_SL5_BASE" "$RL_MAX_5H" 0
+eq 'limit high-water pct' "$_LL_PCT" '020.000'
+eq 'limit high-water reset' "$_LL_RST" 1015900
+rl_choose 5; eq 'current lower pct cannot regress high-water' "$_STATE_RL5_PCT" 20000
+rl_latest "$_SL5_BASE" "$RL_MAX_5H" 1
+entry_count "$_SL5_ROOT"; eq 'limit mutable GC keeps winner' "$_COUNT" 1
+
+rm -rf "$_SL5_ROOT"; mkdir -p "$_SL5_ROOT/0001015900_041.200"
+rl_latest "$_SL5_BASE" "$RL_MAX_5H" 0; eq 'limit fractional pct preserved' "$_LL_PCT" '041.200'
+
+rm -rf "$_SL5_ROOT"; mkdir -p "$_SL5_ROOT/0001015800_090.000"
+_CUR5_VALID=1; _CUR5_RST=1015900; _CUR5_PCT=3000
+rl_latest "$_SL5_BASE" "$RL_MAX_5H" 0; rl_choose 5
+eq 'newer reset supersedes old high pct' "$_STATE_RL5_PCT" 3000
+
+rm -rf "$_SL5_ROOT"; mkdir -p "$_SL5_ROOT/9999999999_099.000" "$_SL5_ROOT/0001015900_030.000"
+rl_latest "$_SL5_BASE" "$RL_MAX_5H" 0
+eq 'limit sentinel ignored read-only' "$_LL_PCT" '030.000'
+true_case 'limit sentinel preserved read-only' test -d "$_SL5_ROOT/9999999999_099.000"
+rl_latest "$_SL5_BASE" "$RL_MAX_5H" 1
+true_case 'limit sentinel healed when mutable' test ! -e "$_SL5_ROOT/9999999999_099.000"
+
+# Runtime helpers.
+if ! command -v jq >/dev/null 2>&1; then
+  bad 'jq prerequisite' missing
+  printf 'SUMMARY pass=%s fail=%s\n' "$pass" "$fail"
+  exit 1
+fi
+make_payload() {  # $1=path $2=p5 $3=r5 $4=p7 $5=r7
+  jq -n --arg p5 "$2" --arg r5 "$3" --arg p7 "$4" --arg r7 "$5" \
+    '{workspace:{current_dir:"/tmp"},rate_limits:{five_hour:{used_percentage:$p5,resets_at:$r5},seven_day:{used_percentage:$p7,resets_at:$r7}}}' > "$1"
+}
+write_config() {  # $1=path $2=root $3=segments $4=sync $5=trim(optional)
+  {
+    printf 'VL_SEGMENTS=%q\n' "$3"
+    printf '%s\n' 'VL_CLOCK=off' 'VL_STYLE=lean' 'VL_NOCOLOR=1' 'VL_BURN_GLYPH=B'
+    printf 'VL_LIMIT_SYNC=%q\n' "$4"
+    printf 'BURN_FILE=%q\n' "$2/burn.tsv"
+    printf 'RL5H_FILE=%q\n' "$2/limit5.tsv"
+    printf 'RL7D_FILE=%q\n' "$2/limit7.tsv"
+    [ -z "${5:-}" ] || printf 'BURN_TRIM=%q\n' "$5"
+  } > "$1"
+}
+write_paths_config() {  # $1=path $2=segments $3=sync $4=burn $5=rl5 $6=rl7 $7=trim(optional)
+  {
+    printf 'VL_SEGMENTS=%q\n' "$2"
+    printf '%s\n' 'VL_CLOCK=off' 'VL_STYLE=lean' 'VL_NOCOLOR=1' 'VL_BURN_GLYPH=B'
+    printf 'VL_LIMIT_SYNC=%q\n' "$3"
+    printf 'BURN_FILE=%q\n' "$4"
+    printf 'RL5H_FILE=%q\n' "$5"
+    printf 'RL7D_FILE=%q\n' "$6"
+    [ -z "${7:-}" ] || printf 'BURN_TRIM=%q\n' "$7"
+  } > "$1"
+}
+run_runtime() {  # $1=shell/runtime $2=config $3=input $4=stdout $5=stderr $6=no-sample
+  if [ "$6" = 1 ]; then
+    CORALLINE_CONFIG="$2" CORALLINE_NO_SAMPLE=1 "$1" "$SCRIPT" < "$3" > "$4" 2> "$5"
+  else
+    CORALLINE_CONFIG="$2" CORALLINE_NO_SAMPLE=0 "$1" "$SCRIPT" < "$3" > "$4" 2> "$5"
+  fi
+}
+run_runtime_cwd() {  # $1=cwd, remaining args match run_runtime
+  local cwd="$1"; shift
+  (cd "$cwd" && run_runtime "$@")
+}
+
+# Strict no-sample: oversized/dirty TSV, orphan tmp, immutable burn.d, limit GC
+# candidates, and every mtime remain byte-for-byte unchanged. A mutable clone
+# computes the same visible result while performing its allowed maintenance.
+CASE="$TMPD/no-sample"; STATE="$CASE/state"; MUT="$CASE/mutable"; mkdir -p "$STATE/burn.d" "$STATE/limit5.d" "$STATE/limit7.d"
+_now=$(date +%s); _r5=$((_now + 15930)); _r7=$((_now + 345630))
+_i=0; while [ "$_i" -lt 1502 ]; do printf '%s\t8\t%s\n' $((_now - 1501 + _i)) "$_r5" >> "$STATE/burn.tsv"; _i=$((_i + 1)); done
+printf '%s\t99\t9999999999\n' "$_now" >> "$STATE/burn.tsv"
+printf 'orphan-canary' > "$STATE/burn.tsv.123.tmp"
+printf 'immutable-canary' > "$STATE/burn.d/b_000000000001_000000000001_001.000_0000"
+mkdir -p "$STATE/limit5.d/$(printf '%010d_020.000' "$_r5")" "$STATE/limit5.d/9999999999_099.000" "$STATE/limit5.d/not-state"
+mkdir -p "$STATE/limit7.d/$(printf '%010d_030.000' "$_r7")" "$STATE/limit7.d/9999999999_099.000" "$STATE/limit7.d/not-state"
+cp -R "$STATE" "$MUT"
+old_mtimes "$STATE"
+write_config "$CASE/read.conf" "$STATE" 'burn limit5h limit7d' 1
+write_config "$CASE/mut.conf" "$MUT" 'burn limit5h limit7d' 1
+make_payload "$CASE/input" 8 "$_r5" 30 "$_r7"
+snapshot_tree "$STATE" "$CASE/before.tar"
+run_runtime "$BASH_BIN" "$CASE/read.conf" "$CASE/input" "$CASE/read.out" "$CASE/read.err" 1; _RC=$?
+snapshot_tree "$STATE" "$CASE/after.tar"
+run_runtime "$BASH_BIN" "$CASE/mut.conf" "$CASE/input" "$CASE/mut.out" "$CASE/mut.err" 0; _MRC=$?
+eq 'no-sample runtime exits zero' "$_RC" 0
+eq 'mutable reference exits zero' "$_MRC" 0
+if cmp -s "$CASE/before.tar" "$CASE/after.tar"; then ok 'no-sample full tree contents and mtimes unchanged'; else bad 'no-sample full tree contents and mtimes unchanged' changed; fi
+if cmp -s "$CASE/read.out" "$CASE/mut.out"; then ok 'no-sample output matches mutable reference'; else bad 'no-sample output matches mutable reference' differs; fi
+eq 'no-sample stderr empty' "$(file_bytes "$CASE/read.err")" 0
+
+CASE="$TMPD/no-sample-missing"; mkdir -p "$CASE/parent"
+write_config "$CASE/conf" "$CASE/parent/state" 'burn limit5h limit7d' 1
+make_payload "$CASE/input" 8 "$_r5" 30 "$_r7"
+old_mtimes "$CASE/parent"; snapshot_tree "$CASE/parent" "$CASE/before.tar"
+run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 1
+snapshot_tree "$CASE/parent" "$CASE/after.tar"
+if cmp -s "$CASE/before.tar" "$CASE/after.tar"; then ok 'no-sample absent roots and parent mtime unchanged'; else bad 'no-sample absent roots and parent mtime unchanged' changed; fi
+
+# Malformed, over-width, scientific, negative, >100, and oversized payload values
+# never create state. The next valid render recovers immediately.
+_invalid_pct=(-1 1e2 101 100.000001 0001 .5 12345678901 "$_LONG_PCT")
+_idx=0
+for _VALUE in "${_invalid_pct[@]}"; do
+  CASE="$TMPD/invalid-pct-$_idx"; mkdir -p "$CASE"
+  write_config "$CASE/conf" "$CASE/state" 'burn limit5h' 1
+  _now=$(date +%s); _r5=$((_now + 15930)); make_payload "$CASE/bad.json" "$_VALUE" "$_r5" '' ''
+  run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/bad.json" "$CASE/bad.out" "$CASE/bad.err" 0
+  true_case "invalid pct $_idx creates no state" test ! -e "$CASE/state"
+  eq "invalid pct $_idx stderr empty" "$(file_bytes "$CASE/bad.err")" 0
+  make_payload "$CASE/good.json" 41.2 "$_r5" '' ''
+  run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/good.json" "$CASE/good.out" "$CASE/good.err" 0
+  true_case "invalid pct $_idx recovers next render" test -s "$CASE/state/burn.tsv"
+  _idx=$((_idx + 1))
+done
+_invalid_rst=(-1 1e2 01 10000000000 9999999999999 '2026-07-31T12:34:56+00:00')
+_idx=0
+for _VALUE in "${_invalid_rst[@]}"; do
+  CASE="$TMPD/invalid-rst-$_idx"; mkdir -p "$CASE"
+  write_config "$CASE/conf" "$CASE/state" 'burn limit5h' 1
+  make_payload "$CASE/bad.json" 41.2 "$_VALUE" '' ''
+  run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/bad.json" "$CASE/bad.out" "$CASE/bad.err" 0
+  true_case "invalid reset $_idx creates no state" test ! -e "$CASE/state"
+  _now=$(date +%s); _r5=$((_now + 15930)); make_payload "$CASE/good.json" 41.2 "$_r5" '' ''
+  run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/good.json" "$CASE/good.out" "$CASE/good.err" 0
+  true_case "invalid reset $_idx recovers next render" test -s "$CASE/state/burn.tsv"
+  _idx=$((_idx + 1))
+done
+
+# Path collision, relative alias, conservative case alias, symlink base/ancestor,
+# and symlink limit-root canaries all fail soft without mutation.
+_now=$(date +%s); _r5=$((_now + 15930)); _r7=$((_now + 345630))
+CASE="$TMPD/path-exact"; mkdir -p "$CASE"; printf 'exact-canary' > "$CASE/shared.tsv"
+write_paths_config "$CASE/conf" 'burn limit5h' 1 "$CASE/shared.tsv" "$CASE/shared.tsv" "$CASE/limit7.tsv"
+make_payload "$CASE/input" 41.2 "$_r5" 30 "$_r7"
+cp "$CASE/shared.tsv" "$CASE/before"; run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 0
+if cmp -s "$CASE/shared.tsv" "$CASE/before"; then ok 'exact path collision preserves canary'; else bad 'exact path collision preserves canary' changed; fi
+
+CASE="$TMPD/path-relative"; mkdir -p "$CASE/a"; printf 'relative-canary' > "$CASE/shared.tsv"
+write_paths_config "$CASE/conf" 'burn limit5h' 1 "$CASE/a/../shared.tsv" "$CASE/shared.tsv" "$CASE/limit7.tsv"
+make_payload "$CASE/input" 41.2 "$_r5" 30 "$_r7"
+cp "$CASE/shared.tsv" "$CASE/before"; run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 0
+if cmp -s "$CASE/shared.tsv" "$CASE/before"; then ok 'relative alias collision preserves canary'; else bad 'relative alias collision preserves canary' changed; fi
+
+CASE="$TMPD/path-case"; mkdir -p "$CASE/State"; printf 'case-canary' > "$CASE/State/burn.tsv"
+write_paths_config "$CASE/conf" 'burn limit5h' 1 "$CASE/State/burn.tsv" "$CASE/state/burn.tsv" "$CASE/limit7.tsv"
+make_payload "$CASE/input" 41.2 "$_r5" 30 "$_r7"
+cp "$CASE/State/burn.tsv" "$CASE/before"; run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 0
+if cmp -s "$CASE/State/burn.tsv" "$CASE/before"; then ok 'case alias collision preserves canary'; else bad 'case alias collision preserves canary' changed; fi
+
+CASE="$TMPD/path-link"; mkdir -p "$CASE/target"; printf 'ancestor-canary' > "$CASE/target/canary"
+if ln -s "$CASE/target" "$CASE/link" 2>/dev/null; then
+  write_paths_config "$CASE/conf" 'burn limit5h' 1 "$CASE/link/burn.tsv" "$CASE/limit5.tsv" "$CASE/limit7.tsv"
+  make_payload "$CASE/input" 41.2 "$_r5" 30 "$_r7"
+  run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 0
+  eq 'symlink ancestor canary unchanged' "$(LC_ALL=C tr -d '\n' < "$CASE/target/canary")" ancestor-canary
+  true_case 'symlink ancestor receives no state' test ! -e "$CASE/target/burn.tsv"
+else ok 'symlink ancestor fixture unavailable'; fi
+
+CASE="$TMPD/path-file-link"; mkdir -p "$CASE"; printf 'file-canary' > "$CASE/target.tsv"
+if ln -s "$CASE/target.tsv" "$CASE/burn.tsv" 2>/dev/null; then
+  write_paths_config "$CASE/conf" burn 0 "$CASE/burn.tsv" "$CASE/limit5.tsv" "$CASE/limit7.tsv"
+  make_payload "$CASE/input" 41.2 "$_r5" 30 "$_r7"
+  run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 0
+  eq 'symlink file target unchanged' "$(LC_ALL=C tr -d '\n' < "$CASE/target.tsv")" file-canary
+else ok 'symlink file fixture unavailable'; fi
+
+CASE="$TMPD/path-limit-link"; mkdir -p "$CASE/target"; printf 'limit-canary' > "$CASE/target/canary"
+if ln -s "$CASE/target" "$CASE/limit5.d" 2>/dev/null; then
+  write_config "$CASE/conf" "$CASE" 'limit5h' 1
+  make_payload "$CASE/input" 41.2 "$_r5" 30 "$_r7"
+  run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 0
+  eq 'symlink limit target unchanged' "$(LC_ALL=C tr -d '\n' < "$CASE/target/canary")" limit-canary
+else ok 'symlink limit fixture unavailable'; fi
+
+# Existing immutable burn.d and unrelated temp canaries are never touched.
+CASE="$TMPD/coexist"; mkdir -p "$CASE/state/burn.d"; printf 'immutable' > "$CASE/state/burn.d/canary"
+write_config "$CASE/conf" "$CASE/state" burn 0 3
+make_payload "$CASE/input" 41.2 "$_r5" 30 "$_r7"
+snapshot_tree "$CASE/state/burn.d" "$CASE/before.tar"
+run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 0
+snapshot_tree "$CASE/state/burn.d" "$CASE/after.tar"
+if cmp -s "$CASE/before.tar" "$CASE/after.tar"; then ok 'immutable burn.d stays untouched'; else bad 'immutable burn.d stays untouched' changed; fi
+printf 'tmp-canary' > "$CASE/state/burn.tsv.keep.tmp"
+_i=0; while [ "$_i" -lt 8 ]; do run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out.$_i" "$CASE/err.$_i" 0; _i=$((_i + 1)); done
+eq 'unrelated temp canary preserved' "$(LC_ALL=C tr -d '\n' < "$CASE/state/burn.tsv.keep.tmp")" tmp-canary
+[ "$(wc -l < "$CASE/state/burn.tsv" | tr -d ' ')" -le 3 ] && ok 'repeated render TSV remains trimmed' || bad 'repeated render TSV remains trimmed' "rows=$(wc -l < "$CASE/state/burn.tsv")"
+
+# Malformed arithmetic/metacharacter basenames and nonempty canonical-looking
+# directories never displace the valid winner, emit stderr, or trigger side effects.
+CASE="$TMPD/arithmetic"; mkdir -p "$CASE/state/limit5.d"
+_now=$(date +%s); _winner=$((_now + 200)); _later=$((_now + 300))
+printf -v _WINNER '%010d_020.000' "$_winner"; printf -v _NONEMPTY '%010d_099.000' "$_later"
+mkdir -p "$CASE/state/limit5.d/$_WINNER" "$CASE/state/limit5.d/$_NONEMPTY"
+printf 'child' > "$CASE/state/limit5.d/$_NONEMPTY/canary"
+_META1='x[$(touch${IFS}ARITH_PWN)]_099.000'
+_META2='1+1_099.000'
+_META3='0000000001_099.000]||touch${IFS}ARITH_PWN||x['
+mkdir -p "$CASE/state/limit5.d/$_META1" "$CASE/state/limit5.d/$_META2" "$CASE/state/limit5.d/$_META3"
+write_config "$CASE/conf" "$CASE/state" limit5h 1
+make_payload "$CASE/input" 15 "$_winner" '' ''
+run_runtime_cwd "$CASE" "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 0; _RC=$?
+eq 'malformed basename runtime exits zero' "$_RC" 0
+eq 'malformed basename stderr empty' "$(file_bytes "$CASE/err")" 0
+true_case 'arithmetic basename creates no side effect' test ! -e "$CASE/ARITH_PWN"
+true_case 'metachar basename one preserved' test -d "$CASE/state/limit5.d/$_META1"
+true_case 'metachar basename two preserved' test -d "$CASE/state/limit5.d/$_META2"
+true_case 'metachar basename three preserved' test -d "$CASE/state/limit5.d/$_META3"
+true_case 'nonempty canonical-looking entry preserved' test -f "$CASE/state/limit5.d/$_NONEMPTY/canary"
+if LC_ALL=C grep -q '20%' "$CASE/out"; then ok 'malformed names do not displace canonical winner'; else bad 'malformed names do not displace canonical winner' "output=$(LC_ALL=C tr '\n' ' ' < "$CASE/out")"; fi
+
+# No immutable-controller tools remain on the state path. Wrappers would fail the
+# render if find or od were invoked.
+CASE="$TMPD/trace"; mkdir -p "$CASE/bin" "$CASE/state"; : > "$CASE/trace.log"
+for _TOOL in find od; do
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' 'printf "%s\n" "$0" >> "$CORALLINE_TRACE"'
+    printf '%s\n' 'exit 97'
+  } > "$CASE/bin/$_TOOL"
+  chmod +x "$CASE/bin/$_TOOL"
+done
+write_config "$CASE/conf" "$CASE/state" 'burn limit5h limit7d' 1
+make_payload "$CASE/input" 41.2 "$_r5" 30 "$_r7"
+CORALLINE_TRACE="$CASE/trace.log" PATH="$CASE/bin:$PATH" run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 0; _RC=$?
+eq 'state trace exits zero without find or od' "$_RC" 0
+eq 'state trace has no find or od calls' "$(file_bytes "$CASE/trace.log")" 0
+eq 'state trace stderr empty' "$(file_bytes "$CASE/err")" 0
+if grep -Eq 'state_scan|state_prepare|find -P|od -An' "$SCRIPT"; then bad 'immutable controller symbols removed' present; else ok 'immutable controller symbols removed'; fi
+
+# State-disabled and subagent paths perform no state work.
+CASE="$TMPD/gates"; mkdir -p "$CASE"
+write_config "$CASE/disabled.conf" "$CASE/disabled-state" dir 1
+make_payload "$CASE/input" 41.2 "$_r5" 30 "$_r7"
+run_runtime "$BASH_BIN" "$CASE/disabled.conf" "$CASE/input" "$CASE/disabled.out" "$CASE/disabled.err" 0
+true_case 'state-disabled runtime creates no state' test ! -e "$CASE/disabled-state"
+printf '%s\n' '{"columns":80,"tasks":[]}' > "$CASE/subagent.json"
+CORALLINE_CONFIG="$CASE/disabled.conf" "$BASH_BIN" "$SCRIPT" --subagent < "$CASE/subagent.json" > "$CASE/subagent.out" 2> "$CASE/subagent.err"
+true_case 'subagent runtime creates no state' test ! -e "$CASE/disabled-state"
+
+# Full-runtime concurrent correctness checker. Each worker performs two renders;
+# every exit/stdout/stderr is accounted for against one fixed no-clock oracle.
+run_concurrency() {  # $1=runtime $2=workers $3=tag
+  local runtime="$1" workers="$2" tag="$3" root i j rc path
+  local pids=()
+  root="$TMPD/concurrency-$tag-$workers"
+  rm -rf "$root"; mkdir -p "$root/state/burn.d" "$root/results"
+  printf 'immutable-concurrency-canary' > "$root/state/burn.d/canary"
+  write_config "$root/conf" "$root/state" burn 0
+  local now reset
+  now=$(date +%s); reset=$((now + 15930)); make_payload "$root/input" 10 "$reset" 0 "$((now + 345630))"
+  printf '\033[0m B … \033[0m\n' > "$root/oracle"
+  for ((i=0; i<workers; i++)); do
+    (
+      for j in 1 2; do
+        path="$root/results/$i.$j"
+        CORALLINE_CONFIG="$root/conf" CORALLINE_NO_SAMPLE=0 "$runtime" "$SCRIPT" < "$root/input" > "$path.out" 2> "$path.err"
+        rc=$?
+        printf '%s\n' "$rc" > "$path.rc"
+      done
+    ) &
+    pids[${#pids[@]}]=$!
+  done
+  for i in "${pids[@]}"; do wait "$i" 2>/dev/null || true; done
+
+  _CC_EXPECTED=$(( workers * 2 )); _CC_RCFILES=0; _CC_SUCCESS=0; _CC_NONZERO=0
+  _CC_NONEMPTY=0; _CC_MATCH=0; _CC_STDERR_EMPTY=0
+  for ((i=0; i<workers; i++)); do
+    for j in 1 2; do
+      path="$root/results/$i.$j"
+      if [ -f "$path.rc" ]; then
+        _CC_RCFILES=$(( _CC_RCFILES + 1 )); IFS= read -r rc < "$path.rc"
+        if [ "$rc" = 0 ]; then _CC_SUCCESS=$(( _CC_SUCCESS + 1 )); else _CC_NONZERO=$(( _CC_NONZERO + 1 )); fi
+      fi
+      [ -s "$path.out" ] && _CC_NONEMPTY=$(( _CC_NONEMPTY + 1 ))
+      cmp -s "$path.out" "$root/oracle" && _CC_MATCH=$(( _CC_MATCH + 1 ))
+      [ ! -s "$path.err" ] && _CC_STDERR_EMPTY=$(( _CC_STDERR_EMPTY + 1 ))
+    done
+  done
+  if [ -f "$root/state/burn.tsv" ]; then _CC_ROWS=$(wc -l < "$root/state/burn.tsv" | tr -d ' '); else _CC_ROWS=0; fi
+  _CC_IMMUTABLE=0
+  [ "$(LC_ALL=C tr -d '\n' < "$root/state/burn.d/canary")" = immutable-concurrency-canary ] && _CC_IMMUTABLE=1
+  [ "$_CC_RCFILES" -eq "$_CC_EXPECTED" ] && [ "$_CC_SUCCESS" -eq "$_CC_EXPECTED" ] \
+    && [ "$_CC_NONEMPTY" -eq "$_CC_EXPECTED" ] && [ "$_CC_MATCH" -eq "$_CC_EXPECTED" ] \
+    && [ "$_CC_STDERR_EMPTY" -eq "$_CC_EXPECTED" ] && [ "$_CC_ROWS" -eq "$_CC_EXPECTED" ] \
+    && [ "$_CC_IMMUTABLE" -eq 1 ]
+}
+
+CASE="$TMPD/fake-runtime"; mkdir -p "$CASE"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 7' > "$CASE/fail.sh"; chmod +x "$CASE/fail.sh"
+if run_concurrency "$CASE/fail.sh" 2 fake; then
+  bad 'concurrency checker rejects nonzero runtime' 'false pass'
+else
+  eq 'fake runtime nonzero exits counted' "$_CC_NONZERO" 4
+  ok 'concurrency checker rejects nonzero runtime'
+fi
+
+for _N in 5 12 16; do
+  if run_concurrency "$BASH_BIN" "$_N" "bash-${BASH_VERSINFO[0]}"; then
+    eq "concurrency n=$_N successes" "$_CC_SUCCESS" $((_N * 2))
+    eq "concurrency n=$_N exact outputs" "$_CC_MATCH" $((_N * 2))
+    eq "concurrency n=$_N stderr empty" "$_CC_STDERR_EMPTY" $((_N * 2))
+    eq "concurrency n=$_N TSV rows" "$_CC_ROWS" $((_N * 2))
+    eq "concurrency n=$_N immutable store untouched" "$_CC_IMMUTABLE" 1
+  else
+    bad "concurrency n=$_N" "expected=$_CC_EXPECTED rcfiles=$_CC_RCFILES success=$_CC_SUCCESS nonempty=$_CC_NONEMPTY match=$_CC_MATCH stderr=$_CC_STDERR_EMPTY rows=$_CC_ROWS immutable=$_CC_IMMUTABLE"
+  fi
+done
+
+# Binding and renderer regressions after state/storage tests. Stubs isolate the
+# already-tested estimators from the presentation logic.
 VL_BURN_GLYPH='↗'; VL_BG_BURN=''; VL_BG_5H=237; VL_LAYOUT=fixed
 VL_FG_OK=114; VL_FG_WARN=179; VL_FG_HOT=167; VL_FG_DIM=245; VL_NOCOLOR=0
 fh_pct=8; wd_pct=0; _STATE_READY=0
+mk5h() { _B5_STATE="$1"; _B5_ETA="$2"; _B5_RATE="$3"; _B5_TTR="$4"; }
+mk7d() { _B7_ETA="$1"; _B7_RATE="$2"; _B7_TTR="$3"; }
+burn_eta_5h() { mk5h "$M5S" "$M5E" "$M5R" "$M5T"; }
+burn_eta_7d() { mk7d "$M7E" "$M7R" "$M7T"; }
+_STATE_MUTATE=0; _CUR7_VALID=0; _STATE_RL7_VALID=0
+M5S=active M5E=21600 M5R=0 M5T=15000 M7E=7200 M7R=0 M7T=86400
+burn_estimate; eq 'binding label 7d' "$_BURN_LABEL" 7d
+M5S=active M5E=5000 M5R=0 M5T=9000 M7E=5000 M7R=0 M7T=9000
+burn_estimate; eq 'binding ETA tie chooses 5h' "$_BURN_LABEL" 5h
 SEG_BGS=(); SEG_TXT=(); SEG_LEN=(); _BURN_STATE=active; _BURN_LABEL=5h; _BURN_ETA=1000; _BURN_RATE=0; _BURN_TTR=900
 seg_burn
-case "${SEG_TXT[0]}" in *'↗ 5h ⇢ 16m'*) ok 'burn renderer uses precomputed estimate' ;; *) bad 'burn renderer uses precomputed estimate' "${SEG_TXT[0]}" ;; esac
-case "${SEG_TXT[0]}" in *$'\033[38;5;179m'*) ok 'burn warning color' ;; *) bad 'burn warning color' 'missing warning fg' ;; esac
-
-# No-sample is strictly read-only for legacy, live stores, GC candidates, and
-# missing roots. A poisoned strict sentinel remains physically present.
-CASE="$TMPD/no-sample"; reset_state_case "$CASE"
-mkdir -p "$CASE/burn.d" "$CASE/limit5.d/9999999999_099.000" "$CASE/limit7.d/9999999999_099.000"
-: > "$CASE/burn.d/b_253402300799_000001000000_099.000_0000"
-printf '1000000\t41.2\t1015900\n' > "$BURN_FILE"
-cp "$BURN_FILE" "$CASE/legacy.before"
-CORALLINE_NO_SAMPLE=1; state_prepare
-cmp -s "$BURN_FILE" "$CASE/legacy.before" && ok 'no-sample preserves legacy bytes' || bad 'no-sample preserves legacy bytes' changed
-true_case 'no-sample preserves burn sentinel' test -f "$CASE/burn.d/b_253402300799_000001000000_099.000_0000"
-true_case 'no-sample preserves 5h sentinel' test -d "$CASE/limit5.d/9999999999_099.000"
-true_case 'no-sample preserves 7d sentinel' test -d "$CASE/limit7.d/9999999999_099.000"
-CASE2="$TMPD/no-sample-missing"; reset_state_case "$CASE2"; CORALLINE_NO_SAMPLE=1; state_prepare
-true_case 'no-sample never creates missing burn root' test ! -e "$CASE2/burn.d"
-true_case 'no-sample never creates missing limit root' test ! -e "$CASE2/limit5.d"
-
-# Mutation-enabled complete snapshots may remove only exact strict sentinels;
-# malformed entries and flat legacy limit files remain untouched.
-CASE="$TMPD/gc-sentinel"; reset_state_case "$CASE"
-mkdir -p "$CASE/burn.d" "$CASE/limit5.d/9999999999_099.000" "$CASE/limit5.d/not-state"
-: > "$CASE/burn.d/b_253402300799_000001000000_099.000_0000"
-: > "$CASE/burn.d/not-state"
-printf 'flat-canary' > "$RL5H_FILE"
-printf '1000000\t99\t99999999\n' > "$BURN_FILE"
-state_prepare
-true_case 'strict burn sentinel GCed' test ! -e "$CASE/burn.d/b_253402300799_000001000000_099.000_0000"
-true_case 'malformed burn entry preserved' test -f "$CASE/burn.d/not-state"
-true_case 'strict limit sentinel GCed' test ! -e "$CASE/limit5.d/9999999999_099.000"
-true_case 'malformed limit entry preserved' test -d "$CASE/limit5.d/not-state"
-eq 'flat limit file preserved' "$(LC_ALL=C tr -d '\n' < "$RL5H_FILE")" flat-canary
-cmp -s "$BURN_FILE" <(printf '1000000\t99\t99999999\n') && ok 'legacy sentinel row preserved physically' || bad 'legacy sentinel row preserved physically' changed
-
-# A malformed entry whose NAME embeds a newline must never be treated as a
-# legitimate marker: unparseable names are counted but never GC candidates,
-# and their embedded percent never becomes a representative sample.
-CASE="$TMPD/newline-spoof"; reset_state_case "$CASE"; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0
-mkdir -p "$CASE/burn.d"
-: > "$CASE/burn.d/b_000001015900_000001000000_041.200_0000"
-: > "$CASE/burn.d/b_000001015900_000000999940_040.000_0000"
-_SPOOF="$CASE/burn.d/b_000001015900_000000999990_099.000_0000"$'\n'"junk"
-if : > "$_SPOOF" 2>/dev/null && [ -e "$_SPOOF" ]; then
-  state_prepare
-  true_case 'newline-spoofed entry is preserved' test -e "$_SPOOF"
-  true_case 'legitimate marker at 41.200 survives' test -e "$CASE/burn.d/b_000001015900_000001000000_041.200_0000"
-  true_case 'legitimate marker at 40.000 survives' test -e "$CASE/burn.d/b_000001015900_000000999940_040.000_0000"
-  _SPOOF_FOUND=0
-  if [ "${#_SB_REP_PCTS[@]}" -gt 0 ]; then
-    for _P in "${_SB_REP_PCTS[@]}"; do [ "$_P" = 99000 ] && _SPOOF_FOUND=1; done
-  fi
-  [ "$_SPOOF_FOUND" -eq 0 ] && ok 'newline-spoofed name never becomes representative' || bad 'newline-spoofed name never becomes representative' 'found 99000'
-else
-  ok 'newline spoof fixture unavailable on this filesystem'
-fi
-
-# GC is snapshot-bound: an exact newer publication created after enumeration is
-# absent from the candidate set and survives this round. The writer is injected
-# via a find wrapper that creates the new marker only after the real find has
-# finished enumerating, going through the production path end to end.
-CASE="$TMPD/barrier"; reset_state_case "$CASE"; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0
-mkdir -p "$CASE/burn.d"
-: > "$CASE/burn.d/b_253402300799_000001000000_099.000_0000"
-mkdir -p "$CASE/bin"
-WIN06_NEW="$CASE/burn.d/b_000001015900_000001000001_042.000_0000"
-WIN06_REAL_FIND=$(command -v find)
-printf '%s\n' '#!/bin/bash' '"$WIN06_REAL_FIND" "$@"' 'rc=$?' ': > "$WIN06_NEW"' 'exit "$rc"' > "$CASE/bin/find"
-chmod +x "$CASE/bin/find"
-export WIN06_REAL_FIND WIN06_NEW
-OLD_PATH=$PATH; PATH="$CASE/bin:$PATH"; state_prepare; PATH=$OLD_PATH
-true_case 'snapshot-bound GC removes the enumerated sentinel' test ! -e "$CASE/burn.d/b_253402300799_000001000000_099.000_0000"
-true_case 'post-snapshot writer survives current GC' test -f "$WIN06_NEW"
-
-# Bounded retention deletes at most 128 per render and blocks publication until
-# every strict retention candidate from the complete snapshot is gone.
-CASE="$TMPD/retention"; reset_state_case "$CASE"; BURN_TRIM=1; mkdir -p "$CASE/burn.d"
-i=0
-while [ "$i" -lt 130 ]; do
-  sample=$(( NOW - 130 + i )); printf -v name 'b_%012d_%012d_%03d.%03d_%04d' 1015900 "$sample" 10 0 0
-  : > "$CASE/burn.d/$name"; i=$((i + 1))
-done
-state_prepare; count_entries "$CASE/burn.d"; eq 'first retention round removes at most 128' "$_COUNT" 2
-true_case 'publication blocked while candidate remains' test ! -e "$CASE/burn.d/b_000001015900_000001000000_041.200_0000"
-state_prepare; count_entries "$CASE/burn.d"; eq 'second maintenance converges then publishes once' "$_COUNT" 2
-
-# The default retained set is a normal steady state, not an adversarial input.
-# Descending creation order exercises the sort inside the single awk pass.
-CASE="$TMPD/steady1500"; reset_state_case "$CASE"; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0; BURN_TRIM=1500
-mkdir -p "$CASE/burn.d"; i=0
-while [ "$i" -lt 1500 ]; do
-  sample=$(( NOW - i - 1 )); printf -v name 'b_%012d_%012d_010.000_0000' 1015900 "$sample"
-  : > "$CASE/burn.d/$name"; i=$(( i + 1 ))
-done
-_START=$SECONDS; state_prepare; _ELAPSED=$(( SECONDS - _START ))
-[ "$_ELAPSED" -lt 5 ] && ok '1500-entry steady render completes under 5s' || bad '1500-entry steady render completes under 5s' "seconds=$_ELAPSED"
-eq '1500-entry steady sort first sample' "${_SB_REP_SAMPS[0]}" 998500
-eq '1500-entry steady sort last sample' "${_SB_REP_SAMPS[1499]}" 999999
-count_entries "$CASE/burn.d"; eq '1500-entry steady render publishes once' "$_COUNT" 1501
-
-# A v0.11 resize burst can append many rows for one second while concurrent
-# session caches make pct decrease. The controller must key-sort the retained
-# legacy rows before the Bash merge or insertion fallback exceeds the 1s budget.
-: > "$BURN_FILE"; i=0
-while [ "$i" -lt 384 ]; do printf '%d\t5\t1015900\n' $(( 997988 + i )) >> "$BURN_FILE"; i=$(( i + 1 )); done
-i=0
-while [ "$i" -lt 128 ]; do printf '998372\t5.%03d\t1015900\n' $(( 127 - i )) >> "$BURN_FILE"; i=$(( i + 1 )); done
-CORALLINE_NO_SAMPLE=1; state_prepare
-eq 'same-second legacy burst retained' "${#_LEG_RSTS[@]}" 512
-eq 'same-second legacy burst sorts low pct first' "${_LEG_PCTS[384]}" 5000
-eq 'same-second legacy burst sorts high pct last' "${_LEG_PCTS[511]}" 5127
-_CUR_BURN_VALID=0; _STEPS=0
-set -o functrace
-trap '_STEPS=$((_STEPS+1))' DEBUG
-burn_eta_5h
-trap - DEBUG
-set +o functrace
-[ "$_STEPS" -le 100000 ] && ok 'same-second legacy burst bounded work' || bad 'same-second legacy burst bounded work' "steps=$_STEPS"
-
-# Raw snapshot and publication watermarks: malformed names consume capacity but
-# are never deletion targets.
-make_files() { local dir="$1" n="$2" i=0; mkdir -p "$dir"; while [ "$i" -lt "$n" ]; do printf -v _N 'x%04d' "$i"; : > "$dir/$_N"; i=$((i + 1)); done; }
-CASE="$TMPD/watermark3967"; reset_state_case "$CASE"; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0; make_files "$CASE/burn.d" 3967
-state_prepare; count_entries "$CASE/burn.d"; eq 'burn raw 3967 may publish one' "$_COUNT" 3968
-CASE="$TMPD/watermark3968"; reset_state_case "$CASE"; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0; make_files "$CASE/burn.d" 3968
-state_prepare; count_entries "$CASE/burn.d"; eq 'burn raw 3968 never publishes' "$_COUNT" 3968
-CASE="$TMPD/overcap"; reset_state_case "$CASE"; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0; make_files "$CASE/burn.d" 4097
-state_prepare; count_entries "$CASE/burn.d"; eq 'burn cap+1 freezes store' "$_COUNT" 4097
-eq 'burn cap+1 returns warming' "$_B5_STATE" warming
-
-# Deterministic early-stop: a store far past the raw cap must make the
-# producer stop enumerating early, not drain the whole directory into the pass.
-CASE="$TMPD/early-stop"; reset_state_case "$CASE"; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0
-make_files "$CASE/burn.d" 8500
-mkdir -p "$CASE/bin"
-WIN05_REAL_FIND=$(command -v find)
-WIN05_RC="$CASE/find-rc"; : > "$WIN05_RC"
-printf '%s\n' '#!/bin/bash' '"$WIN05_REAL_FIND" "$@"' 'rc=$?' 'printf "%s\n" "$rc" >> "$WIN05_RC"' 'exit "$rc"' > "$CASE/bin/find"
-chmod +x "$CASE/bin/find"
-export WIN05_REAL_FIND WIN05_RC
-OLD_PATH=$PATH; PATH="$CASE/bin:$PATH"; state_prepare; PATH=$OLD_PATH
-eq 'over-cap store marks snapshot incomplete' "$_SB_COMPLETE" 0
-_RC_LAST=""
-while IFS= read -r _RC_LINE; do _RC_LAST=$_RC_LINE; done < "$WIN05_RC"
-if [ -z "$_RC_LAST" ]; then
-  bad 'producer stops early past the cap' 'find never ran'
-elif [ "$_RC_LAST" -ne 0 ]; then
-  ok 'producer stops early past the cap'
-else
-  bad 'producer stops early past the cap' "find exited $_RC_LAST"
-fi
-count_entries "$CASE/burn.d"; eq 'over-cap store is frozen' "$_COUNT" 8500
-
-make_dirs() { local dir="$1" n="$2" i=0 paths=(); mkdir -p "$dir"; while [ "$i" -lt "$n" ]; do printf -v _N 'x%04d' "$i"; paths[${#paths[@]}]="$dir/$_N"; i=$((i + 1)); done; mkdir -p "${paths[@]}"; }
-CASE="$TMPD/limit383"; reset_state_case "$CASE"; _STATE_BURN_GATE=0; _STATE_RL7_GATE=0; make_dirs "$CASE/limit5.d" 383
-state_prepare; count_entries "$CASE/limit5.d"; eq 'limit raw 383 may publish one' "$_COUNT" 384
-CASE="$TMPD/limit384"; reset_state_case "$CASE"; _STATE_BURN_GATE=0; _STATE_RL7_GATE=0; make_dirs "$CASE/limit5.d" 384
-state_prepare; count_entries "$CASE/limit5.d"; eq 'limit raw 384 never publishes' "$_COUNT" 384
-CASE="$TMPD/limit513"; reset_state_case "$CASE"; _STATE_BURN_GATE=0; _STATE_RL7_GATE=0; make_dirs "$CASE/limit5.d" 513
-state_prepare; count_entries "$CASE/limit5.d"; eq 'limit cap+1 freezes store' "$_COUNT" 513
-
-# Limit entries are immutable empty directories. The controller streams one
-# bounded child layer so a poisoned canonical name cannot become stored state
-# or force Bash to materialize an unbounded glob.
-CASE="$TMPD/limit-nonempty"; reset_state_case "$CASE"; _STATE_BURN_GATE=0; _STATE_RL7_GATE=0
-mkdir -p "$CASE/limit5.d/0001015900_041.200"; : > "$CASE/limit5.d/0001015900_041.200/canary"
-state_prepare
-eq 'nonempty limit directory is not stored state' "$_SL5_STORED_VALID" 0
-eq 'nonempty limit directory blocks publication' "$_SL5_CLEAN" 0
-true_case 'nonempty limit directory is preserved' test -f "$CASE/limit5.d/0001015900_041.200/canary"
-
-CASE="$TMPD/limit-child-cap"; reset_state_case "$CASE"; _STATE_BURN_GATE=0; _STATE_RL7_GATE=0
-mkdir -p "$CASE/limit5.d/0001015900_041.200"; i=0
-while [ "$i" -lt 513 ]; do printf -v _N 'child%04d' "$i"; : > "$CASE/limit5.d/0001015900_041.200/$_N"; i=$((i + 1)); done
-state_prepare
-eq 'limit child cap+1 freezes store' "$_SL5_COMPLETE" 0
-true_case 'limit child cap+1 preserves poisoned directory' test -f "$CASE/limit5.d/0001015900_041.200/child0512"
-
-# Legacy byte/row/record caps and newest-512 valid-row ring.
-CASE="$TMPD/legacy-bounds"; reset_state_case "$CASE"; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0; CORALLINE_NO_SAMPLE=1
-LC_ALL=C awk 'BEGIN { for (i=0;i<4096;i++) { for(j=0;j<255;j++) printf "x"; printf "\n" } }' > "$BURN_FILE"
-state_prepare; eq 'exact 1MiB bounded legacy completes' "$_SB_COMPLETE" 1
-printf x >> "$BURN_FILE"; state_prepare; eq 'legacy cap+1 is incomplete' "$_SB_COMPLETE" 0
-: > "$BURN_FILE"; i=1
-while [ "$i" -le 600 ]; do printf '%d\t1.2345\t1015900\n' "$i" >> "$BURN_FILE"; i=$((i + 1)); done
-state_prepare; eq 'legacy ring retains 512 valid rows' "${#_LEG_RSTS[@]}" 512
-eq 'legacy ring drops oldest valid rows' "${_LEG_SAMPS[0]}" 89
-LC_ALL=C awk 'BEGIN { for(i=0;i<4097;i++) print "bad" }' > "$BURN_FILE"
-state_prepare; eq 'legacy 4097 physical rows incomplete' "$_SB_COMPLETE" 0
-LC_ALL=C awk 'BEGIN { for(i=0;i<4097;i++) printf "1"; printf "\n" }' > "$BURN_FILE"
-state_prepare; eq 'legacy 4097-byte record incomplete' "$_SB_COMPLETE" 0
-printf '1000000\t1\t1015900\0\n' > "$BURN_FILE"
-state_prepare; eq 'legacy NUL row ignored after bounded read' "${#_LEG_RSTS[@]}" 0
-
-# Controller failures discard partial data and forbid mutation.
-CASE="$TMPD/controller-fail"; reset_state_case "$CASE"; mkdir -p "$CASE/burn.d"; : > "$CASE/burn.d/not-state"
-REAL_FIND=$(command -v find); REAL_OD=$(command -v od); REAL_AWK=$(command -v awk)
-mkdir -p "$CASE/bin"
-printf '%s\n' '#!/bin/bash' 'printf "%s/./partial\0" "$WIN02_ROOT"' 'exit 7' > "$CASE/bin/find"; chmod +x "$CASE/bin/find"
-printf '%s\n' '#!/bin/bash' 'exec "$WIN02_REAL_OD" "$@"' > "$CASE/bin/od"; chmod +x "$CASE/bin/od"
-printf '%s\n' '#!/bin/bash' 'exec "$WIN02_REAL_AWK" "$@"' > "$CASE/bin/awk"; chmod +x "$CASE/bin/awk"
-OLD_PATH=$PATH; export WIN02_ROOT="$CASE/burn.d" WIN02_REAL_OD="$REAL_OD" WIN02_REAL_AWK="$REAL_AWK"; PATH="$CASE/bin:$PATH"
-state_prepare
-PATH=$OLD_PATH
-eq 'partial find failure marks burn incomplete' "$_SB_COMPLETE" 0
-count_entries "$CASE/burn.d"; eq 'partial find failure performs no publication or GC' "$_COUNT" 1
-
-CASE="$TMPD/legacy-fail"; reset_state_case "$CASE"; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0; printf '1000000\t1\t1015900\n' > "$BURN_FILE"
-mkdir -p "$CASE/bin"
-printf '%s\n' '#!/bin/bash' 'exec "$WIN02_REAL_FIND" "$@"' > "$CASE/bin/find"; chmod +x "$CASE/bin/find"
-printf '%s\n' '#!/bin/bash' 'printf "49 48 48 48 48 48 48 9 49 9 49 48 49 53 57 48 48 10\n"' 'exit 7' > "$CASE/bin/od"; chmod +x "$CASE/bin/od"
-printf '%s\n' '#!/bin/bash' 'exec "$WIN02_REAL_AWK" "$@"' > "$CASE/bin/awk"; chmod +x "$CASE/bin/awk"
-export WIN02_REAL_FIND="$REAL_FIND" WIN02_REAL_AWK="$REAL_AWK"; PATH="$CASE/bin:$OLD_PATH"
-state_prepare
-PATH=$OLD_PATH
-eq 'partial od failure marks legacy incomplete' "$_SB_COMPLETE" 0
-eq 'partial od failure discards buffered rows' "${#_LEG_RSTS[@]}" 0
-true_case 'partial od failure publishes nothing' test ! -e "$CASE/burn.d"
-
-# A legacy TSV that exists but cannot be read fails only the legacy source
-# closed. The limit roots are enumerated by the same controller and their
-# completeness must not ride on the legacy reader's exit status.
-CASE="$TMPD/legacy-unreadable"; reset_state_case "$CASE"
-mkdir -p "$CASE/limit5.d/0001015900_040.000" "$CASE/limit7.d/0001345600_029.000"
-printf '1000000\t41.2\t1015900\n' > "$BURN_FILE"
-chmod 000 "$BURN_FILE" 2>/dev/null
-if [ -r "$BURN_FILE" ]; then
-  chmod 644 "$BURN_FILE" 2>/dev/null
-  ok 'unreadable legacy fixture unavailable'
-else
-  state_prepare
-  chmod 644 "$BURN_FILE" 2>/dev/null
-  eq 'unreadable legacy keeps 5h store complete' "$_SL5_COMPLETE" 1
-  eq 'unreadable legacy keeps 7d store complete' "$_SL7_COMPLETE" 1
-  eq 'unreadable legacy marks legacy incomplete' "$_LEG_COMPLETE" 0
-  eq 'unreadable legacy marks burn incomplete' "$_SB_COMPLETE" 0
-  true_case 'unreadable legacy still publishes 5h' test -d "$CASE/limit5.d/0001015900_041.200"
-  true_case 'unreadable legacy still publishes 7d' test -d "$CASE/limit7.d/0001345600_030.000"
-  true_case 'unreadable legacy publishes no burn marker' test ! -e "$CASE/burn.d"
-fi
-
-# Closing the controller fd must not silence the rest of the process. `exec
-# 9<&- 2>/dev/null` carries no command word, so its redirection is permanent and
-# every later diagnostic disappears — that is what kept a bash 3.2 parse failure
-# invisible. Save and restore fd 2 around the call, with no assertion in
-# between, so a regression here cannot strand the suite's own stderr.
-CASE="$TMPD/stderr-scope"; reset_state_case "$CASE"; _STATE_RL5_GATE=0; _STATE_RL7_GATE=0
-mkdir -p "$CASE/burn.d"
-: > "$CASE/burn.d/b_000001015900_000000999940_040.000_0000"
-exec 7>&2
-exec 2>"$CASE/err.out"
-state_prepare
-printf 'stderr-canary\n' >&2
-exec 2>&7 7>&-
-_ERR_CANARY=0; _ERR_LINES=0
-while IFS= read -r _EL; do
-  _ERR_LINES=$(( _ERR_LINES + 1 ))
-  case "$_EL" in (*stderr-canary*) _ERR_CANARY=1 ;; esac
-done < "$CASE/err.out"
-eq 'scan leaves script stderr writable' "$_ERR_CANARY" 1
-eq 'scan writes nothing to stderr itself' "$_ERR_LINES" 1
-
-# Symlink stores and ancestors fail closed without touching their targets. Git
-# Bash's default ln -s emulation copies directories, so create a real Windows
-# reparse point there; native links are visible to Git Bash's -L predicate.
-CASE="$TMPD/symlink"; reset_state_case "$CASE"; mkdir -p "$CASE/target"; : > "$CASE/target/canary"
-case "$(uname -s)" in
-  (MINGW*|MSYS*)
-    _LINK_WIN=$(cygpath -w "$CASE/burn.d"); _TARGET_WIN=$(cygpath -w "$CASE/target")
-    MSYS2_ARG_CONV_EXCL='*' cmd.exe /d /c mklink /J "$_LINK_WIN" "$_TARGET_WIN" >/dev/null 2>&1
-    _LINK_OK=$? ;;
-  (*) ln -s "$CASE/target" "$CASE/burn.d"; _LINK_OK=$? ;;
-esac
-true_case 'native symlink fixture created' test "$_LINK_OK" -eq 0
-state_prepare
-eq 'symlink store makes snapshot incomplete' "$_SB_COMPLETE" 0
-true_case 'symlink target canary survives' test -f "$CASE/target/canary"
-count_entries "$CASE/target"; eq 'symlink target receives no publication' "$_COUNT" 1
-
-# Full-runtime gate and process budget. Wrappers exec the real tools in-place, so
-# each trace line is one external state child; add one for the controller.
-if command -v jq >/dev/null 2>&1; then
-  make_payload() {
-    local path="$1" now reset
-    now=$(date +%s); reset=$((now + 10800))
-    jq --arg r "$reset" '.rate_limits.five_hour.resets_at=$r | .rate_limits.seven_day.resets_at=$r' "$HERE/sample-input.json" > "$path"
-  }
-  trace_wrappers() {
-    local dir="$1" tool real
-    mkdir -p "$dir"
-    for tool in find od awk rm mkdir; do
-      real=$(command -v "$tool")
-      {
-        printf '%s\n' '#!/bin/bash'
-        printf 'printf "%%s\\n" %q >> "$WIN02_TRACE"\n' "$tool"
-        printf 'exec %q "$@"\n' "$real"
-      } > "$dir/$tool"
-      chmod +x "$dir/$tool"
-    done
-  }
-  CASE="$TMPD/process"; mkdir -p "$CASE"; make_payload "$CASE/input"; trace_wrappers "$CASE/bin"
-  printf '%s\n' 'VL_SEGMENTS=dir' 'VL_CLOCK=off' > "$CASE/disabled.conf"
-  : > "$CASE/disabled.log"
-  WIN02_TRACE="$CASE/disabled.log" CORALLINE_CONFIG="$CASE/disabled.conf" PATH="$CASE/bin:$PATH" bash "$SCRIPT" < "$CASE/input" >/dev/null 2> "$CASE/disabled.err"
-  _TRACE=0; while IFS= read -r _; do _TRACE=$((_TRACE + 1)); done < "$CASE/disabled.log"
-  eq 'disabled state adds zero children' "$_TRACE" 0
-  eq 'disabled state stderr empty' "$(wc -c < "$CASE/disabled.err" | tr -d ' ')" 0
-
-  mkdir -p "$CASE/state/burn.d"; printf '1\t1\t2\n' > "$CASE/state/burn.tsv"
-  printf '%s\n' 'VL_SEGMENTS=burn' 'VL_CLOCK=off' "BURN_FILE=$CASE/state/burn.tsv" > "$CASE/read.conf"
-  : > "$CASE/read.log"
-  WIN02_TRACE="$CASE/read.log" CORALLINE_CONFIG="$CASE/read.conf" CORALLINE_NO_SAMPLE=1 PATH="$CASE/bin:$PATH" bash "$SCRIPT" < "$CASE/input" >/dev/null 2> "$CASE/read.err"
-  _TRACE=1; while IFS= read -r _; do _TRACE=$((_TRACE + 1)); done < "$CASE/read.log"
-  [ "$_TRACE" -le 4 ] && ok 'no-sample descendant ceiling <=4' || bad 'no-sample descendant ceiling <=4' "count=$_TRACE"
-  eq 'no-sample process trace stderr empty' "$(wc -c < "$CASE/read.err" | tr -d ' ')" 0
-
-  # Fresh-install path: markers present, no legacy TSV file.
-  rm -rf "$CASE/state"; mkdir -p "$CASE/state/burn.d"
-  now=$(date +%s); old=$((now - 10)); reset=$((now + 10800)); printf -v oldname 'b_%012d_%012d_010.000_0000' "$reset" "$old"; : > "$CASE/state/burn.d/$oldname"
-  printf '%s\n' 'VL_SEGMENTS=burn' 'VL_CLOCK=off' "BURN_FILE=$CASE/state/burn.tsv" > "$CASE/noleg.conf"
-  : > "$CASE/noleg.log"
-  WIN02_TRACE="$CASE/noleg.log" CORALLINE_CONFIG="$CASE/noleg.conf" CORALLINE_NO_SAMPLE=1 PATH="$CASE/bin:$PATH" bash "$SCRIPT" < "$CASE/input" >/dev/null 2> "$CASE/noleg.err"
-  eq 'absent-legacy render exits zero' "$?" 0
-  _TRACE=1; while IFS= read -r _; do _TRACE=$((_TRACE + 1)); done < "$CASE/noleg.log"
-  [ "$_TRACE" -le 4 ] && ok 'absent-legacy descendant ceiling <=4' || bad 'absent-legacy descendant ceiling <=4' "count=$_TRACE"
-  eq 'absent-legacy scan path ran' "$(sort "$CASE/noleg.log" | tr '\n' ' ')" 'awk find od '
-  eq 'absent-legacy process trace stderr empty' "$(wc -c < "$CASE/noleg.err" | tr -d ' ')" 0
-
-  rm -rf "$CASE/state"; mkdir -p "$CASE/state/burn.d"
-  now=$(date +%s); old=$((now - 10)); reset=$((now + 10800)); printf -v oldname 'b_%012d_%012d_010.000_0000' "$reset" "$old"; : > "$CASE/state/burn.d/$oldname"
-  old=$((now - 9)); printf -v oldname 'b_%012d_%012d_011.000_0000' "$reset" "$old"; : > "$CASE/state/burn.d/$oldname"
-  printf '1\t1\t2\n' > "$CASE/state/burn.tsv"
-  printf '%s\n' 'VL_SEGMENTS=burn\ limit5h\ limit7d' 'VL_LIMIT_SYNC=1' 'VL_CLOCK=off' "BURN_FILE=$CASE/state/burn.tsv" "RL5H_FILE=$CASE/state/limit5.tsv" "RL7D_FILE=$CASE/state/limit7.tsv" 'BURN_TRIM=1' > "$CASE/full.conf"
-  : > "$CASE/full.log"
-  WIN02_TRACE="$CASE/full.log" CORALLINE_CONFIG="$CASE/full.conf" PATH="$CASE/bin:$PATH" bash "$SCRIPT" < "$CASE/input" >/dev/null 2> "$CASE/full.err"
-  _TRACE=1; while IFS= read -r _; do _TRACE=$((_TRACE + 1)); done < "$CASE/full.log"
-  [ "$_TRACE" -le 6 ] && ok 'fully enabled descendant ceiling <=6' || bad 'fully enabled descendant ceiling <=6' "count=$_TRACE"
-  eq 'fully enabled process trace stderr empty' "$(wc -c < "$CASE/full.err" | tr -d ' ')" 0
-
-  printf '%s\n' 'VL_SEGMENTS=dir' 'VL_CLOCK=off' "BURN_FILE=$CASE/gated/burn.tsv" > "$CASE/gate.conf"
-  CORALLINE_CONFIG="$CASE/gate.conf" bash "$SCRIPT" < "$CASE/input" >/dev/null 2>/dev/null
-  true_case 'burn absent never creates state root' test ! -e "$CASE/gated/burn.d"
-else
-  ok 'full-runtime gate and process budget skipped without jq'
-fi
+case "${SEG_TXT[0]}" in (*'↗ 5h ⇢ 16m'*) ok 'burn renderer uses precomputed estimate' ;; (*) bad 'burn renderer uses precomputed estimate' "${SEG_TXT[0]}" ;; esac
+case "${SEG_TXT[0]}" in (*$'\033[38;5;179m'*) ok 'burn renderer warning color' ;; (*) bad 'burn renderer warning color' 'missing warning fg' ;; esac
+SEG_BGS=(); SEG_TXT=(); SEG_LEN=(); _BURN_STATE=warming; _BURN_LABEL=''; _BURN_ETA=inf; _BURN_RATE=0; _BURN_TTR=0
+seg_burn
+case "${SEG_TXT[0]}" in (*'↗ …'*) ok 'burn renderer warming marker' ;; (*) bad 'burn renderer warming marker' "${SEG_TXT[0]}" ;; esac
 
 printf 'SUMMARY pass=%s fail=%s\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -143,6 +143,9 @@ eq '5h fractional pct exact eta' "$_B5_ETA" 22050
 run5h '1000000\t6\t1015900\n1000060\t6.500\t1015900\n1000060\t7\t1015900\n1000300\t8\t1015900\n1000360\t8\t1015900\n' 1000360 0
 eq 'same-second maximum keeps slope' "$_B5_ETA" 22080
 
+run5h '1000000\t6\t1015900\n1000300\t8\t1015900\n1000060\t7\t1015900\n1000360\t8\t1015900\n' 1000360 0
+eq 'out-of-order appends sort before slope' "$_B5_ETA" 22080
+
 run5h '1000000\t6\t1015900\n1000060\t50\t1010000\n1000120\t7\t1015900\n1000180\t51\t1010000\n1000300\t8\t1015900\n1000360\t8\t1015900\n' 1000360 0
 eq 'latest reset isolates old windows' "$_B5_ETA" 16560
 
@@ -168,6 +171,14 @@ IFS=$'\t' read -r _FIRST _ _ < "$BURN_FILE"; eq '5h trim first kept' "$_FIRST" 3
 BURN_TRIM=3
 run5h '1\t6\t9\n1\t6.100\t9\n1\t6.200\t9\n2\t7\t9\n2\t7.100\t9\n2\t7.200\t9\n' 3 1
 eq 'resize burst collapses same-second rows' "$(wc -l < "$BURN_FILE" | tr -d ' ')" 2
+
+CASE="$TMPD/stale-tmp"; mkdir -p "$CASE"
+unit_gate "$CASE" 6 '' '' '' '' 1
+printf '1\t6\t9\n2\t7\t9\n3\t8\t9\n4\t9\t9\n' > "$BURN_FILE"
+printf 'stale-canary\n' > "$BURN_FILE.$$.tmp"
+cp "$BURN_FILE" "$CASE/before"; _CUR_BURN_VALID=0; BURN_TRIM=3; burn_eta_5h 1
+if cmp -s "$BURN_FILE" "$CASE/before"; then ok 'pre-existing temp never replaces history'; else bad 'pre-existing temp never replaces history' changed; fi
+eq 'pre-existing temp remains untouched' "$(LC_ALL=C tr -d '\n' < "$BURN_FILE.$$.tmp")" stale-canary
 BURN_TRIM=1500
 
 # Stateless 7d estimator keeps exact rational semantics.
@@ -331,7 +342,14 @@ CASE="$TMPD/path-case"; mkdir -p "$CASE/State"; printf 'case-canary' > "$CASE/St
 write_paths_config "$CASE/conf" 'burn limit5h' 1 "$CASE/State/burn.tsv" "$CASE/state/burn.tsv" "$CASE/limit7.tsv"
 make_payload "$CASE/input" 41.2 "$_r5" 30 "$_r7"
 cp "$CASE/State/burn.tsv" "$CASE/before"; run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 0
-if cmp -s "$CASE/State/burn.tsv" "$CASE/before"; then ok 'case alias collision preserves canary'; else bad 'case alias collision preserves canary' changed; fi
+case "${OSTYPE:-}" in
+  (darwin*|mingw*|msys*)
+    if cmp -s "$CASE/State/burn.tsv" "$CASE/before"; then ok 'case alias collision preserves canary'; else bad 'case alias collision preserves canary' changed; fi
+    ;;
+  (*)
+    if cmp -s "$CASE/State/burn.tsv" "$CASE/before"; then bad 'case-sensitive distinct paths remain usable' unchanged; else ok 'case-sensitive distinct paths remain usable'; fi
+    ;;
+esac
 
 CASE="$TMPD/path-link"; mkdir -p "$CASE/target"; printf 'ancestor-canary' > "$CASE/target/canary"
 if ln -s "$CASE/target" "$CASE/link" 2>/dev/null; then


### PR DESCRIPTION
## Summary

This restores a cheap one-second Bash polling path after the unreleased v0.12 immutable state transaction caused the CPU regression reported in #57. The Bash runtime now returns to the released TSV burn history and compact limit-directory flow, while keeping the v0.12 input, path, symlink, namespace-collision, basename, and strict read-only hardening.

PR #58 bounded the immutable controller's scan and fixed its worst-case behavior. This follow-up addresses the remaining fixed cost by removing the full `state_scan -> GC -> select -> publish` transaction from every state-enabled render instead of reducing `refreshInterval` or caching stale segment output.

Closes #57.

## Changes

- Restore Bash burn sampling to canonical rows in `burn-5h.tsv` and retain the released compact 5h/7d high-water directories.
- Leave the native immutable `burn-5h.d` namespace untouched so the PowerShell implementation and rollback path retain their existing state.
- Reject malformed, oversized, out-of-range, or non-canonical percentages and reset values before any state mutation.
- Canonicalize all configured state paths, reject pairwise aliases and symlink ancestors or targets, and revalidate identities immediately before append, rename, mkdir, or deletion.
- Make `CORALLINE_NO_SAMPLE=1` fully read-only, including TSV trim/healing, limit GC, root creation, temporary files, and mtimes.
- Remove `find` and `od` from the Bash state path and reduce path-validation overhead by checking each unique parent once per pass.
- Rebuild the focused burn suite around released estimator semantics, trust-boundary regressions, immutable-state coexistence, process tracing, and deterministic concurrent render checks at 5, 12, and 16 workers.

## Verification

- macOS Bash 3.2.57: `178/178` focused checks passed.
- macOS Bash 5.3.15: `178/178` focused checks passed.
- Windows Git Bash 5.3.9: `178/178` focused checks passed.
- State-disabled, subagent, and valid v0.11-state output parity passed.
- Concurrent renders at `n=5`, `n=12`, and `n=16` produced the exact fixed output with zero nonzero exits or stderr; the fake failing runtime was detected.
- Five alternating paired rounds with Claude statuslines disabled measured candidate/v0.11 CPU ratios of `0.593` at `n=5` and `0.623` at `n=12` on Bash 3.2, with an `n=12` p95 ratio of `0.701`.
- The same paired run measured CPU ratios of `0.528` at `n=5` and `0.589` at `n=12` on Bash 5.3, with an `n=12` p95 ratio of `0.596`.
- A separate 12-session corpus replay measured a median candidate/v0.11 CPU ratio of `0.859` (`95.86 ms/render` versus `106.68 ms/render`) across 144 renders per variant with zero failures.

The original baseline p95 spread qualifier remained inconclusive because baseline spread was still 51-68% after removing Claude statuslines. It is not reported as passing. The accepted evidence is the paired median ratios, absolute candidate latency, separate corpus replay, and cross-platform correctness results.

## Scope

This PR changes only `statusline.sh` and `test/test-burn.sh`. It does not change `refreshInterval`, clock cadence, `statusline.ps1`, the PowerShell test suite, the installed local v0.11 runtime, or release state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
