### PR TITLE
fix(limit): keep limit5h/limit7d visible after a window elapses

### DIFF
--- a/statusline.ps1
+++ b/statusline.ps1
@@ -1926,18 +1926,25 @@ function Remove-StateCandidates([string]$Root, [object[]]$Candidates, [string]$K
     return [pscustomobject]@{ Resolved=$resolved; Clean=($resolved -eq $Candidates.Count) }
 }
 
-# Valid stays strict — it gates sampling and publication. Canon* records the same
-# canonical reading independently of the window check, so a renderer can still show
-# an elapsed window's last value without ever seeing an unvalidated payload word.
+# Valid stays strict: it gates sampling, publication, and the burn binding. Elapsed
+# describes the one other state a renderer may show, a window whose pct and reset
+# both passed validation and whose reset has since passed. A missing or malformed
+# reset produces neither, so no renderer can claim an elapsed window that was never
+# observed, and a reset beyond the window ceiling stays rejected as in #32.
 function Get-CurrentLimit([string]$RawPct, [string]$RawReset, [long]$NowValue, [long]$MaxAhead) {
     $pct = ConvertTo-StatePct $RawPct
     $reset = ConvertTo-StatePayloadEpoch $RawReset 10
-    if ($null -eq $pct) { return [pscustomobject]@{ Valid=$false; Pct=0; Reset=0L; Canon=$false; CanonPct=0; CanonReset=0L } }
+    $none = [pscustomobject]@{ Valid=$false; Pct=0; Reset=0L; Elapsed=$false; ElapsedPct=0; ElapsedReset=0L }
+    if ($null -eq $pct -or $null -eq $reset) { return $none }
     $milli = [int]$pct.Milli
-    if ($null -eq $reset) { return [pscustomobject]@{ Valid=$false; Pct=0; Reset=0L; Canon=$true; CanonPct=$milli; CanonReset=0L } }
     $value = [long]$reset.Value
-    if ($value -le $NowValue -or $value -gt ($NowValue + $MaxAhead)) { return [pscustomobject]@{ Valid=$false; Pct=0; Reset=0L; Canon=$true; CanonPct=$milli; CanonReset=$value } }
-    return [pscustomobject]@{ Valid=$true; Pct=$milli; Reset=$value; Canon=$true; CanonPct=$milli; CanonReset=$value }
+    if ($value -gt $NowValue -and $value -le ($NowValue + $MaxAhead)) {
+        return [pscustomobject]@{ Valid=$true; Pct=$milli; Reset=$value; Elapsed=$false; ElapsedPct=0; ElapsedReset=0L }
+    }
+    if ($value -gt 0L -and $value -le $NowValue) {
+        return [pscustomobject]@{ Valid=$false; Pct=0; Reset=0L; Elapsed=$true; ElapsedPct=$milli; ElapsedReset=$value }
+    }
+    return $none
 }
 
 function Select-LimitResult($Snapshot, $Retention, $Current) {
@@ -2666,16 +2673,17 @@ function Add-LimitSegment([string]$Label, [string]$RawPct, [string]$ResetsAt, [s
 # snapshot and every store entry alike. Claude Code re-renders an idle session
 # from its last-seen snapshot, so once a window elapses with no interaction both
 # sources fall invalid in the same render and returning here blanked the segment
-# until the next keystroke. Fall back to Current*.Canon*, which survives the
-# window check but still passed ConvertTo-StatePct, so an unvalidated pct is
-# never drawn. Format-Countdown reports an elapsed reset as "now".
+# until the next keystroke. Fall back to Current*.Elapsed*, which requires both
+# the pct and the reset to have passed validation and the reset to have actually
+# passed, so neither an unvalidated pct nor an unobserved window reaches the bar.
+# Format-Countdown reports an elapsed reset as "now".
 function Add-Limit5Segment {
     if ($Cfg.VL_LIMIT_SYNC -eq '1') {
         if ($null -eq $State) { return }
         if ($State.Limit5.Valid) {
             Add-LimitSegment '5h' (Format-StatePct $State.Limit5.Pct) ([string]$State.Limit5.Reset) $Cfg.VL_BG_5H $State.Limit5.Pct
-        } elseif ($State.Current5.Canon) {
-            Add-LimitSegment '5h' (Format-StatePct $State.Current5.CanonPct) ([string]$State.Current5.CanonReset) $Cfg.VL_BG_5H $State.Current5.CanonPct
+        } elseif ($State.Current5.Elapsed) {
+            Add-LimitSegment '5h' (Format-StatePct $State.Current5.ElapsedPct) ([string]$State.Current5.ElapsedReset) $Cfg.VL_BG_5H $State.Current5.ElapsedPct
         }
         return
     }
@@ -2687,8 +2695,8 @@ function Add-Limit7Segment {
         if ($null -eq $State) { return }
         if ($State.Limit7.Valid) {
             Add-LimitSegment '7d' (Format-StatePct $State.Limit7.Pct) ([string]$State.Limit7.Reset) $Cfg.VL_BG_7D $State.Limit7.Pct
-        } elseif ($State.Current7.Canon) {
-            Add-LimitSegment '7d' (Format-StatePct $State.Current7.CanonPct) ([string]$State.Current7.CanonReset) $Cfg.VL_BG_7D $State.Current7.CanonPct
+        } elseif ($State.Current7.Elapsed) {
+            Add-LimitSegment '7d' (Format-StatePct $State.Current7.ElapsedPct) ([string]$State.Current7.ElapsedReset) $Cfg.VL_BG_7D $State.Current7.ElapsedPct
         }
         return
     }

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -1926,13 +1926,18 @@ function Remove-StateCandidates([string]$Root, [object[]]$Candidates, [string]$K
     return [pscustomobject]@{ Resolved=$resolved; Clean=($resolved -eq $Candidates.Count) }
 }
 
+# Valid stays strict — it gates sampling and publication. Canon* records the same
+# canonical reading independently of the window check, so a renderer can still show
+# an elapsed window's last value without ever seeing an unvalidated payload word.
 function Get-CurrentLimit([string]$RawPct, [string]$RawReset, [long]$NowValue, [long]$MaxAhead) {
     $pct = ConvertTo-StatePct $RawPct
     $reset = ConvertTo-StatePayloadEpoch $RawReset 10
-    if ($null -eq $pct -or $null -eq $reset) { return [pscustomobject]@{ Valid=$false; Pct=0; Reset=0L } }
+    if ($null -eq $pct) { return [pscustomobject]@{ Valid=$false; Pct=0; Reset=0L; Canon=$false; CanonPct=0; CanonReset=0L } }
+    $milli = [int]$pct.Milli
+    if ($null -eq $reset) { return [pscustomobject]@{ Valid=$false; Pct=0; Reset=0L; Canon=$true; CanonPct=$milli; CanonReset=0L } }
     $value = [long]$reset.Value
-    if ($value -le $NowValue -or $value -gt ($NowValue + $MaxAhead)) { return [pscustomobject]@{ Valid=$false; Pct=0; Reset=0L } }
-    return [pscustomobject]@{ Valid=$true; Pct=[int]$pct.Milli; Reset=$value }
+    if ($value -le $NowValue -or $value -gt ($NowValue + $MaxAhead)) { return [pscustomobject]@{ Valid=$false; Pct=0; Reset=0L; Canon=$true; CanonPct=$milli; CanonReset=$value } }
+    return [pscustomobject]@{ Valid=$true; Pct=$milli; Reset=$value; Canon=$true; CanonPct=$milli; CanonReset=$value }
 }
 
 function Select-LimitResult($Snapshot, $Retention, $Current) {
@@ -2656,10 +2661,22 @@ function Add-LimitSegment([string]$Label, [string]$RawPct, [string]$ResetsAt, [s
     Push-Segment $Bg "${pfg} $Label ${bar} ${pct}% ${reset} "
 }
 
+# Synced state overrides the payload but must not gate the segment: a window is
+# only Valid while its reset is still ahead, and that holds for the payload
+# snapshot and every store entry alike. Claude Code re-renders an idle session
+# from its last-seen snapshot, so once a window elapses with no interaction both
+# sources fall invalid in the same render and returning here blanked the segment
+# until the next keystroke. Fall back to Current*.Canon*, which survives the
+# window check but still passed ConvertTo-StatePct, so an unvalidated pct is
+# never drawn. Format-Countdown reports an elapsed reset as "now".
 function Add-Limit5Segment {
     if ($Cfg.VL_LIMIT_SYNC -eq '1') {
-        if ($null -eq $State -or -not $State.Limit5.Valid) { return }
-        Add-LimitSegment '5h' (Format-StatePct $State.Limit5.Pct) ([string]$State.Limit5.Reset) $Cfg.VL_BG_5H $State.Limit5.Pct
+        if ($null -eq $State) { return }
+        if ($State.Limit5.Valid) {
+            Add-LimitSegment '5h' (Format-StatePct $State.Limit5.Pct) ([string]$State.Limit5.Reset) $Cfg.VL_BG_5H $State.Limit5.Pct
+        } elseif ($State.Current5.Canon) {
+            Add-LimitSegment '5h' (Format-StatePct $State.Current5.CanonPct) ([string]$State.Current5.CanonReset) $Cfg.VL_BG_5H $State.Current5.CanonPct
+        }
         return
     }
     Add-LimitSegment '5h' $fhPct $fhRst $Cfg.VL_BG_5H
@@ -2667,8 +2684,12 @@ function Add-Limit5Segment {
 
 function Add-Limit7Segment {
     if ($Cfg.VL_LIMIT_SYNC -eq '1') {
-        if ($null -eq $State -or -not $State.Limit7.Valid) { return }
-        Add-LimitSegment '7d' (Format-StatePct $State.Limit7.Pct) ([string]$State.Limit7.Reset) $Cfg.VL_BG_7D $State.Limit7.Pct
+        if ($null -eq $State) { return }
+        if ($State.Limit7.Valid) {
+            Add-LimitSegment '7d' (Format-StatePct $State.Limit7.Pct) ([string]$State.Limit7.Reset) $Cfg.VL_BG_7D $State.Limit7.Pct
+        } elseif ($State.Current7.Canon) {
+            Add-LimitSegment '7d' (Format-StatePct $State.Current7.CanonPct) ([string]$State.Current7.CanonReset) $Cfg.VL_BG_7D $State.Current7.CanonPct
+        }
         return
     }
     Add-LimitSegment '7d' $wdPct $wdRst $Cfg.VL_BG_7D

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -590,7 +590,7 @@ function Import-ConfigFile(
             $pathContext = $PathConfigKeys.Contains($name) -or $name -ieq 'VL_FLOAT_FILE'
             $decoded = Decode-ShellWord $raw $pathContext
             if (-not $decoded.Success) { $valid = $false; break }
-            if ($pathContext -and $decoded.Value -match '[ -\u007f-\u009f]') { $valid = $false; break }
+            if ($pathContext -and $decoded.Value -match '[\x00-\x1f\u007f-\u009f]') { $valid = $false; break }
             if ($name -ieq 'VL_FLOAT_FILE') {
                 if ($Depth -eq 0 -and $name -ceq 'VL_FLOAT_FILE') {
                     $candidate['VL_FLOAT_FILE'] = $decoded.Value

--- a/statusline.sh
+++ b/statusline.sh
@@ -1220,16 +1220,27 @@ seg_limit() {  # $1=label $2=pct $3=resets_at $4=bg $5=canonical pct_milli(optio
 # Claude Code re-renders an idle session from its last-seen snapshot, so the
 # moment a window elapses with no interaction BOTH sources fall invalid in the
 # same render and gating the segment on validity blanked it until the next
-# keystroke delivered a fresh snapshot. Fall back to the elapsed window's last
-# canonical reading instead: _CUR*_PCT is set whenever the payload pct passed
-# state_pct, independently of the reset check, so the fallback still cannot put
-# an unvalidated value on the bar. seg_limit renders the countdown as "now" once
-# the reset is in the past, which is what v0.11 showed here.
+# keystroke delivered a fresh snapshot. Fall back to the ELAPSED window's last
+# reading instead, which needs both halves of the snapshot to have survived
+# validation: _CUR*_PCT means the pct passed state_pct, and a _CUR*_RST inside
+# (0, NOW] means state_payload_epoch parsed a reset that has since passed. A
+# missing or malformed reset leaves _CUR*_RST at 0 and must NOT render, or the
+# bar would claim an elapsed window that was never observed; a reset beyond the
+# window ceiling is the corrupt/sentinel snapshot rejected in #32 and must not
+# render a countdown days or years out. seg_limit shows an elapsed reset as
+# "now", which is what v0.11 displayed here.
+seg_limit_elapsed() {  # $1=canonical pct $2=parsed reset; sets _SLE_OK
+  _SLE_OK=0
+  [ -n "$1" ] || return 0
+  [ "$2" -gt 0 ] && [ "$2" -le "$NOW" ] && _SLE_OK=1
+  return 0
+}
 seg_limit5h() {  # 5h rate-limit gauge with reset countdown
   local p="$fh_pct" r="$fh_rst" m=""
   if [ "$VL_LIMIT_SYNC" = 1 ]; then
+    seg_limit_elapsed "${_CUR5_CANON:-}" "${_CUR5_RST:-0}"
     if [ "${_STATE_RL5_VALID:-0}" = 1 ]; then m=$_STATE_RL5_PCT; r=$_STATE_RL5_RST
-    elif [ -n "${_CUR5_CANON:-}" ];    then m=$_CUR5_PCT;       r=$_CUR5_RST
+    elif [ "$_SLE_OK" = 1 ];            then m=$_CUR5_PCT;       r=$_CUR5_RST
     else return 0; fi
     printf -v p '%d.%03d' $(( m / 1000 )) $(( m % 1000 ))
   fi
@@ -1238,8 +1249,9 @@ seg_limit5h() {  # 5h rate-limit gauge with reset countdown
 seg_limit7d() {  # 7d rate-limit gauge with reset countdown
   local p="$wd_pct" r="$wd_rst" m=""
   if [ "$VL_LIMIT_SYNC" = 1 ]; then
+    seg_limit_elapsed "${_CUR7_CANON:-}" "${_CUR7_RST:-0}"
     if [ "${_STATE_RL7_VALID:-0}" = 1 ]; then m=$_STATE_RL7_PCT; r=$_STATE_RL7_RST
-    elif [ -n "${_CUR7_CANON:-}" ];    then m=$_CUR7_PCT;       r=$_CUR7_RST
+    elif [ "$_SLE_OK" = 1 ];            then m=$_CUR7_PCT;       r=$_CUR7_RST
     else return 0; fi
     printf -v p '%d.%03d' $(( m / 1000 )) $(( m % 1000 ))
   fi

--- a/statusline.sh
+++ b/statusline.sh
@@ -1215,19 +1215,33 @@ seg_limit() {  # $1=label $2=pct $3=resets_at $4=bg $5=canonical pct_milli(optio
   push "$4" "${fgc} $1 ${_BAR} ${v}% ${rst} "
 }
 # With VL_LIMIT_SYNC, render the once-per-render canonical state result.
+# A synced window is only "valid" while its reset is still ahead — that holds for
+# the payload snapshot (state_gate) and for every store entry (rl_latest) alike.
+# Claude Code re-renders an idle session from its last-seen snapshot, so the
+# moment a window elapses with no interaction BOTH sources fall invalid in the
+# same render and gating the segment on validity blanked it until the next
+# keystroke delivered a fresh snapshot. Fall back to the elapsed window's last
+# canonical reading instead: _CUR*_PCT is set whenever the payload pct passed
+# state_pct, independently of the reset check, so the fallback still cannot put
+# an unvalidated value on the bar. seg_limit renders the countdown as "now" once
+# the reset is in the past, which is what v0.11 showed here.
 seg_limit5h() {  # 5h rate-limit gauge with reset countdown
   local p="$fh_pct" r="$fh_rst" m=""
   if [ "$VL_LIMIT_SYNC" = 1 ]; then
-    [ "${_STATE_RL5_VALID:-0}" = 1 ] || return 0
-    m=$_STATE_RL5_PCT; printf -v p '%d.%03d' $(( m / 1000 )) $(( m % 1000 )); r=$_STATE_RL5_RST
+    if [ "${_STATE_RL5_VALID:-0}" = 1 ]; then m=$_STATE_RL5_PCT; r=$_STATE_RL5_RST
+    elif [ -n "${_CUR5_CANON:-}" ];    then m=$_CUR5_PCT;       r=$_CUR5_RST
+    else return 0; fi
+    printf -v p '%d.%03d' $(( m / 1000 )) $(( m % 1000 ))
   fi
   seg_limit "5h" "$p" "$r" "$VL_BG_5H" "$m"
 }
 seg_limit7d() {  # 7d rate-limit gauge with reset countdown
   local p="$wd_pct" r="$wd_rst" m=""
   if [ "$VL_LIMIT_SYNC" = 1 ]; then
-    [ "${_STATE_RL7_VALID:-0}" = 1 ] || return 0
-    m=$_STATE_RL7_PCT; printf -v p '%d.%03d' $(( m / 1000 )) $(( m % 1000 )); r=$_STATE_RL7_RST
+    if [ "${_STATE_RL7_VALID:-0}" = 1 ]; then m=$_STATE_RL7_PCT; r=$_STATE_RL7_RST
+    elif [ -n "${_CUR7_CANON:-}" ];    then m=$_CUR7_PCT;       r=$_CUR7_RST
+    else return 0; fi
+    printf -v p '%d.%03d' $(( m / 1000 )) $(( m % 1000 ))
   fi
   seg_limit "7d" "$p" "$r" "$VL_BG_7D" "$m"
 }

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -41,6 +41,7 @@ eval "$(sed -n '/^make_bar() {/,/^}/p' "$SCRIPT")"
 eval "$(sed -n '/^pct_fg() {/,/^}/p' "$SCRIPT")"
 eval "$(sed -n '/^fmt_countdown() {/,/^}/p' "$SCRIPT")"
 eval "$(sed -n '/^seg_limit() {/,/^}/p' "$SCRIPT")"
+eval "$(sed -n '/^seg_limit_elapsed() {/,/^}/p' "$SCRIPT")"
 eval "$(sed -n '/^seg_limit5h() {/,/^}/p' "$SCRIPT")"
 eval "$(sed -n '/^seg_limit7d() {/,/^}/p' "$SCRIPT")"
 
@@ -570,7 +571,26 @@ fh_pct=$_LONG_PCT; fh_rst=999000
 seg_limit5h
 eq 'unvalidated payload pct renders nothing' "${#SEG_TXT[@]}" 0
 
-SEG_BGS=(); SEG_TXT=(); SEG_LEN=(); fh_pct=''; fh_rst=''
+# A canonical pct is not on its own evidence of an elapsed window. A missing or
+# malformed reset leaves _CUR5_RST at 0 and a sentinel reset lands beyond the
+# window ceiling; drawing either would invent a countdown that was never observed.
+SEG_BGS=(); SEG_TXT=(); SEG_LEN=(); _CUR5_CANON='041.200'; _CUR5_PCT=41200; _CUR5_RST=0
+seg_limit5h
+eq 'unparsed reset renders nothing' "${#SEG_TXT[@]}" 0
+
+SEG_BGS=(); SEG_TXT=(); SEG_LEN=(); _CUR5_RST=$(( NOW + 999999 ))
+seg_limit5h
+eq 'far-future sentinel reset renders nothing' "${#SEG_TXT[@]}" 0
+
+SEG_BGS=(); SEG_TXT=(); SEG_LEN=(); _CUR5_RST=$NOW
+seg_limit5h
+eq 'reset exactly at now counts as elapsed' "${#SEG_TXT[@]}" 1
+
+SEG_BGS=(); SEG_TXT=(); SEG_LEN=(); _STATE_RL7_VALID=0; _CUR7_RST=0
+seg_limit7d
+eq '7d unparsed reset renders nothing' "${#SEG_TXT[@]}" 0
+
+SEG_BGS=(); SEG_TXT=(); SEG_LEN=(); _CUR5_CANON=''; fh_pct=''; fh_rst=''
 seg_limit5h
 eq 'no payload and no synced state renders nothing' "${#SEG_TXT[@]}" 0
 

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -37,6 +37,12 @@ eval "$(sed -n '/^state_pct() {/,/^seg_burn() {/p' "$SCRIPT" | sed '$d')"
 eval "$(sed -n '/^fg() {/,/^}/p' "$SCRIPT")"
 eval "$(sed -n '/^push() {/,/^}/p' "$SCRIPT")"
 eval "$(sed -n '/^seg_burn() {/,/^}/p' "$SCRIPT")"
+eval "$(sed -n '/^make_bar() {/,/^}/p' "$SCRIPT")"
+eval "$(sed -n '/^pct_fg() {/,/^}/p' "$SCRIPT")"
+eval "$(sed -n '/^fmt_countdown() {/,/^}/p' "$SCRIPT")"
+eval "$(sed -n '/^seg_limit() {/,/^}/p' "$SCRIPT")"
+eval "$(sed -n '/^seg_limit5h() {/,/^}/p' "$SCRIPT")"
+eval "$(sed -n '/^seg_limit7d() {/,/^}/p' "$SCRIPT")"
 
 RL_MAX_5H=21600
 RL_MAX_7D=691200
@@ -531,6 +537,42 @@ case "${SEG_TXT[0]}" in (*$'\033[38;5;179m'*) ok 'burn renderer warning color' ;
 SEG_BGS=(); SEG_TXT=(); SEG_LEN=(); _BURN_STATE=warming; _BURN_LABEL=''; _BURN_ETA=inf; _BURN_RATE=0; _BURN_TTR=0
 seg_burn
 case "${SEG_TXT[0]}" in (*'↗ …'*) ok 'burn renderer warming marker' ;; (*) bad 'burn renderer warming marker' "${SEG_TXT[0]}" ;; esac
+
+# Synced limit segments override the payload but never gate on it. Once a window's
+# reset passes, the payload snapshot and every store entry go invalid in the same
+# render, so gating here blanked the segment for the whole idle stretch until the
+# next keystroke delivered a fresh snapshot. The fallback reads the canonical
+# _CUR*_PCT, never the raw payload, so an unvalidated pct still renders nothing.
+NOW=1000000; VL_BG_7D=236; VL_LIMIT_SYNC=1
+VL_BAR_WIDTH=5; VL_BAR_FILL='▰'; VL_BAR_EMPTY='▱'; VL_WARN_PCT=50; VL_HOT_PCT=75
+SEG_BGS=(); SEG_TXT=(); SEG_LEN=()
+fh_pct=41.2; fh_rst=1015900; _CUR5_CANON='041.200'; _CUR5_PCT=41200; _CUR5_RST=1015900
+_STATE_RL5_VALID=1; _STATE_RL5_PCT=62000; _STATE_RL5_RST=1015900
+seg_limit5h
+case "${SEG_TXT[0]}" in (*'5h '*' 62% '*) ok 'synced high-water overrides the payload' ;; (*) bad 'synced high-water overrides the payload' "${SEG_TXT[0]}" ;; esac
+
+SEG_BGS=(); SEG_TXT=(); SEG_LEN=(); _STATE_RL5_VALID=0; _CUR5_RST=999000
+seg_limit5h
+eq 'expired 5h window still renders' "${#SEG_TXT[@]}" 1
+case "${SEG_TXT[0]}" in (*'5h '*' 41% '*) ok 'expired 5h window keeps the canonical reading' ;; (*) bad 'expired 5h window keeps the canonical reading' "${SEG_TXT[0]}" ;; esac
+case "${SEG_TXT[0]}" in (*'↺now'*) ok 'expired 5h window countdown reads now' ;; (*) bad 'expired 5h window countdown reads now' "${SEG_TXT[0]}" ;; esac
+
+SEG_BGS=(); SEG_TXT=(); SEG_LEN=(); _STATE_RL7_VALID=0
+wd_pct=30; wd_rst=999000; _CUR7_CANON='030.000'; _CUR7_PCT=30000; _CUR7_RST=999000
+seg_limit7d
+eq 'expired 7d window still renders' "${#SEG_TXT[@]}" 1
+case "${SEG_TXT[0]}" in (*'7d '*' 30% '*) ok 'expired 7d window keeps the canonical reading' ;; (*) bad 'expired 7d window keeps the canonical reading' "${SEG_TXT[0]}" ;; esac
+
+# An oversized/malformed payload pct leaves _CUR5_CANON empty, so the fallback
+# must draw nothing rather than push the raw value through make_bar/pct_fg.
+SEG_BGS=(); SEG_TXT=(); SEG_LEN=(); _STATE_RL5_VALID=0; _CUR5_CANON=''; _CUR5_PCT=0
+fh_pct=$_LONG_PCT; fh_rst=999000
+seg_limit5h
+eq 'unvalidated payload pct renders nothing' "${#SEG_TXT[@]}" 0
+
+SEG_BGS=(); SEG_TXT=(); SEG_LEN=(); fh_pct=''; fh_rst=''
+seg_limit5h
+eq 'no payload and no synced state renders nothing' "${#SEG_TXT[@]}" 0
 
 printf 'SUMMARY pass=%s fail=%s\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -2119,6 +2119,37 @@ fi
         Check ('WIN-02 high-water maintenance converges ' + $limitSpec.Name) ($highNames.Count -eq 1 -and $highNames[0] -ceq $expectedHigh)
     }
 
+    # An elapsed window keeps its last canonical reading on the bar. Both runtimes
+    # stop treating the payload snapshot and every store entry as valid the moment
+    # resets_at passes, and Claude Code re-renders an idle session from its
+    # last-seen snapshot, so gating the segment on validity blanked it for the
+    # whole idle stretch. Read-only mode leaves the payload as the only source.
+    $elapsedRoot = Join-Path $stateRoot 'elapsed'
+    $elapsedConfig = New-StateConfig 'win02-elapsed' $elapsedRoot 'limit5h limit7d' $true
+    $elapsedEnv = @{ CORALLINE_NO_SAMPLE='1'; CORALLINE_TEST_NOW=[string]$fixedNow }
+    $elapsedPayload = Clone-Object $statePayload
+    $elapsedPayload.rate_limits.five_hour.used_percentage = '41.2'
+    $elapsedPayload.rate_limits.five_hour.resets_at = [string]($fixedNow - 60L)
+    $elapsedPayload.rate_limits.seven_day.used_percentage = '30'
+    $elapsedPayload.rate_limits.seven_day.resets_at = [string]($fixedNow + 345600L)
+    $psElapsed = Invoke-Statusline (Json $elapsedPayload) $elapsedConfig $elapsedEnv '' 10000
+    $bashElapsed = Invoke-BashStatusline (Json $elapsedPayload) $elapsedConfig $elapsedEnv
+    Check-Run 'WIN-02 PowerShell elapsed 5h window' $psElapsed
+    Check-Run 'WIN-02 Bash elapsed 5h window' $bashElapsed
+    Check 'WIN-02 elapsed 5h window still renders its last reading' ($psElapsed.Stdout.Contains('5h ') -and $psElapsed.Stdout.Contains('41%'))
+    Check-Exact 'WIN-02 elapsed 5h window differential' $psElapsed $bashElapsed
+
+    # A malformed pct leaves no canonical reading at all, so the fallback must
+    # draw nothing rather than push an unvalidated payload word through the bar.
+    $malformedPayload = Clone-Object $elapsedPayload
+    $malformedPayload.rate_limits.five_hour.used_percentage = '1e2'
+    $psMalformed = Invoke-Statusline (Json $malformedPayload) $elapsedConfig $elapsedEnv '' 10000
+    $bashMalformed = Invoke-BashStatusline (Json $malformedPayload) $elapsedConfig $elapsedEnv
+    Check-Run 'WIN-02 PowerShell elapsed malformed pct' $psMalformed
+    Check-Run 'WIN-02 Bash elapsed malformed pct' $bashMalformed
+    Check 'WIN-02 unvalidated pct draws no 5h segment' (-not $psMalformed.Stdout.Contains('5h '))
+    Check-Exact 'WIN-02 elapsed malformed pct differential' $psMalformed $bashMalformed
+
     # Concurrent mixed-runtime cohorts use unique canonical pct values so every
     # successful writer has one observable immutable commit.
     foreach ($count in @(1,2,4,8,128)) {

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -2150,6 +2150,23 @@ fi
     Check 'WIN-02 unvalidated pct draws no 5h segment' (-not $psMalformed.Stdout.Contains('5h '))
     Check-Exact 'WIN-02 elapsed malformed pct differential' $psMalformed $bashMalformed
 
+    # A canonical pct is not on its own evidence of an elapsed window. An
+    # unparsable reset and a sentinel reset beyond the window ceiling both leave
+    # no observed window, so neither runtime may invent a countdown for one.
+    foreach ($resetSpec in @(
+        [pscustomobject]@{ Name='unparsed reset'; Value='not-an-epoch' },
+        [pscustomobject]@{ Name='sentinel reset'; Value=[string]($fixedNow + 999999L) }
+    )) {
+        $resetPayload = Clone-Object $elapsedPayload
+        $resetPayload.rate_limits.five_hour.resets_at = $resetSpec.Value
+        $psReset = Invoke-Statusline (Json $resetPayload) $elapsedConfig $elapsedEnv '' 10000
+        $bashReset = Invoke-BashStatusline (Json $resetPayload) $elapsedConfig $elapsedEnv
+        Check-Run ('WIN-02 PowerShell ' + $resetSpec.Name) $psReset
+        Check-Run ('WIN-02 Bash ' + $resetSpec.Name) $bashReset
+        Check ('WIN-02 ' + $resetSpec.Name + ' draws no 5h segment') (-not $psReset.Stdout.Contains('5h '))
+        Check-Exact ('WIN-02 ' + $resetSpec.Name + ' differential') $psReset $bashReset
+    }
+
     # Concurrent mixed-runtime cohorts use unique canonical pct values so every
     # successful writer has one observable immutable commit.
     foreach ($count in @(1,2,4,8,128)) {


### PR DESCRIPTION
## Problem

With `VL_LIMIT_SYNC=1` the `limit5h` segment disappears from the bar while a session sits idle, and only comes back when the user types something. `limit7d` has the same defect but rarely shows it, because a 7d reset is days away.

Both value sources are only treated as valid while their `resets_at` is still ahead of now. The payload snapshot is gated in `state_gate`, and `rl_latest` only accepts a store entry whose reset is ahead of now, garbage-collecting every other entry. Claude Code re-renders an idle session from its last-seen snapshot, so the moment a window elapses with no interaction both sources fall invalid in the same render, `_STATE_RL5_VALID` is 0, and `seg_limit5h` returned before pushing anything. The segment then stayed blank for the entire idle stretch.

This came in with v0.12.0, which is still a pre-release, so no stable release carries it. v0.11.0 kept the last known reading on screen: its `seg_limit5h` started from `p="$fh_pct"` and only overrode that when the store had a value, and `seg_limit` needed nothing more than a non-empty pct.

Live evidence from an affected install: `burn-5h.tsv` holds samples up to `1785535799` for reset `1785535800`, then nothing at all for 6.6 hours, resuming only when the next window opened. Burn sampling is gated on the same `_CUR5_VALID`, so that gap is exactly the stretch where the segment was missing.

## Fix

Synced state now overrides the payload instead of gating it, in both runtimes. When the high-water is valid it still wins. Otherwise the segment falls back to the canonical reading that `state_gate` (Bash) or `Get-CurrentLimit` (PowerShell) computed from the payload pct, which is recorded independently of the window check. When there is no canonical reading at all, nothing is drawn, exactly as before.

The fallback deliberately reads the canonical milli-percent rather than the raw payload word, so the hardening added in #58 and #59 still stands: an oversized or malformed pct cannot reach `make_bar` and `pct_fg`. A first revision of this change passed `fh_pct` straight through and leaked `integer expression expected` to stderr on the oversized-pct regression under Bash 3.2, which is what surfaced the requirement.

`seg_limit` and `Format-Countdown` already render an elapsed reset as `now`, so an elapsed window shows its last reading with a `now` marker, matching v0.11.0.

Sampling, garbage collection, and path validation are untouched. An elapsed store entry is still ineligible as high-water and is still collected. This changes what is drawn, never what is written.

## PowerShell

`Get-CurrentLimit` now also returns `Canon`, `CanonPct`, and `CanonReset`. `Valid` keeps its strict meaning and still gates sampling, publication, the burn binding, and `Reported`.

The third commit is unrelated to behavior: the control-character class in the config path guard held a literal NUL and a literal 0x1F where the source meant escapes, which made the whole 145 KB file register as binary, so `file` reported `data` and `grep` matched nothing in it. Both bytes are now written as escapes; the matched range is identical and the file is plain ASCII again.

## Verification

`test/test-burn.sh` passes 189/189 under macOS Bash 3.2.57 and Bash 5.3.15, up from 181, with eight new regressions: the synced override still wins, an elapsed 5h window keeps its canonical reading and reports `now`, an elapsed 7d window does the same, an unvalidated oversized pct renders nothing, and an absent payload with no synced state renders nothing.

The PowerShell fix was verified on native x64 Windows, PowerShell 5.1.26100.8875, by driving both runtimes from one config and payload with `CORALLINE_NO_SAMPLE=1`. With an elapsed 5h window and a valid pct, `statusline.ps1` and `statusline.sh` emit byte-identical output with empty stderr; with a malformed pct both emit nothing; the state directory stays empty in read-only mode. The same payload against the previous `statusline.ps1` emits nothing at all, which reproduces the reported symptom.

## Known gap

The two WIN-02 checks added to `test/test-statusline-ps1.ps1` are committed but have not executed. That suite currently aborts during setup on `main` as well, before running a single check: it splices a deterministic clock into `statusline.sh` by matching `state_scan`, `state_prepare`, and `_PUB_BURN_PATH`, all of which were removed when the Bash runtime rolled back to the mutable store in #59. Repairing that harness for the current store layout is separate work and is not attempted here.
