### PR TITLE
perf(win): drop the PowerShell burn marker store for the mutable TSV

### DIFF
--- a/statusline.ps1
+++ b/statusline.ps1
@@ -2202,20 +2202,32 @@ function Get-CorallineState([bool]$BurnGate, [bool]$Limit5Gate, [bool]$Limit7Gat
             if ($namespace[$i].Equals($namespace[$j], [StringComparison]::OrdinalIgnoreCase)) { $collision = $true }
         }
     }
-    # A state path must not alias something the renderer reads rather than owns.
-    # The burn base is now an appended file, so BURN_FILE pointing at the active
-    # config, one of its includes, or the runtime script would write a TSV record
-    # into that file: the first render still succeeds, the next one parses a
-    # corrupted config and falls back to defaults, and the user's file is damaged.
-    # Test-FloatCollision already protects the float writer with exactly this set,
-    # so the same set guards state mutation. Protected paths are compared against
-    # state paths only, never against each other, so a repeated include cannot
-    # manufacture a collision.
+    # A state path must not alias a file the renderer reads or writes for another
+    # purpose. The burn base is now appended to, so any such alias means a TSV
+    # record lands in that file: the render still succeeds, and the damage shows
+    # up on the next one, in a file the user has to repair by hand.
+    #
+    # This is the complete set for the main render path, enumerated rather than
+    # discovered one report at a time. The renderer reads the config, every file
+    # the config includes (themes arrive this way), and its own script; it writes
+    # the float target. Test-FloatCollision already protects the float writer
+    # against the state paths, so this is the same relation in the other
+    # direction, and both must hold because the state append runs first.
+    #
+    # The transcript is deliberately absent: it is used only to derive a subagent
+    # sidecar path under --subagent, and that mode performs no state mutation.
+    #
+    # Protected paths are compared against state paths only, never against each
+    # other, so a repeated include cannot manufacture a collision.
     if (-not $collision) {
         $protected = New-Object 'System.Collections.Generic.List[string]'
         $runtimePath = ''
         try { $runtimePath = [IO.Path]::GetFullPath($ScriptPath) } catch { }
-        foreach ($path in @($ConfigPath, $runtimePath)) {
+        $floatTarget = ''
+        if (-not [string]::IsNullOrEmpty([string]$Cfg.VL_FLOAT_FILE) -and ([string]$Cfg.VL_FLOAT_FILE).Length -le 4096) {
+            $floatTarget = ConvertTo-LocalFullPath ([string]$Cfg.VL_FLOAT_FILE) ([Environment]::CurrentDirectory)
+        }
+        foreach ($path in @($ConfigPath, $runtimePath, $floatTarget)) {
             if (-not [string]::IsNullOrEmpty([string]$path)) { [void]$protected.Add([string]$path) }
         }
         foreach ($path in $ConfigVisitedPaths) {

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -4,8 +4,9 @@
 
   This runtime implements the main bar and optional float producer without Bash,
   jq, WSL, or PowerShell 7. Config is read from the same coralline.conf through a
-  narrow, non-executing Bash-word parser. Burn and synced limit state share the
-  same immutable store as Bash; --subagent renders native panel rows.
+  narrow, non-executing Bash-word parser. Burn uses validated TSV history and
+  synced limit state uses compact directories, matching Bash; --subagent renders
+  native panel rows.
 #>
 
 $SubagentMode = $args.Count -gt 0 -and [string]$args[0] -ceq '--subagent'
@@ -1578,8 +1579,8 @@ function ConvertTo-Epoch([string]$Raw) {
 
 $Now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
 
-# Immutable burn and limit state. Percentages are integer milli-percent and all
-# midpoint decisions use exact Int64 quotient/remainder arithmetic.
+# Mutable burn TSV and compact limit state. Percentages are integer milli-percent
+# and all midpoint decisions use exact Int64 quotient/remainder arithmetic.
 function ConvertTo-StatePct([string]$Raw) {
     if ([string]::IsNullOrEmpty($Raw)) { return $null }
     $match = [regex]::Match($Raw, '\A(0|[1-9][0-9]?|100)(?:\.([0-9]{1,6}))?\z', [Text.RegularExpressions.RegexOptions]::CultureInvariant)
@@ -1648,6 +1649,12 @@ function Format-StatePct([int]$Milli) {
     return [string]::Format($Invariant, '{0:000}.{1:000}', $whole, $fraction)
 }
 
+function Format-BurnPct([int]$Milli) {
+    $fraction = 0L
+    $whole = [Math]::DivRem([long]$Milli, 1000L, [ref]$fraction)
+    return [string]::Format($Invariant, '{0}.{1:000}', $whole, $fraction)
+}
+
 function Get-StatePaths([string]$Base) {
     $full = ConvertTo-LocalFullPath $Base ([Environment]::CurrentDirectory)
     if ([string]::IsNullOrEmpty($full)) { return $null }
@@ -1711,20 +1718,6 @@ function ConvertFrom-CanonicalStatePct([string]$Raw) {
     return $milli
 }
 
-function ConvertFrom-BurnName([string]$Name, [long]$NowValue) {
-    $match = [regex]::Match($Name, '\Ab_([0-9]{12})_([0-9]{12})_((?:0[0-9]{2}|100)\.[0-9]{3})_([0-9]{4})\z', [Text.RegularExpressions.RegexOptions]::CultureInvariant)
-    if (-not $match.Success) { return $null }
-    $reset = 0L
-    $sample = 0L
-    if (-not [long]::TryParse($match.Groups[1].Value, $IntegerStyle, $Invariant, [ref]$reset)) { return $null }
-    if (-not [long]::TryParse($match.Groups[2].Value, $IntegerStyle, $Invariant, [ref]$sample)) { return $null }
-    if ($reset -gt 253402300799L -or $sample -gt 253402300799L) { return $null }
-    $pct = ConvertFrom-CanonicalStatePct $match.Groups[3].Value
-    if ($null -eq $pct) { return $null }
-    $plausible = $sample -le ($NowValue + 300L) -and $reset -ge $sample -and $reset -le ($NowValue + 21600L)
-    return [pscustomobject]@{ Name=$Name; Reset=$reset; Sample=$sample; Pct=[int]$pct; Plausible=$plausible }
-}
-
 function ConvertFrom-LimitName([string]$Name, [long]$NowValue, [long]$MaxAhead) {
     $match = [regex]::Match($Name, '\A([0-9]{10})_((?:0[0-9]{2}|100)\.[0-9]{3})\z', [Text.RegularExpressions.RegexOptions]::CultureInvariant)
     if (-not $match.Success) { return $null }
@@ -1736,7 +1729,7 @@ function ConvertFrom-LimitName([string]$Name, [long]$NowValue, [long]$MaxAhead) 
     return [pscustomobject]@{ Name=$Name; Reset=$reset; Pct=[int]$pct; Plausible=$plausible }
 }
 
-function Get-StateDirectorySnapshot([string]$Root, [string]$Kind, [int]$Cap, [long]$NowValue, [long]$MaxAhead) {
+function Get-StateDirectorySnapshot([string]$Root, [int]$Cap, [long]$NowValue, [long]$MaxAhead) {
     $entries = New-Object 'System.Collections.Generic.List[object]'
     if (-not (Test-StateRoot $Root)) { return [pscustomobject]@{ Complete=$false; Raw=0; Entries=@() } }
     if (-not [IO.Directory]::Exists($Root)) { return [pscustomobject]@{ Complete=$true; Raw=0; Entries=@() } }
@@ -1754,17 +1747,11 @@ function Get-StateDirectorySnapshot([string]$Root, [string]$Kind, [int]$Cap, [lo
             $name = [IO.Path]::GetFileName($full)
             try { $attrs = [IO.File]::GetAttributes($full) } catch { return [pscustomobject]@{ Complete=$false; Raw=$raw; Entries=@() } }
             if (($attrs -band [IO.FileAttributes]::ReparsePoint) -ne 0) { continue }
-            if ($Kind -eq 'burn') {
-                $parsed = ConvertFrom-BurnName $name $NowValue
-                if ($null -eq $parsed -or ($attrs -band [IO.FileAttributes]::Directory) -ne 0) { continue }
-                try { if ((New-Object IO.FileInfo($full)).Length -ne 0) { continue } } catch { return [pscustomobject]@{ Complete=$false; Raw=$raw; Entries=@() } }
-            } else {
-                $parsed = ConvertFrom-LimitName $name $NowValue $MaxAhead
-                if ($null -eq $parsed -or ($attrs -band [IO.FileAttributes]::Directory) -eq 0) { continue }
-                $emptyStatus = Get-EmptyStateDirectoryStatus $full
-                if (-not $emptyStatus.Success) { return [pscustomobject]@{ Complete=$false; Raw=$raw; Entries=@() } }
-                if (-not $emptyStatus.Empty) { continue }
-            }
+            $parsed = ConvertFrom-LimitName $name $NowValue $MaxAhead
+            if ($null -eq $parsed -or ($attrs -band [IO.FileAttributes]::Directory) -eq 0) { continue }
+            $emptyStatus = Get-EmptyStateDirectoryStatus $full
+            if (-not $emptyStatus.Success) { return [pscustomobject]@{ Complete=$false; Raw=$raw; Entries=@() } }
+            if (-not $emptyStatus.Empty) { continue }
             $parsed | Add-Member -NotePropertyName Path -NotePropertyValue $full
             [void]$entries.Add($parsed)
         }
@@ -1773,79 +1760,228 @@ function Get-StateDirectorySnapshot([string]$Root, [string]$Kind, [int]$Cap, [lo
     return [pscustomobject]@{ Complete=$true; Raw=$raw; Entries=$entries.ToArray() }
 }
 
-function ConvertFrom-LegacyRecord([string]$Record, [long]$NowValue) {
+function ConvertFrom-BurnRecord([string]$Record, [long]$NowValue) {
     $fields = $Record.Split(@("`t"), [StringSplitOptions]::None)
     if ($fields.Length -ne 3) { return $null }
     $sampleValue = ConvertTo-StateEpoch $fields[0] 12
     $pct = ConvertTo-StatePct $fields[1]
+    if ($null -eq $pct) {
+        $canonical = ConvertFrom-CanonicalStatePct $fields[1]
+        if ($null -ne $canonical) { $pct = [pscustomobject]@{ Milli=[int]$canonical } }
+    }
     $resetValue = ConvertTo-StateEpoch $fields[2] 12
     if ($null -eq $sampleValue -or $null -eq $pct -or $null -eq $resetValue) { return $null }
     $sample = [long]$sampleValue.Value
     $reset = [long]$resetValue.Value
-    if ($sample -gt ($NowValue + 300L) -or $reset -lt $sample -or $reset -gt ($NowValue + 21600L)) { return $null }
-    return [pscustomobject]@{ Reset=$reset; Sample=$sample; Pct=[int]$pct.Milli }
+    $plausible = $sample -le ($NowValue + 300L) -and $reset -ge $sample -and $reset -le ($NowValue + 21600L)
+    return [pscustomobject]@{ Reset=$reset; Sample=$sample; Pct=[int]$pct.Milli; Plausible=$plausible }
 }
 
-function Read-LegacyState([string]$Path, [long]$NowValue) {
-    $queue = New-Object 'System.Collections.Generic.Queue[object]'
-    if (-not [IO.File]::Exists($Path)) {
-        if (Test-StateObjectExists $Path) { return [pscustomobject]@{ Complete=$false; Rows=@() } }
-        if (Test-NoReparseComponents $Path) { return [pscustomobject]@{ Complete=$true; Rows=@() } }
-        return [pscustomobject]@{ Complete=$false; Rows=@() }
+function Write-BurnState([string]$Path, [object[]]$Rows, [bool]$Mutate) {
+    if (-not $Mutate -or [string]::IsNullOrEmpty($Path) -or -not (Test-NoReparseComponents $Path)) { return $false }
+    $parent = $null
+    try { $parent = [IO.Path]::GetDirectoryName($Path) } catch { return $false }
+    if ([string]::IsNullOrEmpty($parent) -or -not (Test-NoReparseComponents $parent)) { return $false }
+    try {
+        if (-not [IO.Directory]::Exists($parent)) { [void][IO.Directory]::CreateDirectory($parent) }
+    } catch { return $false }
+    if (-not (Test-NoReparseComponents $parent) -or -not [IO.Directory]::Exists($parent)) { return $false }
+    if ((Test-StateObjectExists $Path) -and -not (Test-StateRegularFile $Path)) { return $false }
+
+    $builder = New-Object Text.StringBuilder
+    foreach ($row in @($Rows)) {
+        [void]$builder.Append(([long]$row.Sample).ToString($Invariant))
+        [void]$builder.Append("`t")
+        [void]$builder.Append((Format-BurnPct ([int]$row.Pct)))
+        [void]$builder.Append("`t")
+        [void]$builder.Append(([long]$row.Reset).ToString($Invariant))
+        [void]$builder.Append("`n")
     }
-    if (-not (Test-StateRegularFile $Path)) { return [pscustomobject]@{ Complete=$false; Rows=@() } }
+    $temp = ''
+    $backup = ''
+    try {
+        for ($attempt = 0; $attempt -lt 8; $attempt++) {
+            $candidate = [IO.Path]::Combine($parent, '.burn.tmp.' + [string]$PID + '.' + [guid]::NewGuid().ToString('N'))
+            if ($candidate.Length -gt 4096) { return $false }
+            $stream = $null
+            try {
+                $stream = New-Object IO.FileStream($candidate, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None, 4096, [IO.FileOptions]::WriteThrough)
+                $bytes = $Utf8NoBom.GetBytes($builder.ToString())
+                if ($bytes.Length -gt 0) { $stream.Write($bytes, 0, $bytes.Length) }
+                $stream.Flush($true)
+                $stream.Dispose()
+                $stream = $null
+                $temp = $candidate
+                break
+            } catch [IO.IOException] {
+                if ($null -ne $stream) { $stream.Dispose() }
+            } catch {
+                if ($null -ne $stream) { $stream.Dispose() }
+                return $false
+            }
+        }
+        if ([string]::IsNullOrEmpty($temp) -or -not (Test-NoReparseComponents $parent)) { return $false }
+        if (Test-StateObjectExists $Path) {
+            if (-not (Test-StateRegularFile $Path)) { return $false }
+            for ($attempt = 0; $attempt -lt 8; $attempt++) {
+                $backup = [IO.Path]::Combine($parent, '.burn.bak.' + [string]$PID + '.' + [guid]::NewGuid().ToString('N'))
+                if ($backup.Length -gt 4096) { $backup = ''; return $false }
+                if (-not (Test-StateObjectExists $backup)) { break }
+                $backup = ''
+            }
+            if ([string]::IsNullOrEmpty($backup)) { return $false }
+            [IO.File]::Replace($temp, $Path, $backup)
+            if (Test-StateRegularFile $backup) { [IO.File]::Delete($backup); $backup = '' }
+            elseif (-not (Test-StateObjectExists $backup)) { $backup = '' }
+        } else {
+            [IO.File]::Move($temp, $Path)
+        }
+        $temp = ''
+        return $true
+    } catch { return $false }
+    finally {
+        foreach ($leftover in @($temp, $backup)) {
+            if (-not [string]::IsNullOrEmpty($leftover)) {
+                try { if (Test-StateRegularFile $leftover) { [IO.File]::Delete($leftover) } } catch { }
+            }
+        }
+    }
+}
+
+function Read-BurnState([string]$Path, [long]$NowValue, [int]$Trim, [bool]$Mutate) {
+    if (-not [IO.File]::Exists($Path)) {
+        if (Test-StateObjectExists $Path) { return [pscustomobject]@{ Complete=$false; Exists=$false; Raw=0; Rows=@() } }
+        if (Test-NoReparseComponents $Path) { return [pscustomobject]@{ Complete=$true; Exists=$false; Raw=0; Rows=@() } }
+        return [pscustomobject]@{ Complete=$false; Exists=$false; Raw=0; Rows=@() }
+    }
+    if (-not (Test-StateRegularFile $Path)) { return [pscustomobject]@{ Complete=$false; Exists=$true; Raw=0; Rows=@() } }
+    $rows = New-Object 'System.Collections.Generic.List[object]'
+    $byKey = New-Object 'System.Collections.Generic.Dictionary[string,object]' ([StringComparer]::Ordinal)
+    $physical = 0
+    $heal = $false
+    $lastByte = -1
     $stream = $null
     try {
         $share = [IO.FileShare]::ReadWrite -bor [IO.FileShare]::Delete
         $stream = New-Object IO.FileStream($Path, [IO.FileMode]::Open, [IO.FileAccess]::Read, $share, 4096, [IO.FileOptions]::SequentialScan)
         $length = [long]$stream.Length
-        if ($length -gt 1048576L) { return [pscustomobject]@{ Complete=$false; Rows=@() } }
+        if ($length -gt 1048576L) { return [pscustomobject]@{ Complete=$false; Exists=$true; Raw=0; Rows=@() } }
         $buffer = New-Object byte[] 4096
         $builder = New-Object Text.StringBuilder
         $remaining = $length
-        $physical = 0
         $recordLength = 0
         $rowAscii = $true
         while ($remaining -gt 0) {
             $want = [int][Math]::Min([long]$buffer.Length, $remaining)
             $read = $stream.Read($buffer, 0, $want)
-            if ($read -le 0) { return [pscustomobject]@{ Complete=$false; Rows=@() } }
+            if ($read -le 0) { return [pscustomobject]@{ Complete=$false; Exists=$true; Raw=$physical; Rows=@() } }
             $remaining -= $read
             for ($i=0; $i -lt $read; $i++) {
                 $byte = [int]$buffer[$i]
+                $lastByte = $byte
                 if ($byte -eq 10) {
                     $physical++
-                    if ($physical -gt 4096) { return [pscustomobject]@{ Complete=$false; Rows=@() } }
+                    if ($physical -gt 4096) { return [pscustomobject]@{ Complete=$false; Exists=$true; Raw=$physical; Rows=@() } }
                     if ($rowAscii) {
-                        $row = ConvertFrom-LegacyRecord $builder.ToString() $NowValue
+                        $row = ConvertFrom-BurnRecord $builder.ToString() $NowValue
                         if ($null -ne $row) {
-                            if ($queue.Count -eq 512) { [void]$queue.Dequeue() }
-                            $queue.Enqueue($row)
+                            if (-not $row.Plausible) { $heal = $true }
+                            else {
+                                $key = ([string]$row.Reset) + '_' + ([string]$row.Sample)
+                                if ($byKey.ContainsKey($key)) {
+                                    $old = $byKey[$key]
+                                    if ($row.Pct -gt $old.Pct) { $old.Pct = [int]$row.Pct }
+                                } else {
+                                    $byKey[$key] = $row
+                                    [void]$rows.Add($row)
+                                }
+                            }
                         }
                     }
                     [void]$builder.Clear(); $recordLength=0; $rowAscii=$true
                     continue
                 }
                 $recordLength++
-                if ($recordLength -gt 4096) { return [pscustomobject]@{ Complete=$false; Rows=@() } }
+                if ($recordLength -gt 4096) { return [pscustomobject]@{ Complete=$false; Exists=$true; Raw=$physical; Rows=@() } }
                 if ($byte -eq 9 -or $byte -eq 46 -or ($byte -ge 48 -and $byte -le 57)) { [void]$builder.Append([char]$byte) }
                 else { $rowAscii=$false }
             }
         }
+        if ($length -gt 0 -and $lastByte -ne 10 -and $length -ge 1048576L) {
+            return [pscustomobject]@{ Complete=$false; Exists=$true; Raw=$physical; Rows=@() }
+        }
         if ($recordLength -gt 0) {
             $physical++
-            if ($physical -gt 4096) { return [pscustomobject]@{ Complete=$false; Rows=@() } }
+            if ($physical -gt 4096) { return [pscustomobject]@{ Complete=$false; Exists=$true; Raw=$physical; Rows=@() } }
             if ($rowAscii) {
-                $row = ConvertFrom-LegacyRecord $builder.ToString() $NowValue
+                $row = ConvertFrom-BurnRecord $builder.ToString() $NowValue
                 if ($null -ne $row) {
-                    if ($queue.Count -eq 512) { [void]$queue.Dequeue() }
-                    $queue.Enqueue($row)
+                    if (-not $row.Plausible) { $heal = $true }
+                    else {
+                        $key = ([string]$row.Reset) + '_' + ([string]$row.Sample)
+                        if ($byKey.ContainsKey($key)) {
+                            $old = $byKey[$key]
+                            if ($row.Pct -gt $old.Pct) { $old.Pct = [int]$row.Pct }
+                        } else {
+                            $byKey[$key] = $row
+                            [void]$rows.Add($row)
+                        }
+                    }
                 }
             }
         }
-        return [pscustomobject]@{ Complete=$true; Rows=$queue.ToArray() }
-    } catch { return [pscustomobject]@{ Complete=$false; Rows=@() } }
+    } catch { return [pscustomobject]@{ Complete=$false; Exists=$true; Raw=$physical; Rows=@() } }
     finally { if ($null -ne $stream) { $stream.Dispose() } }
+
+    $finalRows = $rows.ToArray()
+    if ($Mutate -and ($physical -gt $Trim -or $heal)) {
+        $retained = New-Object 'System.Collections.Generic.List[object]'
+        $start = [Math]::Max(0, $finalRows.Length - $Trim)
+        for ($i=$start; $i -lt $finalRows.Length; $i++) { [void]$retained.Add($finalRows[$i]) }
+        [void](Write-BurnState $Path $retained.ToArray() $true)
+    }
+    return [pscustomobject]@{ Complete=$true; Exists=$true; Raw=$physical; Rows=$finalRows }
+}
+
+function Append-BurnState([string]$Path, $Current, [bool]$Mutate) {
+    if (-not $Mutate -or $null -eq $Current -or -not $Current.Valid -or [string]::IsNullOrEmpty($Path)) { return $false }
+    $parent = $null
+    try { $parent = [IO.Path]::GetDirectoryName($Path) } catch { return $false }
+    if ([string]::IsNullOrEmpty($parent) -or -not (Test-NoReparseComponents $parent)) { return $false }
+    try {
+        if (-not [IO.Directory]::Exists($parent)) { [void][IO.Directory]::CreateDirectory($parent) }
+    } catch { return $false }
+    if (-not (Test-NoReparseComponents $parent) -or -not [IO.Directory]::Exists($parent)) { return $false }
+    if ((Test-StateObjectExists $Path) -and -not (Test-StateRegularFile $Path)) { return $false }
+    if (-not (Test-NoReparseComponents $Path)) { return $false }
+    $record = ([long]$Current.Sample).ToString($Invariant) + "`t" + (Format-BurnPct ([int]$Current.Pct)) + "`t" + ([long]$Current.Reset).ToString($Invariant) + "`n"
+    # [IO.File]::AppendAllText opens exclusively for writing and gives up on the
+    # first sharing violation, so a second session appending in the same instant
+    # loses its sample: measured at 16 concurrent renderers, 5 of 320 rows lost
+    # against 0 for the Bash runtime. Widening to FileShare.ReadWrite is worse,
+    # not better -- .NET's FileMode.Append seeks to the end once at open rather
+    # than per write, so simultaneous writers share an offset and overwrite each
+    # other; that measured 62 of 320 lost. The exclusive open is what keeps whole
+    # rows intact, and what was actually missing is the retry: a writer that finds
+    # the handle held waits and takes its turn instead of dropping the row. The
+    # loop only runs under contention.
+    $bytes = $Utf8NoBom.GetBytes($record)
+    for ($attempt = 0; $attempt -lt 64; $attempt++) {
+        $stream = $null
+        try {
+            $stream = New-Object IO.FileStream($Path, [IO.FileMode]::Append, [IO.FileAccess]::Write, [IO.FileShare]::Read)
+            $stream.Write($bytes, 0, $bytes.Length)
+            $stream.Flush($true)
+            return $true
+        } catch [IO.IOException] {
+            [Threading.Thread]::Sleep(1)
+        } catch {
+            return $false
+        } finally {
+            if ($null -ne $stream) { $stream.Dispose() }
+        }
+    }
+    return $false
 }
 
 function Sort-StateEntries([object[]]$Entries) {
@@ -1859,26 +1995,6 @@ function Sort-StateEntries([object[]]$Entries) {
     return ,($list.ToArray())
 }
 
-function Get-BurnRetention([object[]]$Entries, [int]$Trim) {
-    $sorted = Sort-StateEntries $Entries
-    $candidates = New-Object 'System.Collections.Generic.List[object]'
-    $representatives = @{}
-    foreach ($entry in $sorted) {
-        if (-not $entry.Plausible) { [void]$candidates.Add($entry); continue }
-        $key = ([string]$entry.Reset) + '_' + ([string]$entry.Sample)
-        if (-not $representatives.ContainsKey($key)) { $representatives[$key] = $entry; continue }
-        $old = $representatives[$key]
-        $replace = $entry.Pct -gt $old.Pct -or ($entry.Pct -eq $old.Pct -and [string]::CompareOrdinal($entry.Name, $old.Name) -lt 0)
-        if ($replace) { [void]$candidates.Add($old); $representatives[$key] = $entry }
-        else { [void]$candidates.Add($entry) }
-    }
-    $reps = Sort-StateEntries @($representatives.Values)
-    $oldCount = $reps.Count - $Trim
-    if ($oldCount -lt 0) { $oldCount = 0 }
-    for ($i=0; $i -lt $oldCount; $i++) { [void]$candidates.Add($reps[$i]) }
-    return [pscustomobject]@{ Candidates=$candidates.ToArray(); Representatives=$reps }
-}
-
 function Get-LimitRetention([object[]]$Entries) {
     $sorted = Sort-StateEntries $Entries
     $winner = $null
@@ -1888,17 +2004,6 @@ function Get-LimitRetention([object[]]$Entries) {
     return [pscustomobject]@{ Candidates=$candidates.ToArray(); Winner=$winner }
 }
 
-function Test-BurnDeleteCandidate([string]$Root, $Entry) {
-    if ($null -eq $Entry -or -not $Entry.Path.Equals([IO.Path]::Combine($Root, $Entry.Name), [StringComparison]::OrdinalIgnoreCase)) { return $false }
-    if (-not (Test-StateRoot $Root) -or -not [IO.Directory]::Exists($Root)) { return $false }
-    if ($null -eq (ConvertFrom-BurnName $Entry.Name $Now)) { return $false }
-    try {
-        $attrs = [IO.File]::GetAttributes($Entry.Path)
-        if (($attrs -band [IO.FileAttributes]::ReparsePoint) -ne 0 -or ($attrs -band [IO.FileAttributes]::Directory) -ne 0) { return $false }
-        return (New-Object IO.FileInfo($Entry.Path)).Length -eq 0
-    } catch { return $false }
-}
-
 function Test-LimitDeleteCandidate([string]$Root, $Entry, [long]$MaxAhead) {
     if ($null -eq $Entry -or -not $Entry.Path.Equals([IO.Path]::Combine($Root, $Entry.Name), [StringComparison]::OrdinalIgnoreCase)) { return $false }
     if (-not (Test-StateRoot $Root) -or -not [IO.Directory]::Exists($Root)) { return $false }
@@ -1906,20 +2011,16 @@ function Test-LimitDeleteCandidate([string]$Root, $Entry, [long]$MaxAhead) {
     return Test-EmptyStateDirectory $Entry.Path
 }
 
-function Remove-StateCandidates([string]$Root, [object[]]$Candidates, [string]$Kind, [long]$MaxAhead, [bool]$Mutate) {
+function Remove-StateCandidates([string]$Root, [object[]]$Candidates, [long]$MaxAhead, [bool]$Mutate) {
     if (-not $Mutate) { return [pscustomobject]@{ Resolved=0; Clean=($Candidates.Count -eq 0) } }
     $limit = [Math]::Min(128, $Candidates.Count)
     $resolved = 0
     for ($i=0; $i -lt $limit; $i++) {
         $entry = $Candidates[$i]
         if (-not (Test-StateObjectExists $entry.Path)) { $resolved++; continue }
-        $safe = $false
-        if ($Kind -eq 'burn') { $safe = Test-BurnDeleteCandidate $Root $entry }
-        else { $safe = Test-LimitDeleteCandidate $Root $entry $MaxAhead }
-        if (-not $safe) { continue }
+        if (-not (Test-LimitDeleteCandidate $Root $entry $MaxAhead)) { continue }
         try {
-            if ($Kind -eq 'burn') { [IO.File]::Delete($entry.Path) }
-            else { [IO.Directory]::Delete($entry.Path, $false) }
+            [IO.Directory]::Delete($entry.Path, $false)
         } catch { }
         if (-not (Test-StateObjectExists $entry.Path)) { $resolved++ }
     }
@@ -1975,33 +2076,11 @@ function Publish-LimitState([string]$Root, $Current, $Snapshot, $Gc, [long]$MaxA
     return Test-LimitDeleteCandidate $Root ([pscustomobject]@{ Name=$name; Path=$path }) $MaxAhead
 }
 
-function Publish-BurnState([string]$Root, $Current, $Snapshot, $Gc, [bool]$Mutate) {
-    if (-not $Mutate -or -not $Snapshot.Complete -or -not $Gc.Clean -or -not $Current.Valid) { return $false }
-    if (($Snapshot.Raw - $Gc.Resolved) -ge 3968) { return $false }
-    if (-not (Test-StateRoot $Root)) { return $false }
-    try { [void][IO.Directory]::CreateDirectory($Root) } catch { return $false }
-    if (-not (Test-StateRoot $Root) -or -not [IO.Directory]::Exists($Root)) { return $false }
-    for ($slot=0; $slot -lt 32; $slot++) {
-        $name = 'b_' + $Current.Reset.ToString('D12', $Invariant) + '_' + $Current.Sample.ToString('D12', $Invariant) + '_' + (Format-StatePct $Current.Pct) + '_' + $slot.ToString('D4', $Invariant)
-        $path = [IO.Path]::Combine($Root, $name)
-        try {
-            $stream = New-Object IO.FileStream($path, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
-            $stream.Dispose()
-            return $true
-        } catch [IO.IOException] {
-            if (Test-StateObjectExists $path) { continue }
-            return $false
-        } catch { return $false }
-    }
-    return $false
-}
-
-function Get-Burn5Estimate($Snapshot, $Retention, $Legacy, $Current, [long]$NowValue, [int]$Window) {
+function Get-Burn5Estimate($Snapshot, $Current, [long]$NowValue, [int]$Window) {
     $warming = [pscustomobject]@{ State='warming'; Eta='inf'; Rate='0.0000000000'; Ttr=0L }
-    if (-not $Snapshot.Complete -or -not $Legacy.Complete) { return $warming }
+    if (-not $Snapshot.Complete) { return $warming }
     $observations = New-Object 'System.Collections.Generic.List[object]'
-    foreach ($entry in $Retention.Representatives) { if ($entry.Plausible) { [void]$observations.Add($entry) } }
-    foreach ($row in $Legacy.Rows) { [void]$observations.Add($row) }
+    foreach ($row in $Snapshot.Rows) { [void]$observations.Add($row) }
     if ($Current.Valid) { [void]$observations.Add($Current) }
     if ($observations.Count -eq 0) { return $warming }
     $maxReset = 0L
@@ -2082,9 +2161,8 @@ function Get-CorallineState([bool]$BurnGate, [bool]$Limit5Gate, [bool]$Limit7Gat
     $currentBurn = [pscustomobject]@{ Valid=$false; Reset=0L; Sample=$Now; Pct=0 }
     if ($current5.Valid -and $current5.Reset -ge $Now) { $currentBurn = [pscustomobject]@{ Valid=$true; Reset=[long]$current5.Reset; Sample=$Now; Pct=[int]$current5.Pct } }
 
-    $emptySnapshot = [pscustomobject]@{ Complete=$false; Raw=0; Entries=@() }
-    $emptyLegacy = [pscustomobject]@{ Complete=$false; Rows=@() }
-    $burnSnapshot=$emptySnapshot; $limit5Snapshot=$emptySnapshot; $limit7Snapshot=$emptySnapshot; $legacy=$emptyLegacy
+    $emptySnapshot = [pscustomobject]@{ Complete=$false; Exists=$false; Raw=0; Entries=@(); Rows=@() }
+    $burnSnapshot=$emptySnapshot; $limit5Snapshot=$emptySnapshot; $limit7Snapshot=$emptySnapshot
     $burnPaths=$null; $limit5Paths=$null; $limit7Paths=$null
     if ($BurnGate) { $burnPaths = Get-StatePaths $Cfg.BURN_FILE }
     if ($Limit5Gate) { $limit5Paths = Get-StatePaths $Cfg.RL5H_FILE }
@@ -2097,35 +2175,29 @@ function Get-CorallineState([bool]$BurnGate, [bool]$Limit5Gate, [bool]$Limit7Gat
     }
     if (-not $collision) {
         if ($BurnGate -and $null -ne $burnPaths) {
-            $burnSnapshot = Get-StateDirectorySnapshot $burnPaths.Root 'burn' 4096 $Now 21600L
-            $legacy = Read-LegacyState $burnPaths.Base $Now
-            if (-not $legacy.Complete) { $burnSnapshot = [pscustomobject]@{ Complete=$false; Raw=$burnSnapshot.Raw; Entries=@() } }
+            [void](Append-BurnState $burnPaths.Base $currentBurn $mutate)
+            $burnSnapshot = Read-BurnState $burnPaths.Base $Now $trim $mutate
         }
-        if ($Limit5Gate -and $null -ne $limit5Paths) { $limit5Snapshot = Get-StateDirectorySnapshot $limit5Paths.Root 'limit' 512 $Now 21600L }
-        if ($Limit7Gate -and $null -ne $limit7Paths) { $limit7Snapshot = Get-StateDirectorySnapshot $limit7Paths.Root 'limit' 512 $Now 691200L }
+        if ($Limit5Gate -and $null -ne $limit5Paths) { $limit5Snapshot = Get-StateDirectorySnapshot $limit5Paths.Root 512 $Now 21600L }
+        if ($Limit7Gate -and $null -ne $limit7Paths) { $limit7Snapshot = Get-StateDirectorySnapshot $limit7Paths.Root 512 $Now 691200L }
     }
 
-    $burnRetention = [pscustomobject]@{ Candidates=@(); Representatives=@() }
     $limit5Retention = [pscustomobject]@{ Candidates=@(); Winner=$null }
     $limit7Retention = [pscustomobject]@{ Candidates=@(); Winner=$null }
-    if ($burnSnapshot.Complete) { $burnRetention = Get-BurnRetention $burnSnapshot.Entries $trim }
     if ($limit5Snapshot.Complete) { $limit5Retention = Get-LimitRetention $limit5Snapshot.Entries }
     if ($limit7Snapshot.Complete) { $limit7Retention = Get-LimitRetention $limit7Snapshot.Entries }
 
-    $burnGc = [pscustomobject]@{ Resolved=0; Clean=$false }
     $limit5Gc = [pscustomobject]@{ Resolved=0; Clean=$false }
     $limit7Gc = [pscustomobject]@{ Resolved=0; Clean=$false }
-    if ($burnSnapshot.Complete) { $burnGc = Remove-StateCandidates $burnPaths.Root $burnRetention.Candidates 'burn' 21600L $mutate }
-    if ($limit5Snapshot.Complete) { $limit5Gc = Remove-StateCandidates $limit5Paths.Root $limit5Retention.Candidates 'limit' 21600L $mutate }
-    if ($limit7Snapshot.Complete) { $limit7Gc = Remove-StateCandidates $limit7Paths.Root $limit7Retention.Candidates 'limit' 691200L $mutate }
+    if ($limit5Snapshot.Complete) { $limit5Gc = Remove-StateCandidates $limit5Paths.Root $limit5Retention.Candidates 21600L $mutate }
+    if ($limit7Snapshot.Complete) { $limit7Gc = Remove-StateCandidates $limit7Paths.Root $limit7Retention.Candidates 691200L $mutate }
 
     $limit5 = Select-LimitResult $limit5Snapshot $limit5Retention $current5
     $limit7 = Select-LimitResult $limit7Snapshot $limit7Retention $current7
-    if ($BurnGate -and $burnSnapshot.Complete) { [void](Publish-BurnState $burnPaths.Root $currentBurn $burnSnapshot $burnGc $mutate) }
     if ($Limit5Gate -and $limit5Snapshot.Complete) { [void](Publish-LimitState $limit5Paths.Root $current5 $limit5Snapshot $limit5Gc 21600L $mutate) }
     if ($Limit7Gate -and $limit7Snapshot.Complete) { [void](Publish-LimitState $limit7Paths.Root $current7 $limit7Snapshot $limit7Gc 691200L $mutate) }
 
-    $five = Get-Burn5Estimate $burnSnapshot $burnRetention $legacy $currentBurn $Now $window
+    $five = Get-Burn5Estimate $burnSnapshot $currentBurn $Now $window
     # The ownership rule covers the projection as well: burn can bind to the 7d
     # window, so a stored percentage from another session would otherwise reach
     # the bar as an ETA even while the 7d gauge is hidden.

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -2168,16 +2168,30 @@ function Get-CorallineState([bool]$BurnGate, [bool]$Limit5Gate, [bool]$Limit7Gat
     if ($Limit5Gate) { $limit5Paths = Get-StatePaths $Cfg.RL5H_FILE }
     if ($Limit7Gate) { $limit7Paths = Get-StatePaths $Cfg.RL7D_FILE }
     # Bash compares all six canonical paths pairwise in state_paths_validate, not
-    # just the three roots. Roots alone miss a base that aliases another store's
-    # root: BURN_FILE=...\limit5.d together with RL5H_FILE=...\limit5.tsv gives
-    # burn.Base equal to limit5.Root. That was harmless while the burn store was a
-    # directory and its base was never written, but the burn base is now an
-    # appended file, so the append would create limit5.d as a regular file and
-    # block the limit store permanently. Measured on Windows before this guard:
+    # just the three roots, and it does so for every configured store regardless
+    # of which segments are enabled. Both parts matter here.
+    #
+    # Roots alone miss a base that aliases another store's root: BURN_FILE=
+    # ...\limit5.d together with RL5H_FILE=...\limit5.tsv gives burn.Base equal to
+    # limit5.Root, because a root is a base with .tsv replaced by .d. That was
+    # harmless while the burn store was a directory and its base was never
+    # written; the burn base is now an appended file, so the append would create
+    # limit5.d as a regular file and block the limit store permanently.
+    #
+    # Gate-filtered paths miss the same alias whenever the other store is dormant,
+    # which is the default: with VL_LIMIT_SYNC=0 the limit paths are never derived,
+    # so their roots never enter the namespace and the append lands anyway. The
+    # damage outlives the setting -- enabling synchronisation later finds a
+    # regular file where the store belongs. So the namespace is built from the
+    # configuration, not from this render's gates.
+    #
+    # Measured on Windows for both shapes, sync enabled and sync disabled:
     # statusline.sh created nothing at all, statusline.ps1 created the file.
     $collision = $false
     $namespace = New-Object 'System.Collections.Generic.List[string]'
-    foreach ($candidate in @($burnPaths, $limit5Paths, $limit7Paths)) {
+    foreach ($configured in @($Cfg.BURN_FILE, $Cfg.RL5H_FILE, $Cfg.RL7D_FILE)) {
+        if ([string]::IsNullOrEmpty([string]$configured)) { continue }
+        $candidate = Get-StatePaths $configured
         if ($null -ne $candidate) {
             [void]$namespace.Add([string]$candidate.Base)
             [void]$namespace.Add([string]$candidate.Root)

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -2167,11 +2167,26 @@ function Get-CorallineState([bool]$BurnGate, [bool]$Limit5Gate, [bool]$Limit7Gat
     if ($BurnGate) { $burnPaths = Get-StatePaths $Cfg.BURN_FILE }
     if ($Limit5Gate) { $limit5Paths = Get-StatePaths $Cfg.RL5H_FILE }
     if ($Limit7Gate) { $limit7Paths = Get-StatePaths $Cfg.RL7D_FILE }
+    # Bash compares all six canonical paths pairwise in state_paths_validate, not
+    # just the three roots. Roots alone miss a base that aliases another store's
+    # root: BURN_FILE=...\limit5.d together with RL5H_FILE=...\limit5.tsv gives
+    # burn.Base equal to limit5.Root. That was harmless while the burn store was a
+    # directory and its base was never written, but the burn base is now an
+    # appended file, so the append would create limit5.d as a regular file and
+    # block the limit store permanently. Measured on Windows before this guard:
+    # statusline.sh created nothing at all, statusline.ps1 created the file.
     $collision = $false
-    $roots = New-Object 'System.Collections.Generic.List[object]'
-    foreach ($candidateRoot in @($burnPaths, $limit5Paths, $limit7Paths)) { if ($null -ne $candidateRoot) { [void]$roots.Add($candidateRoot) } }
-    for ($i=0; $i -lt $roots.Count; $i++) {
-        for ($j=$i+1; $j -lt $roots.Count; $j++) { if ($roots[$i].Root.Equals($roots[$j].Root, [StringComparison]::OrdinalIgnoreCase)) { $collision=$true } }
+    $namespace = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($candidate in @($burnPaths, $limit5Paths, $limit7Paths)) {
+        if ($null -ne $candidate) {
+            [void]$namespace.Add([string]$candidate.Base)
+            [void]$namespace.Add([string]$candidate.Root)
+        }
+    }
+    for ($i=0; $i -lt $namespace.Count; $i++) {
+        for ($j=$i+1; $j -lt $namespace.Count; $j++) {
+            if ($namespace[$i].Equals($namespace[$j], [StringComparison]::OrdinalIgnoreCase)) { $collision = $true }
+        }
     }
     if (-not $collision) {
         if ($BurnGate -and $null -ne $burnPaths) {

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -2202,6 +2202,31 @@ function Get-CorallineState([bool]$BurnGate, [bool]$Limit5Gate, [bool]$Limit7Gat
             if ($namespace[$i].Equals($namespace[$j], [StringComparison]::OrdinalIgnoreCase)) { $collision = $true }
         }
     }
+    # A state path must not alias something the renderer reads rather than owns.
+    # The burn base is now an appended file, so BURN_FILE pointing at the active
+    # config, one of its includes, or the runtime script would write a TSV record
+    # into that file: the first render still succeeds, the next one parses a
+    # corrupted config and falls back to defaults, and the user's file is damaged.
+    # Test-FloatCollision already protects the float writer with exactly this set,
+    # so the same set guards state mutation. Protected paths are compared against
+    # state paths only, never against each other, so a repeated include cannot
+    # manufacture a collision.
+    if (-not $collision) {
+        $protected = New-Object 'System.Collections.Generic.List[string]'
+        $runtimePath = ''
+        try { $runtimePath = [IO.Path]::GetFullPath($ScriptPath) } catch { }
+        foreach ($path in @($ConfigPath, $runtimePath)) {
+            if (-not [string]::IsNullOrEmpty([string]$path)) { [void]$protected.Add([string]$path) }
+        }
+        foreach ($path in $ConfigVisitedPaths) {
+            if (-not [string]::IsNullOrEmpty([string]$path)) { [void]$protected.Add([string]$path) }
+        }
+        foreach ($statePath in $namespace) {
+            foreach ($guard in $protected) {
+                if ($statePath.Equals($guard, [StringComparison]::OrdinalIgnoreCase)) { $collision = $true }
+            }
+        }
+    }
     if (-not $collision) {
         if ($BurnGate -and $null -ne $burnPaths) {
             [void](Append-BurnState $burnPaths.Base $currentBurn $mutate)

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -1619,7 +1619,7 @@ fi
     Check 'stdout is UTF-8 without BOM' ($codepageRun.StdoutBytes.Length -ge 3 -and -not ($codepageRun.StdoutBytes[0] -eq 0xEF -and $codepageRun.StdoutBytes[1] -eq 0xBB -and $codepageRun.StdoutBytes[2] -eq 0xBF) -and $codepageRun.Stdout.Contains((Glyph 0x96EA)))
     Check 'stdout uses LF without CR' (-not ($codepageRun.StdoutBytes -contains [byte]13) -and $codepageRun.StdoutBytes[$codepageRun.StdoutBytes.Length - 1] -eq 10)
 
-    # WIN-02 immutable state, estimator parity, mixed writers, and path boundaries.
+    # WIN-02 mutable TSV state, estimator parity, and path boundaries.
     $stateRoot = Join-Path $TempRoot 'win02-state'
     [void][IO.Directory]::CreateDirectory($stateRoot)
     $fixedNow = 1000000L
@@ -1659,23 +1659,25 @@ fi
     $sequentialConfig = New-StateConfig 'win02-sequential' $sequentialRoot 'burn limit5h limit7d' $true
     $psWrite = Invoke-Statusline (Json $statePayload) $sequentialConfig $stateEnvWrite '' 10000
     Check-Run 'WIN-02 PowerShell first writer' $psWrite
+    $burnPath = Join-Path $sequentialRoot 'burn.tsv'
     $burnStore = Join-Path $sequentialRoot 'burn.d'
     $limit5Store = Join-Path $sequentialRoot 'limit5.d'
     $limit7Store = Join-Path $sequentialRoot 'limit7.d'
-    $burnNames = Get-ImmediateNames $burnStore
-    Check 'WIN-02 PowerShell canonical burn name' ($burnNames.Count -eq 1 -and $burnNames[0] -ceq 'b_000001015900_000001000000_041.200_0000')
+    $burnRows = [IO.File]::ReadAllLines($burnPath, $StrictUtf8)
+    Check 'WIN-02 PowerShell appends canonical burn TSV row' ($burnRows.Count -eq 1 -and $burnRows[0] -ceq "1000000`t41.200`t1015900")
+    Check 'WIN-02 PowerShell ignores absent burn marker store' (-not [IO.Directory]::Exists($burnStore))
     Check 'WIN-02 PowerShell canonical 5h directory' ([IO.Directory]::Exists((Join-Path $limit5Store '0001015900_041.200')))
     Check 'WIN-02 PowerShell canonical 7d directory' ([IO.Directory]::Exists((Join-Path $limit7Store '0001345600_030.000')))
-    Check 'WIN-02 PowerShell writer leaves legacy TSV absent' (-not [IO.File]::Exists((Join-Path $sequentialRoot 'burn.tsv')))
 
     $bashRead = Invoke-BashStatusline (Json $statePayload) $sequentialConfig $stateEnvRead
     Check-Run 'WIN-02 Bash reads PowerShell state' $bashRead
     Check-Exact 'WIN-02 Bash reader matches PowerShell fixed-pill output' $bashRead $psWrite
-    Remove-Item -LiteralPath $burnStore,$limit5Store,$limit7Store -Recurse -Force
+    Remove-Item -LiteralPath $burnPath,$limit5Store,$limit7Store -Recurse -Force -ErrorAction SilentlyContinue
     $bashWrite = Invoke-BashStatusline (Json $statePayload) $sequentialConfig $stateEnvWrite
     Check-Run 'WIN-02 Bash first writer' $bashWrite
-    $burnNames = Get-ImmediateNames $burnStore
-    Check 'WIN-02 Bash canonical burn name' ($burnNames.Count -eq 1 -and $burnNames[0] -ceq 'b_000001015900_000001000000_041.200_0000')
+    $burnRows = [IO.File]::ReadAllLines($burnPath, $StrictUtf8)
+    Check 'WIN-02 Bash appends canonical burn TSV row' ($burnRows.Count -eq 1 -and $burnRows[0] -ceq "1000000`t41.200`t1015900")
+    Check 'WIN-02 Bash leaves absent burn marker store absent' (-not [IO.Directory]::Exists($burnStore))
     $psRead = Invoke-Statusline (Json $statePayload) $sequentialConfig $stateEnvRead '' 10000
     Check-Run 'WIN-02 PowerShell reads Bash state' $psRead
     Check-Exact 'WIN-02 PowerShell reader matches Bash fixed-pill output' $psRead $bashWrite
@@ -1698,17 +1700,17 @@ fi
         else { $run = Invoke-BashStatusline (Json $payload) $config $identityEnv }
         Check-Run "WIN-02 path identity writer $i" $run
     }
-    $identityNames = Get-ImmediateNames (Join-Path $identityRoot 'burn.d')
-    if ($identityNames.Count -ne 3) {
-        [Console]::Out.WriteLine('DIAG  WIN-02 identity names=' + ($identityNames -join ','))
+    $identityRows = [IO.File]::ReadAllLines($identityNative, $StrictUtf8)
+    if ($identityRows.Count -ne 3) {
+        [Console]::Out.WriteLine('DIAG  WIN-02 identity rows=' + ($identityRows -join '|'))
         foreach ($dump in @(Get-ChildItem -LiteralPath $identityRoot -Filter 'state-*.txt' -File | Sort-Object Name)) { [Console]::Out.WriteLine('DIAG  ' + $dump.Name + '=' + [IO.File]::ReadAllText($dump.FullName, $StrictUtf8)) }
     }
-    Check 'WIN-02 C native/forward/MSYS forms share one store' ($identityNames.Count -eq 3)
+    Check 'WIN-02 C native/forward/MSYS forms share one TSV' ($identityRows.Count -eq 3 -and -not [IO.Directory]::Exists((Join-Path $identityRoot 'burn.d')))
 
-    # Exact decimal vectors are checked through committed filenames in both runtimes.
+    # Exact decimal vectors are checked through canonical TSV rows in both runtimes.
     $pctVectors = @(
-        [pscustomobject]@{Raw='1.2345'; Canon='001.234'; Valid=$true},
-        [pscustomobject]@{Raw='1.2355'; Canon='001.236'; Valid=$true},
+        [pscustomobject]@{Raw='1.2345'; Canon='1.234'; Valid=$true},
+        [pscustomobject]@{Raw='1.2355'; Canon='1.236'; Valid=$true},
         [pscustomobject]@{Raw='99.9995'; Canon='100.000'; Valid=$true},
         [pscustomobject]@{Raw='100.000001'; Canon=''; Valid=$false},
         [pscustomobject]@{Raw='-0'; Canon=''; Valid=$false},
@@ -1723,25 +1725,19 @@ fi
         if (($i % 2) -eq 0) { $run = Invoke-Statusline (Json $payload) $config $stateEnvWrite '' 10000 }
         else { $run = Invoke-BashStatusline (Json $payload) $config $stateEnvWrite }
         Check-Run "WIN-02 canonical pct writer $i" $run
-        $names = Get-ImmediateNames (Join-Path $vectorRoot 'burn.d')
-        if ($pctVectors[$i].Valid) { Check "WIN-02 canonical pct $($pctVectors[$i].Raw)" ($names.Count -eq 1 -and $names[0].Contains('_' + $pctVectors[$i].Canon + '_')) }
-        else { Check "WIN-02 rejects pct $($pctVectors[$i].Raw)" ($names.Count -eq 0) }
+        $rows = @()
+        $vectorPath = Join-Path $vectorRoot 'burn.tsv'
+        if ([IO.File]::Exists($vectorPath)) { $rows = [IO.File]::ReadAllLines($vectorPath, $StrictUtf8) }
+        if ($pctVectors[$i].Valid) { Check "WIN-02 canonical pct $($pctVectors[$i].Raw)" ($rows.Count -eq 1 -and $rows[0].Contains("`t$($pctVectors[$i].Canon)`t")) }
+        else { Check "WIN-02 rejects pct $($pctVectors[$i].Raw)" ($rows.Count -eq 0) }
     }
 
     # Store-only estimator vector: exact same-second reduction, rate-derived ETA,
     # reset isolation, and raw fixed-pill output must agree.
     $estimateRoot = Join-Path $stateRoot 'estimate'
     $estimateConfig = New-StateConfig 'win02-estimate' $estimateRoot 'burn' $false
-    $estimateStore = Join-Path $estimateRoot 'burn.d'
-    [void][IO.Directory]::CreateDirectory($estimateStore)
-    foreach ($name in @(
-        'b_000001015900_000000999640_006.000_0000',
-        'b_000001015900_000000999700_007.000_0000',
-        'b_000001015900_000000999700_006.500_0001',
-        'b_000001015900_000000999940_008.000_0000',
-        'b_000001015900_000001000000_008.000_0000',
-        'b_000001010000_000000999900_051.000_0000'
-    )) { [IO.File]::WriteAllBytes((Join-Path $estimateStore $name), [byte[]]@()) }
+    $estimatePath = Join-Path $estimateRoot 'burn.tsv'
+    Write-Utf8 $estimatePath "999640`t006.000`t1015900`n999700`t007.000`t1015900`n999700`t006.500`t1015900`n999940`t008.000`t1015900`n1000000`t008.000`t1015900`n999900`t051.000`t1010000`n"
     $estimatePayload = Clone-Object $statePayload
     $estimatePayload.rate_limits.five_hour.used_percentage = '8'
     $estimatePsDump = Join-Path $estimateRoot 'ps-state.json'
@@ -1789,7 +1785,7 @@ fi
         $bashState = [IO.File]::ReadAllText($bashDump, $StrictUtf8).Trim()
         Check ('WIN-02 rational ETA ' + $vector.Pct) ([string]$psState.SevenEta -eq $vector.Eta -and $bashState.Contains('SevenEta=' + $vector.Eta + ' '))
         if (-not [string]::IsNullOrEmpty($vector.Rate)) { Check 'WIN-02 rational non-divisible 7d rate' ($psState.SevenRate -eq $vector.Rate -and $bashState.Contains('SevenRate=' + $vector.Rate + ' ')) }
-        Check ('WIN-02 rational no-sample root absent ' + $vector.Pct) (-not [IO.Directory]::Exists((Join-Path $rationalRoot 'burn.d')))
+        Check ('WIN-02 rational no-sample burn TSV absent ' + $vector.Pct) (-not [IO.File]::Exists((Join-Path $rationalRoot 'burn.tsv')))
     }
 
     # Deterministic controls distinguish unchanged usage, truly idle history, and
@@ -1798,34 +1794,33 @@ fi
         [pscustomobject]@{
             Name='unchanged'; Expected='warming'; Pct='10';
             Entries=@(
-                'b_000001015900_000000999500_010.000_0000',
-                'b_000001015900_000000999700_010.000_0000',
-                'b_000001015900_000000999900_010.000_0000'
+                '999500`t010.000`t1015900',
+                '999700`t010.000`t1015900',
+                '999900`t010.000`t1015900'
             )
         },
         [pscustomobject]@{
             Name='idle'; Expected='idle'; Pct='6';
             Entries=@(
-                'b_000001015900_000000999000_005.000_0000',
-                'b_000001015900_000000999100_006.000_0000',
-                'b_000001015900_000000999900_006.000_0000'
+                '999000`t005.000`t1015900',
+                '999100`t006.000`t1015900',
+                '999900`t006.000`t1015900'
             )
         },
         [pscustomobject]@{
             Name='reset-rollover'; Expected='warming'; Pct='2';
             Entries=@(
-                'b_000001010000_000000999500_005.000_0000',
-                'b_000001010000_000000999700_006.000_0000',
-                'b_000001010000_000000999900_007.000_0000',
-                'b_000001015900_000000999950_002.000_0000'
+                '999500`t005.000`t1010000',
+                '999700`t006.000`t1010000',
+                '999900`t007.000`t1010000',
+                '999950`t002.000`t1015900'
             )
         }
     )) {
         $controlRoot = Join-Path $stateRoot ('estimator-' + $control.Name)
         $controlConfig = New-StateConfig ('win02-estimator-' + $control.Name) $controlRoot 'burn' $false
-        $controlStore = Join-Path $controlRoot 'burn.d'
-        [void][IO.Directory]::CreateDirectory($controlStore)
-        foreach ($name in $control.Entries) { [IO.File]::WriteAllBytes((Join-Path $controlStore $name), [byte[]]@()) }
+        $controlPath = Join-Path $controlRoot 'burn.tsv'
+        Write-Utf8 $controlPath (($control.Entries -join "`n") + "`n")
         $controlPayload = Clone-Object $statePayload
         $controlPayload.rate_limits.five_hour.used_percentage = $control.Pct
         $controlPayload.rate_limits.seven_day.used_percentage = $null
@@ -1844,47 +1839,7 @@ fi
         Check ('WIN-02 deterministic estimator state ' + $control.Name) ($psState.FiveState -eq $control.Expected -and $bashState.Contains('FiveState=' + $control.Expected + ' '))
     }
 
-    # Legacy is bounded, permanently read-only, deduplicated in memory, and never
-    # imported as l_* state.
-    $legacyRoot = Join-Path $stateRoot 'legacy'
-    $legacyConfig = New-StateConfig 'win02-legacy' $legacyRoot 'burn' $false
-    $legacyPath = Join-Path $legacyRoot 'burn.tsv'
-    Write-Utf8 $legacyPath "999640`t6`t1015900`n999700`t7`t1015900`n999940`t8`t1015900`n1000000`t8`t1015900`n9999999`t99`t99999999`n"
-    $legacyBefore = Snapshot-File $legacyPath
-    $legacyPayload = Clone-Object $statePayload
-    $legacyPayload.rate_limits.five_hour.used_percentage = '8'
-    $legacyPs = Invoke-Statusline (Json $legacyPayload) $legacyConfig $stateEnvWrite '' 10000
-    $legacyBash = Invoke-BashStatusline (Json $legacyPayload) $legacyConfig $stateEnvWrite
-    Check-Run 'WIN-02 PowerShell legacy read' $legacyPs
-    Check-Run 'WIN-02 Bash legacy read' $legacyBash
-    Check 'WIN-02 legacy bytes/timestamp/hash unchanged' ((Snapshot-File $legacyPath) -eq $legacyBefore)
-    $legacyNames = Get-ImmediateNames (Join-Path $legacyRoot 'burn.d')
-    Check 'WIN-02 no runtime creates l_*' (@($legacyNames | Where-Object { $_ -like 'l_*' }).Count -eq 0)
-
-    # Simulate a downgrade runtime appending the permanent legacy TSV after the
-    # immutable store already exists. New readers must reread those rows without
-    # importing, rewriting, or changing either source.
-    [IO.File]::AppendAllText($legacyPath, "999500`t10`t1016000`n999700`t11`t1016000`n999940`t12`t1016000`n", $Utf8NoBom)
-    $downgradeLegacyBefore = Snapshot-File $legacyPath
-    [void](Snapshot-StateTree (Join-Path $legacyRoot 'burn.d'))
-    $downgradeStoreBefore = Snapshot-StateTree (Join-Path $legacyRoot 'burn.d')
-    $downgradePsDump = Join-Path $legacyRoot 'downgrade-ps.json'
-    $downgradeBashDump = Join-Path $legacyRoot 'downgrade-bash.txt'
-    $downgradePsEnv = @{ CORALLINE_NO_SAMPLE='1'; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_STATE_DUMP=$downgradePsDump }
-    $downgradeBashEnv = @{ CORALLINE_NO_SAMPLE='1'; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_STATE_DUMP=(Forward-Path $downgradeBashDump) }
-    $downgradePs = Invoke-Statusline (Json $legacyPayload) $legacyConfig $downgradePsEnv '' 10000
-    $downgradeBash = Invoke-BashStatusline (Json $legacyPayload) $legacyConfig $downgradeBashEnv
-    Check-Run 'WIN-02 PowerShell post-downgrade legacy reread' $downgradePs
-    Check-Run 'WIN-02 Bash post-downgrade legacy reread' $downgradeBash
-    Check-Exact 'WIN-02 post-downgrade reader differential' $downgradePs $downgradeBash
-    $downgradeState = [IO.File]::ReadAllText($downgradePsDump, $StrictUtf8) | ConvertFrom-Json
-    Check 'WIN-02 post-downgrade rows drive latest synthetic reset' ($downgradeState.FiveState -eq 'active' -and [string]$downgradeState.FiveEta -eq '21120' -and [string]$downgradeState.FiveTtr -eq '16000')
-    Check 'WIN-02 post-downgrade legacy remains byte exact during reread' ((Snapshot-File $legacyPath) -eq $downgradeLegacyBefore)
-    Check 'WIN-02 post-downgrade store remains unchanged during reread' ((Snapshot-StateTree (Join-Path $legacyRoot 'burn.d')) -ceq $downgradeStoreBefore)
-    Check 'WIN-02 post-downgrade reread creates no l_*' (@((Get-ImmediateNames (Join-Path $legacyRoot 'burn.d')) | Where-Object { $_ -like 'l_*' }).Count -eq 0)
-
-    # CORALLINE_NO_SAMPLE preserves all roots, strict sentinels, malformed entries,
-    # legacy bytes, and missing roots under both readers.
+    # CORALLINE_NO_SAMPLE preserves the mutable TSV and any pre-existing marker tree.
     $readonlyRoot = Join-Path $stateRoot 'readonly'
     $readonlyConfig = New-StateConfig 'win02-readonly' $readonlyRoot 'burn limit5h limit7d' $true
     [void][IO.Directory]::CreateDirectory((Join-Path $readonlyRoot 'burn.d'))
@@ -1904,17 +1859,101 @@ fi
     $missingReadonlyConfig = New-StateConfig 'win02-readonly-missing' $missingReadonlyRoot 'burn limit5h limit7d' $true
     [void](Invoke-Statusline (Json $statePayload) $missingReadonlyConfig $stateEnvRead '' 10000)
     [void](Invoke-BashStatusline (Json $statePayload) $missingReadonlyConfig $stateEnvRead)
-    Check 'WIN-02 no-sample leaves missing roots absent' (-not [IO.Directory]::Exists((Join-Path $missingReadonlyRoot 'burn.d')) -and -not [IO.Directory]::Exists((Join-Path $missingReadonlyRoot 'limit5.d')))
+    Check 'WIN-02 no-sample leaves missing roots absent' (-not [IO.File]::Exists((Join-Path $missingReadonlyRoot 'burn.tsv')) -and -not [IO.Directory]::Exists((Join-Path $missingReadonlyRoot 'limit5.d')))
 
-    # Over-cap stores are incomplete, bounded by watchdog, and frozen.
+    # A valid marker directory is ignored and a bounded TSV is trimmed/healed.
+    $mutableRoot = Join-Path $stateRoot 'mutable'
+    $mutableConfig = New-StateConfig 'win02-mutable' $mutableRoot 'burn' $false
+    $mutablePath = Join-Path $mutableRoot 'burn.tsv'
+    $mutableMarker = Join-Path $mutableRoot 'burn.d'
+    [void][IO.Directory]::CreateDirectory($mutableMarker)
+    $markerFile = Join-Path $mutableMarker 'keep'
+    Write-Utf8 $markerFile 'marker'
+    $mutableBuilder = New-Object Text.StringBuilder
+    [void]$mutableBuilder.Append("999998`t010.000`t999997`n")
+    for ($i=0; $i -lt 1500; $i++) {
+        [void]$mutableBuilder.Append((($fixedNow - 1500L + $i).ToString($Invariant) + "`t010.000`t1015900`n"))
+    }
+    Write-Utf8 $mutablePath $mutableBuilder.ToString()
+    $markerBefore = Snapshot-StateTree $mutableMarker
+    $mutableRun = Invoke-Statusline (Json $statePayload) $mutableConfig $stateEnvWrite '' 30000
+    Check-Run 'WIN-02 mutable burn trim/heal' $mutableRun
+    $mutableRows = [IO.File]::ReadAllLines($mutablePath, $StrictUtf8)
+    Check 'WIN-02 mutable burn trims to BURN_TRIM and heals stale row' ($mutableRows.Count -eq 1500 -and -not ($mutableRows -contains "999998`t010.000`t999997"))
+    Check 'WIN-02 mutable burn leaves marker tree byte exact' ((Snapshot-StateTree $mutableMarker) -ceq $markerBefore)
+    # Trim keeps the tail, in order. A row count alone would pass on rewritten,
+    # reordered or partially written content.
+    $mutableExpected = New-Object 'System.Collections.Generic.List[string]'
+    for ($i = $mutableRows.Count - 1; $i -ge 0; $i--) { [void]$mutableExpected.Add($mutableRows[$i]) }
+    $mutableSorted = $true
+    for ($i = 1; $i -lt $mutableRows.Count; $i++) {
+        $prev = [long](($mutableRows[$i - 1]).Split(@("`t"), [StringSplitOptions]::None)[0])
+        $cur = [long](($mutableRows[$i]).Split(@("`t"), [StringSplitOptions]::None)[0])
+        if ($cur -lt $prev) { $mutableSorted = $false; break }
+    }
+    Check 'WIN-02 mutable burn retains rows in sample order' $mutableSorted
+    $mutableFields = $true
+    foreach ($line in $mutableRows) {
+        if (($line.Split(@("`t"), [StringSplitOptions]::None)).Length -ne 3) { $mutableFields = $false; break }
+    }
+    Check 'WIN-02 mutable burn writes no partial record' $mutableFields
+    # The rewrite goes through a temp and a backup; neither may survive it.
+    $mutableParent = [IO.Path]::GetDirectoryName($mutablePath)
+    $mutableResidue = @(Get-ChildItem -LiteralPath $mutableParent -Force -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -like '.burn.tmp.*' -or $_.Name -like '.burn.bak.*' })
+    Check 'WIN-02 mutable burn leaves no temp or backup residue' ($mutableResidue.Count -eq 0)
+
+    # A NUL byte inside a record must be skipped, not abort the render and not
+    # rewrite history. The reader accepts only tab, dot and digits per record.
+    $nulRoot = Join-Path $stateRoot 'nulrow'
+    $nulConfig = New-StateConfig 'win02-nulrow' $nulRoot 'burn' $false
+    $nulPath = Join-Path $nulRoot 'burn.tsv'
+    $nulText = (($fixedNow - 300L).ToString($Invariant) + "`t010.000`t1015900`n") +
+               (($fixedNow - 200L).ToString($Invariant) + "`t01" + ([char]0) + "0.000`t1015900`n") +
+               (($fixedNow - 100L).ToString($Invariant) + "`t020.000`t1015900`n")
+    Write-Utf8 $nulPath $nulText
+    $nulBefore = ([IO.File]::ReadAllBytes($nulPath)).Length
+    $nulRun = Invoke-Statusline (Json $statePayload) $nulConfig $stateEnvRead '' 15000
+    Check-Run 'WIN-02 NUL row does not abort the render' $nulRun
+    Check 'WIN-02 NUL row leaves the read-only TSV byte exact' ((([IO.File]::ReadAllBytes($nulPath)).Length) -eq $nulBefore)
+
+    # A single record longer than the reader's per-record ceiling is rejected
+    # without consuming the rest of the file.
+    $longRoot = Join-Path $stateRoot 'longrecord'
+    $longConfig = New-StateConfig 'win02-longrecord' $longRoot 'burn' $false
+    $longPath = Join-Path $longRoot 'burn.tsv'
+    $longText = (('9' * 5000) + "`t010.000`t1015900`n") +
+                (($fixedNow - 100L).ToString($Invariant) + "`t020.000`t1015900`n")
+    Write-Utf8 $longPath $longText
+    $longBefore = ([IO.File]::ReadAllBytes($longPath)).Length
+    $longRun = Invoke-Statusline (Json $statePayload) $longConfig $stateEnvRead '' 15000
+    Check-Run 'WIN-02 overlong record does not abort the render' $longRun
+    Check 'WIN-02 overlong record leaves the read-only TSV byte exact' ((([IO.File]::ReadAllBytes($longPath)).Length) -eq $longBefore)
+
+    # Beyond the byte ceiling the reader must refuse the file rather than rewrite
+    # a truncated version of it.
+    $hugeRoot = Join-Path $stateRoot 'hugetsv'
+    $hugeConfig = New-StateConfig 'win02-hugetsv' $hugeRoot 'burn' $false
+    $hugePath = Join-Path $hugeRoot 'burn.tsv'
+    $hugeRow = (($fixedNow - 100L).ToString($Invariant) + "`t010.000`t1015900`n")
+    $hugeBuilder = New-Object Text.StringBuilder
+    while ($hugeBuilder.Length -le 1048576) { [void]$hugeBuilder.Append($hugeRow) }
+    Write-Utf8 $hugePath $hugeBuilder.ToString()
+    $hugeBefore = ([IO.File]::ReadAllBytes($hugePath)).Length
+    $hugeRun = Invoke-Statusline (Json $statePayload) $hugeConfig $stateEnvWrite '' 30000
+    Check-Run 'WIN-02 oversized TSV does not abort the render' $hugeRun
+    Check 'WIN-02 oversized TSV is refused rather than truncated' ((([IO.File]::ReadAllBytes($hugePath)).Length) -eq $hugeBefore)
+
     $overRoot = Join-Path $stateRoot 'overcap'
-    $overConfig = New-StateConfig 'win02-overcap' $overRoot 'burn limit5h' $true
-    $overBurn = Join-Path $overRoot 'burn.d'
-    [void][IO.Directory]::CreateDirectory($overBurn)
-    for ($i=0; $i -lt 4097; $i++) { [IO.File]::WriteAllBytes((Join-Path $overBurn ('x' + $i.ToString('D4'))), [byte[]]@()) }
-    $overPs = Invoke-Statusline (Json $statePayload) $overConfig $stateEnvWrite '' 20000
+    $overConfig = New-StateConfig 'win02-overcap' $overRoot 'burn' $false
+    $overPath = Join-Path $overRoot 'burn.tsv'
+    $overLines = New-Object Text.StringBuilder
+    for ($i=0; $i -lt 4097; $i++) { [void]$overLines.Append((($fixedNow - $i - 1L).ToString($Invariant) + "`t010.000`t1015900`n")) }
+    Write-Utf8 $overPath $overLines.ToString()
+    $overPs = Invoke-Statusline (Json $statePayload) $overConfig $stateEnvWrite '' 30000
     Check-Run 'WIN-02 PowerShell burn cap+1 watchdog' $overPs
-    Check 'WIN-02 PowerShell burn cap+1 frozen' ((Get-ImmediateNames $overBurn).Count -eq 4097)
+    Check 'WIN-02 PowerShell burn cap+1 leaves the oversized TSV untrimmed' (([IO.File]::ReadAllLines($overPath, $StrictUtf8)).Count -eq 4098)
+    Check 'WIN-02 PowerShell burn cap+1 creates no ignored marker store' (-not [IO.Directory]::Exists((Join-Path $overRoot 'burn.d')))
     $overLimit = Join-Path $overRoot 'limit5.d'
     if ([IO.Directory]::Exists($overLimit)) { [IO.Directory]::Delete($overLimit, $true) }
     [void][IO.Directory]::CreateDirectory($overLimit)
@@ -1923,18 +1962,19 @@ fi
     Check-Run 'WIN-02 PowerShell limit cap+1 watchdog' $overPs2
     Check 'WIN-02 PowerShell limit cap+1 frozen' ((Get-ImmediateNames $overLimit).Count -eq 513)
 
-    # Publication watermarks and complete scan caps are distinct boundaries.
+    # TSV trim and complete-read caps are distinct boundaries.
     foreach ($rawCount in @(3967,3968,4096)) {
         $boundaryRoot = Join-Path $stateRoot ("burn-boundary-$rawCount")
         $boundaryConfig = New-StateConfig ("win02-burn-boundary-$rawCount") $boundaryRoot 'burn' $false
-        $boundaryStore = Join-Path $boundaryRoot 'burn.d'
-        [void][IO.Directory]::CreateDirectory($boundaryStore)
-        for ($i=0; $i -lt $rawCount; $i++) { [IO.File]::WriteAllBytes((Join-Path $boundaryStore ('x' + $i.ToString('D4'))), [byte[]]@()) }
+        $boundaryStore = Join-Path $boundaryRoot 'burn.tsv'
+        $boundaryLines = New-Object Text.StringBuilder
+        for ($i=0; $i -lt $rawCount; $i++) { [void]$boundaryLines.Append((($fixedNow - $i - 1L).ToString($Invariant) + "`t010.000`t1015900`n")) }
+        Write-Utf8 $boundaryStore $boundaryLines.ToString()
         $boundaryRun = Invoke-Statusline (Json $statePayload) $boundaryConfig $stateEnvWrite '' 30000
         Check-Run "WIN-02 PowerShell burn raw boundary $rawCount" $boundaryRun
-        $expectedCount = $rawCount
-        if ($rawCount -eq 3967) { $expectedCount++ }
-        Check "WIN-02 burn raw boundary $rawCount publication" ((Get-ImmediateNames $boundaryStore).Count -eq $expectedCount)
+        $expectedRows = 1500
+        if ($rawCount -eq 4096) { $expectedRows = 4097 }
+        Check "WIN-02 burn raw boundary $rawCount" (([IO.File]::ReadAllLines($boundaryStore, $StrictUtf8)).Count -eq $expectedRows)
     }
     foreach ($rawCount in @(383,384,512)) {
         $boundaryRoot = Join-Path $stateRoot ("limit-boundary-$rawCount")
@@ -1950,72 +1990,22 @@ fi
     }
 
     # The default 1500-entry retained set must remain usable on the prompt path.
-    # Every filename is canonical so this exercises the real native sort path.
     $steadyRoot = Join-Path $stateRoot 'steady-1500'
     $steadyConfig = New-StateConfig 'win02-steady-1500' $steadyRoot 'burn' $false
-    $steadyStore = Join-Path $steadyRoot 'burn.d'
-    [void][IO.Directory]::CreateDirectory($steadyStore)
+    $steadyStore = Join-Path $steadyRoot 'burn.tsv'
+    $steadyBuilder = New-Object Text.StringBuilder
     for ($i=0; $i -lt 1500; $i++) {
         $sample = $fixedNow - $i - 1L
-        $name = 'b_' + $reset5.ToString('D12', $Invariant) + '_' + $sample.ToString('D12', $Invariant) + '_010.000_0000'
-        [IO.File]::WriteAllBytes((Join-Path $steadyStore $name), [byte[]]@())
+        [void]$steadyBuilder.Append(($sample.ToString($Invariant) + "`t010.000`t1015900`n"))
     }
+    Write-Utf8 $steadyStore $steadyBuilder.ToString()
     $steadyPs = Invoke-Statusline (Json $statePayload) $steadyConfig $stateEnvWrite '' 5000
     Check-Run 'WIN-02 PowerShell 1500-entry steady render' $steadyPs
     Check 'WIN-02 PowerShell 1500-entry steady render under 3s' ($steadyPs.ElapsedMs -lt 3000)
-    Check 'WIN-02 PowerShell 1500-entry steady publication' ((Get-ImmediateNames $steadyStore).Count -eq 1501)
+    Check 'WIN-02 PowerShell 1500-entry steady render trims to 1500 rows' (([IO.File]::ReadAllLines($steadyStore, $StrictUtf8)).Count -eq 1500)
     $steadyBash = Invoke-BashStatusline (Json $statePayload) $steadyConfig $stateEnvRead
     Check-Run 'WIN-02 Bash 1500-entry steady render' $steadyBash
     Check 'WIN-02 Bash 1500-entry steady render under 3s' ($steadyBash.ElapsedMs -lt 3000)
-
-    # PowerShell legacy reads enforce the same byte/row/record bounds and keep the
-    # physical TSV untouched. Exact-cap input is complete; cap+1 and late bounds
-    # freeze publication instead of using partial rows.
-    $legacyExactRoot = Join-Path $stateRoot 'legacy-exact-cap'
-    $legacyExactConfig = New-StateConfig 'win02-legacy-exact-cap' $legacyExactRoot 'burn' $false
-    $legacyExactPath = Join-Path $legacyExactRoot 'burn.tsv'
-    $legacyRecord = New-Object byte[] 4096
-    for ($i=0; $i -lt 4095; $i++) { $legacyRecord[$i] = 120 }
-    $legacyRecord[4095] = 10
-    $legacyExactBytes = New-Object byte[] 1048576
-    for ($offset=0; $offset -lt $legacyExactBytes.Length; $offset += $legacyRecord.Length) { [Array]::Copy($legacyRecord, 0, $legacyExactBytes, $offset, $legacyRecord.Length) }
-    [IO.File]::WriteAllBytes($legacyExactPath, $legacyExactBytes)
-    $legacyExactBefore = Snapshot-File $legacyExactPath
-    $legacyExactRun = Invoke-Statusline (Json $statePayload) $legacyExactConfig $stateEnvWrite '' 30000
-    Check-Run 'WIN-02 PowerShell exact 1MiB legacy' $legacyExactRun
-    Check 'WIN-02 exact 1MiB legacy completes and publishes' ((Get-ImmediateNames (Join-Path $legacyExactRoot 'burn.d')).Count -eq 1)
-    Check 'WIN-02 exact 1MiB legacy remains byte exact' ((Snapshot-File $legacyExactPath) -eq $legacyExactBefore)
-
-    $legacyOverRoot = Join-Path $stateRoot 'legacy-cap-plus-one'
-    $legacyOverConfig = New-StateConfig 'win02-legacy-cap-plus-one' $legacyOverRoot 'burn' $false
-    $legacyOverPath = Join-Path $legacyOverRoot 'burn.tsv'
-    $legacyOverBytes = New-Object byte[] 1048577
-    [Array]::Copy($legacyExactBytes, $legacyOverBytes, $legacyExactBytes.Length)
-    $legacyOverBytes[1048576] = 120
-    [IO.File]::WriteAllBytes($legacyOverPath, $legacyOverBytes)
-    $legacyOverBefore = Snapshot-File $legacyOverPath
-    $legacyOverRun = Invoke-Statusline (Json $statePayload) $legacyOverConfig $stateEnvWrite '' 30000
-    Check-Run 'WIN-02 PowerShell legacy cap+1 watchdog' $legacyOverRun
-    Check 'WIN-02 legacy cap+1 freezes publication' (-not [IO.Directory]::Exists((Join-Path $legacyOverRoot 'burn.d')))
-    Check 'WIN-02 legacy cap+1 remains byte exact' ((Snapshot-File $legacyOverPath) -eq $legacyOverBefore)
-
-    foreach ($legacyCase in @(
-        [pscustomobject]@{Name='row-cap-plus-one'; Bytes=([byte[]](,10 * 4097))},
-        [pscustomobject]@{Name='record-cap-plus-one'; Bytes=([Text.Encoding]::ASCII.GetBytes(('1' * 4097)))},
-        [pscustomobject]@{Name='nul-row'; Bytes=([byte[]](49,48,48,48,48,48,48,9,49,9,49,48,49,53,57,48,48,10,49,0,9,49,9,49,10))}
-    )) {
-        $caseRoot = Join-Path $stateRoot ('legacy-' + $legacyCase.Name)
-        $caseConfig = New-StateConfig ('win02-legacy-' + $legacyCase.Name) $caseRoot 'burn' $false
-        $casePath = Join-Path $caseRoot 'burn.tsv'
-        [IO.File]::WriteAllBytes($casePath, $legacyCase.Bytes)
-        $caseBefore = Snapshot-File $casePath
-        $caseRun = Invoke-Statusline (Json $statePayload) $caseConfig $stateEnvWrite '' 10000
-        Check-Run ('WIN-02 PowerShell legacy ' + $legacyCase.Name) $caseRun
-        $casePublished = [IO.Directory]::Exists((Join-Path $caseRoot 'burn.d'))
-        if ($legacyCase.Name -eq 'nul-row') { Check 'WIN-02 bounded NUL row is ignored without poisoning snapshot' $casePublished }
-        else { Check ('WIN-02 ' + $legacyCase.Name + ' freezes publication') (-not $casePublished) }
-        Check ('WIN-02 ' + $legacyCase.Name + ' remains byte exact') ((Snapshot-File $casePath) -eq $caseBefore)
-    }
 
     # Fixed-clock limit edges are strict for both stores. Only NOW+1 and NOW+max
     # are plausible and publishable; expired/far-future strict sentinels are
@@ -2190,122 +2180,23 @@ fi
         Check-Exact ('WIN-02 ' + $resetSpec.Name + ' differential') $psReset $bashReset
     }
 
-    # Concurrent mixed-runtime cohorts use unique canonical pct values so every
-    # successful writer has one observable immutable commit.
-    foreach ($count in @(1,2,4,8,128)) {
-        $cohortRoot = Join-Path $stateRoot ("cohort-$count")
-        $cohortConfig = New-StateConfig ("win02-cohort-$count") $cohortRoot 'burn' $false
-        $handles = New-Object 'System.Collections.Generic.List[object]'
-        for ($i=0; $i -lt $count; $i++) {
-            $payload = Clone-Object $statePayload
-            $payload.rate_limits.five_hour.used_percentage = [string]::Format($Invariant, '10.{0:000}', $i)
-            $writerEnv = @{ CORALLINE_NO_SAMPLE=$null; CORALLINE_TEST_NOW=[string]($fixedNow + $i) }
-            $environment = Runtime-Environment $cohortConfig $writerEnv
-            if (($i % 2) -eq 0) {
-                $args = '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + $script:StateScript + '"'
-                [void]$handles.Add((Start-CapturedProcessAsync $PowerShellExe $args (Json $payload) $environment $Repo))
-            } else {
-                $args = '--noprofile --norc "' + (Forward-Path $script:StateBashScript) + '"'
-                [void]$handles.Add((Start-CapturedProcessAsync $script:BashExe $args (Json $payload) $environment $Repo))
-            }
-        }
-        $cohortOk = $true
-        $cohortErrors = New-Object 'System.Collections.Generic.List[string]'
-        $writerIndex = 0
-        foreach ($handle in $handles) {
-            $result = Wait-CapturedProcessAsync $handle 120000
-            if ($result.TimedOut -or $result.ExitCode -ne 0 -or $result.StderrBytes.Length -ne 0) {
-                $cohortOk = $false
-                [void]$cohortErrors.Add(("writer=$writerIndex timeout=$($result.TimedOut) exit=$($result.ExitCode) stderr=" + $Utf8NoBom.GetString($result.StderrBytes)))
-            }
-            $writerIndex++
-        }
-        $cohortNames = Get-ImmediateNames (Join-Path $cohortRoot 'burn.d')
-        if (-not $cohortOk -or $cohortNames.Count -ne $count) { [Console]::Out.WriteLine("DIAG  WIN-02 cohort N=$count names=$($cohortNames.Count) errors=" + ($cohortErrors -join ';')) }
-        Check "WIN-02 mixed cohort N=$count writers succeed" ($cohortOk -and $cohortNames.Count -eq $count)
-    }
-
-    # Every mixed writer snapshots before the parent injects occupied live slots.
-    # The occupied names are therefore post-snapshot commits and cannot enter this
-    # GC round; writers must collide through them and exclusively claim later slots.
-    $raceRoot = Join-Path $stateRoot 'same-name-race'
-    $raceConfig = New-StateConfig 'win02-same-name-race' $raceRoot 'burn' $false
-    $raceBarrier = Join-Path $raceRoot 'release'
-    $racePayload = Clone-Object $statePayload
-    $racePayload.rate_limits.five_hour.used_percentage = '42.345'
-    $raceHandles = New-Object 'System.Collections.Generic.List[object]'
-    for ($i=0; $i -lt 8; $i++) {
-        $raceEnv = Runtime-Environment $raceConfig @{ CORALLINE_NO_SAMPLE=$null; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_BARRIER=(Forward-Path $raceBarrier) }
-        if (($i % 2) -eq 0) {
-            $raceArgs = '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + $script:StateScript + '"'
-            [void]$raceHandles.Add((Start-CapturedProcessAsync $PowerShellExe $raceArgs (Json $racePayload) $raceEnv $Repo))
-        } else {
-            $raceArgs = '--noprofile --norc "' + (Forward-Path $script:StateBashScript) + '"'
-            [void]$raceHandles.Add((Start-CapturedProcessAsync $script:BashExe $raceArgs (Json $racePayload) $raceEnv $Repo))
-        }
-    }
-    $raceReady = Wait-StateBarrier $raceBarrier 8 120000
-    Check 'WIN-02 mixed same-name writers reach complete-snapshot barrier' $raceReady
-    $raceStore = Join-Path $raceRoot 'burn.d'
-    if ($raceReady) {
-        [void][IO.Directory]::CreateDirectory($raceStore)
-        for ($slot=0; $slot -lt 4; $slot++) {
-            $name = 'b_000001015900_000001000000_042.345_' + $slot.ToString('D4', $Invariant)
-            [IO.File]::WriteAllBytes((Join-Path $raceStore $name), [byte[]]@())
-        }
-        [IO.File]::WriteAllBytes($raceBarrier, [byte[]]@())
-    }
-    $raceOk = $raceReady
-    foreach ($handle in $raceHandles) {
-        $result = Wait-CapturedProcessAsync $handle 120000
-        if ($result.TimedOut -or $result.ExitCode -ne 0 -or $result.StderrBytes.Length -ne 0) { $raceOk=$false }
-    }
-    $raceNames = Get-ImmediateNames $raceStore
-    $expectedRaceNames = @()
-    for ($slot=0; $slot -lt 12; $slot++) { $expectedRaceNames += 'b_000001015900_000001000000_042.345_' + $slot.ToString('D4', $Invariant) }
-    Check 'WIN-02 preoccupied slots and eight mixed commits are exact' ($raceOk -and ($raceNames -join "`n") -ceq ($expectedRaceNames -join "`n"))
-    Check 'WIN-02 post-snapshot occupied entries survive current GC' (@($raceNames | Where-Object { $_ -like '*_0000' -or $_ -like '*_0001' -or $_ -like '*_0002' -or $_ -like '*_0003' }).Count -eq 4)
-
-    # Crash before the commit point leaves no entry. Crash after exclusive create
-    # leaves one complete zero-byte entry and no partial grammar-valid artifact.
-    $beforeCrashRoot = Join-Path $stateRoot 'crash-before-create'
-    $beforeCrashConfig = New-StateConfig 'win02-crash-before-create' $beforeCrashRoot 'burn' $false
-    $beforeBarrier = Join-Path $beforeCrashRoot 'release'
-    $beforeEnv = Runtime-Environment $beforeCrashConfig @{ CORALLINE_NO_SAMPLE=$null; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_BARRIER=(Forward-Path $beforeBarrier) }
-    $beforeArgs = '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + $script:StateScript + '"'
-    $beforeHandle = Start-CapturedProcessAsync $PowerShellExe $beforeArgs (Json $statePayload) $beforeEnv $Repo
-    $beforeReady = Wait-StateBarrier $beforeBarrier 1 30000
-    Check 'WIN-02 crash-before-create reaches complete snapshot' $beforeReady
-    if ($beforeReady) { try { $beforeHandle.Process.Kill() } catch { } }
-    [void](Wait-CapturedProcessAsync $beforeHandle 30000)
-    Check 'WIN-02 crash-before-create leaves no committed entry' ((Get-ImmediateNames (Join-Path $beforeCrashRoot 'burn.d')).Count -eq 0)
-
-    $afterCrashRoot = Join-Path $stateRoot 'crash-after-create'
-    $afterCrashConfig = New-StateConfig 'win02-crash-after-create' $afterCrashRoot 'burn' $false
-    $afterBarrier = Join-Path $afterCrashRoot 'release'
-    $afterEnv = Runtime-Environment $afterCrashConfig @{ CORALLINE_NO_SAMPLE=$null; CORALLINE_TEST_NOW=[string]$fixedNow; CORALLINE_TEST_AFTER_CREATE=(Forward-Path $afterBarrier) }
-    $afterArgs = '--noprofile --norc "' + (Forward-Path $script:StateBashScript) + '"'
-    $afterHandle = Start-CapturedProcessAsync $script:BashExe $afterArgs (Json $statePayload) $afterEnv $Repo
-    $afterReady = Wait-StateBarrier $afterBarrier 1 30000
-    Check 'WIN-02 crash-after-create reaches committed barrier' $afterReady
-    $afterStore = Join-Path $afterCrashRoot 'burn.d'
-    $afterNames = Get-ImmediateNames $afterStore
-    $afterComplete = $afterNames.Count -eq 1 -and [IO.File]::Exists((Join-Path $afterStore $afterNames[0])) -and (New-Object IO.FileInfo((Join-Path $afterStore $afterNames[0]))).Length -eq 0
-    if ($afterReady) { try { $afterHandle.Process.Kill() } catch { } }
-    [void](Wait-CapturedProcessAsync $afterHandle 30000)
-    Check 'WIN-02 crash-after-create preserves complete commit' ($afterComplete -and (Get-ImmediateNames $afterStore).Count -eq 1)
-
-    # Culture cannot change canonical decimal filenames or output.
-    $cultureRoot = Join-Path $stateRoot 'culture'
-    $cultureConfig = New-StateConfig 'win02-culture' $cultureRoot 'burn' $false
-    $culturePayload = Clone-Object $statePayload
-    $culturePayload.rate_limits.five_hour.used_percentage = '1.2355'
-    $cultureCommand = '[Threading.Thread]::CurrentThread.CurrentCulture=[Globalization.CultureInfo]::GetCultureInfo(''de-DE''); & ''' + $script:StateScript + ''''
-    $cultureArgs = '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "' + $cultureCommand.Replace('"','\"') + '"'
-    $cultureRun = Invoke-CapturedProcess $PowerShellExe $cultureArgs (Json $culturePayload) (Runtime-Environment $cultureConfig $stateEnvWrite) $Repo 10000
-    Check-Run 'WIN-02 comma-decimal PowerShell culture' $cultureRun
-    $cultureNames = Get-ImmediateNames (Join-Path $cultureRoot 'burn.d')
-    Check 'WIN-02 culture keeps invariant decimal filename' ($cultureNames.Count -eq 1 -and $cultureNames[0].Contains('_001.236_'))
+    # Mutable burn state is a single TSV. Existing marker trees remain ignored
+    # during append, trim, and healing.
+    $coexistRoot = Join-Path $stateRoot 'coexist'
+    $coexistConfig = New-StateConfig 'win02-coexist' $coexistRoot 'burn' $false
+    $coexistMarker = Join-Path $coexistRoot 'burn.d'
+    [void][IO.Directory]::CreateDirectory($coexistMarker)
+    $coexistSentinel = Join-Path $coexistMarker 'legacy-marker'
+    Write-Utf8 $coexistSentinel 'keep'
+    $coexistBefore = Snapshot-StateTree $coexistMarker
+    Write-Utf8 (Join-Path $coexistRoot 'burn.tsv') "999900`t010.000`t1015900`n"
+    $coexistPayload = Clone-Object $statePayload
+    $coexistPayload.rate_limits.five_hour.used_percentage = '1.2355'
+    $coexistRun = Invoke-Statusline (Json $coexistPayload) $coexistConfig $stateEnvWrite '' 10000
+    Check-Run 'WIN-02 mutable TSV coexistence' $coexistRun
+    $coexistRows = [IO.File]::ReadAllLines((Join-Path $coexistRoot 'burn.tsv'), $StrictUtf8)
+    Check 'WIN-02 mutable TSV canonical culture row' ($coexistRows -contains "1000000`t1.236`t1015900")
+    Check 'WIN-02 mutable TSV leaves marker tree byte exact' ((Snapshot-StateTree $coexistMarker) -ceq $coexistBefore)
 
     # State path positive controls plus ADS, junction, symlink, UNC, and device
     # negatives. Required NTFS capabilities are failures, never BLOCKED.
@@ -2313,13 +2204,16 @@ fi
     $pathPositive = New-StateConfig 'win02-path-positive' (Join-Path $pathRoot 'positive') 'burn' $false
     $pathPositiveRun = Invoke-Statusline (Json $statePayload) $pathPositive $stateEnvWrite '' 10000
     Check-Run 'WIN-02 state path positive control' $pathPositiveRun
+    $positivePath = Join-Path $pathRoot 'positive\burn.tsv'
+    Check 'WIN-02 state path positive control reaches write' ([IO.File]::Exists($positivePath))
     $positiveStore = Join-Path $pathRoot 'positive\burn.d'
-    Check 'WIN-02 state path positive control reaches write' ([IO.Directory]::Exists($positiveStore))
-    $positiveSentinel = Join-Path $positiveStore 'b_253402300799_000001000000_099.000_0000'
-    [IO.File]::WriteAllBytes($positiveSentinel, [byte[]]@())
+    [void][IO.Directory]::CreateDirectory($positiveStore)
+    $positiveSentinel = Join-Path $positiveStore 'legacy-marker'
+    Write-Utf8 $positiveSentinel 'keep'
+    $positiveBefore = Snapshot-StateTree $positiveStore
     $pathPositiveGc = Invoke-Statusline (Json $statePayload) $pathPositive $stateEnvWrite '' 10000
     Check-Run 'WIN-02 state path positive GC control' $pathPositiveGc
-    Check 'WIN-02 state path positive control reaches exact GC' (-not [IO.File]::Exists($positiveSentinel))
+    Check 'WIN-02 state path positive marker tree remains untouched' ((Snapshot-StateTree $positiveStore) -ceq $positiveBefore)
 
     $adsCarrier = Join-Path $pathRoot 'ads-carrier'
     [void][IO.Directory]::CreateDirectory($pathRoot)
@@ -2342,14 +2236,13 @@ fi
     $junctionReady = $mkJunction.ExitCode -eq 0 -and [IO.Directory]::Exists($junctionLink)
     Check 'WIN-02 NTFS junction capability available' $junctionReady
     if ($junctionReady) {
-        $junctionTargetStore = Join-Path $junctionTarget 'burn.d'
-        [void][IO.Directory]::CreateDirectory($junctionTargetStore)
-        $junctionSentinel = Join-Path $junctionTargetStore 'b_253402300799_000001000000_099.000_0000'
-        [IO.File]::WriteAllBytes($junctionSentinel, [byte[]]@())
+        $junctionTargetPath = Join-Path $junctionTarget 'burn.tsv'
+        Write-Utf8 $junctionTargetPath "1000000`t010.000`t1015900`n"
+        $junctionBefore = Snapshot-File $junctionTargetPath
         $junctionConfig = New-Config 'win02-path-junction' @('VL_SEGMENTS=burn','VL_CLOCK=off',("BURN_FILE='" + (Forward-Path (Join-Path $junctionLink 'burn.tsv')) + "'"))
         $junctionRun = Invoke-Statusline (Json $statePayload) $junctionConfig $stateEnvWrite '' 10000
         Check-Run 'WIN-02 junction state rejection' $junctionRun
-        Check 'WIN-02 junction target receives no publication or GC' ([IO.File]::Exists($junctionSentinel) -and (Get-ImmediateNames $junctionTargetStore).Count -eq 1)
+        Check 'WIN-02 junction target receives no append or trim' ((Snapshot-File $junctionTargetPath) -ceq $junctionBefore)
     }
 
     $symlinkTarget = Join-Path $pathRoot 'symlink-target'
@@ -2359,18 +2252,17 @@ fi
     $symlinkReady = $mkSymlink.ExitCode -eq 0 -and [IO.Directory]::Exists($symlinkLink)
     Check 'WIN-02 NTFS directory symlink capability available' $symlinkReady
     if ($symlinkReady) {
-        $symlinkTargetStore = Join-Path $symlinkTarget 'burn.d'
-        [void][IO.Directory]::CreateDirectory($symlinkTargetStore)
-        $symlinkSentinel = Join-Path $symlinkTargetStore 'b_253402300799_000001000000_099.000_0000'
-        [IO.File]::WriteAllBytes($symlinkSentinel, [byte[]]@())
+        $symlinkTargetPath = Join-Path $symlinkTarget 'burn.tsv'
+        Write-Utf8 $symlinkTargetPath "1000000`t010.000`t1015900`n"
+        $symlinkBefore = Snapshot-File $symlinkTargetPath
         $symlinkConfig = New-Config 'win02-path-symlink' @('VL_SEGMENTS=burn','VL_CLOCK=off',("BURN_FILE='" + (Forward-Path (Join-Path $symlinkLink 'burn.tsv')) + "'"))
         $symlinkRun = Invoke-Statusline (Json $statePayload) $symlinkConfig $stateEnvWrite '' 10000
         Check-Run 'WIN-02 directory symlink state rejection' $symlinkRun
-        Check 'WIN-02 directory symlink target receives no publication or GC' ([IO.File]::Exists($symlinkSentinel) -and (Get-ImmediateNames $symlinkTargetStore).Count -eq 1)
+        Check 'WIN-02 directory symlink target receives no append or trim' ((Snapshot-File $symlinkTargetPath) -ceq $symlinkBefore)
     }
 
-    $fileTarget = Join-Path $pathRoot 'legacy-target.tsv'
-    $fileLink = Join-Path $pathRoot 'legacy-link.tsv'
+    $fileTarget = Join-Path $pathRoot 'state-target.tsv'
+    $fileLink = Join-Path $pathRoot 'state-link.tsv'
     Write-Utf8 $fileTarget "1000000`t1`t1015900`n"
     $mkFileLink = Invoke-CapturedProcess $env:ComSpec ('/d /s /c "mklink ""' + $fileLink + '"" ""' + $fileTarget + '"""') '' @{} $Repo 5000
     $fileLinkReady = $mkFileLink.ExitCode -eq 0 -and [IO.File]::Exists($fileLink)
@@ -2394,7 +2286,7 @@ fi
         $uncConfig = New-Config 'win02-path-unc' @('VL_SEGMENTS=burn','VL_CLOCK=off',("BURN_FILE='" + $uncStateBase + "'"))
         $uncRun = Invoke-Statusline (Json $statePayload) $uncConfig $stateEnvWrite '' 5000
         Check-Run 'WIN-02 UNC state rejection' $uncRun
-        Check 'WIN-02 UNC state rejection is pre-I/O' (-not [IO.Directory]::Exists((Join-Path ([IO.Path]::GetDirectoryName($localStateBase)) 'burn.d')))
+        Check 'WIN-02 UNC state rejection is pre-I/O' (-not [IO.File]::Exists($localStateBase))
 
         $uncGitRoot = '\\localhost\' + $driveRoot.Substring(0,1) + '$\' + $gitRoot.Substring($driveRoot.Length)
         $uncPayload = New-Payload $uncGitRoot
@@ -2411,7 +2303,7 @@ fi
         $deviceConfig = New-Config ('win02-path-device-' + [Math]::Abs($deviceBase.GetHashCode())) @('VL_SEGMENTS=burn','VL_CLOCK=off',("BURN_FILE='" + $deviceBase + "'"))
         $deviceRun = Invoke-Statusline (Json $statePayload) $deviceConfig $stateEnvWrite '' 5000
         Check-Run 'WIN-02 device namespace state rejection' $deviceRun
-        Check 'WIN-02 device namespace creates no store' (-not [IO.Directory]::Exists((Join-Path ([IO.Path]::GetDirectoryName($localStateBase)) 'burn.d')))
+        Check 'WIN-02 device namespace creates no store' (-not [IO.File]::Exists($localStateBase))
     }
 
     $subagentRun = Invoke-Statusline '' '\\localhost\never\touch.conf' @{} '--subagent' 5000
@@ -2713,7 +2605,7 @@ fi
     $collisionConfig = New-Config 'win03-dormant-state-collision' @('VL_SEGMENTS=model','VL_CLOCK=off','VL_FLOAT=1','VL_FLOAT_SEGMENTS=model',('VL_FLOAT_FILE=' + (Quote-FromConfigure $collisionBase)),('BURN_FILE=' + (Quote-FromConfigure $collisionBase)))
     $collisionRun = Invoke-Float (Json $basePayload) $collisionConfig @{}
     Check-Run 'WIN-03 dormant state collision' $collisionRun
-    Check 'WIN-03 dormant state collision creates no float or state root' (-not [IO.File]::Exists($collisionBase) -and -not [IO.Directory]::Exists((Join-Path $collisionRoot 'burn.d')))
+    Check 'WIN-03 dormant state collision creates no float or state file' (-not [IO.File]::Exists($collisionBase))
 
     $longTarget = Join-Path $win03Root 'long.txt'
     $longSegments = 'model ' + ('x' * 4091)

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -1930,8 +1930,11 @@ fi
     Check-Run 'WIN-02 overlong record does not abort the render' $longRun
     Check 'WIN-02 overlong record leaves the read-only TSV byte exact' ((([IO.File]::ReadAllBytes($longPath)).Length) -eq $longBefore)
 
-    # Beyond the byte ceiling the reader must refuse the file rather than rewrite
-    # a truncated version of it.
+    # Beyond the byte ceiling the reader refuses to compact the file, so it is
+    # never rewritten or truncated. Sampling still appends, exactly as the Bash
+    # runtime does: measured on Windows, three mutable renders grow an oversized
+    # TSV by 87 bytes in both runtimes. The guard here is that the existing bytes
+    # survive untouched, not that the file stops growing.
     $hugeRoot = Join-Path $stateRoot 'hugetsv'
     $hugeConfig = New-StateConfig 'win02-hugetsv' $hugeRoot 'burn' $false
     $hugePath = Join-Path $hugeRoot 'burn.tsv'
@@ -1939,10 +1942,18 @@ fi
     $hugeBuilder = New-Object Text.StringBuilder
     while ($hugeBuilder.Length -le 1048576) { [void]$hugeBuilder.Append($hugeRow) }
     Write-Utf8 $hugePath $hugeBuilder.ToString()
-    $hugeBefore = ([IO.File]::ReadAllBytes($hugePath)).Length
+    $hugeOriginal = [IO.File]::ReadAllBytes($hugePath)
     $hugeRun = Invoke-Statusline (Json $statePayload) $hugeConfig $stateEnvWrite '' 30000
     Check-Run 'WIN-02 oversized TSV does not abort the render' $hugeRun
-    Check 'WIN-02 oversized TSV is refused rather than truncated' ((([IO.File]::ReadAllBytes($hugePath)).Length) -eq $hugeBefore)
+    $hugeAfter = [IO.File]::ReadAllBytes($hugePath)
+    $hugePrefixIntact = $hugeAfter.Length -ge $hugeOriginal.Length
+    if ($hugePrefixIntact) {
+        for ($i = 0; $i -lt $hugeOriginal.Length; $i++) {
+            if ($hugeAfter[$i] -ne $hugeOriginal[$i]) { $hugePrefixIntact = $false; break }
+        }
+    }
+    Check 'WIN-02 oversized TSV is never rewritten or truncated' $hugePrefixIntact
+    Check 'WIN-02 oversized TSV still accepts the appended sample' ($hugeAfter.Length -gt $hugeOriginal.Length)
 
     $overRoot = Join-Path $stateRoot 'overcap'
     $overConfig = New-StateConfig 'win02-overcap' $overRoot 'burn' $false


### PR DESCRIPTION
## Problem

`statusline.ps1` still maintained the immutable burn marker store that the Bash runtime abandoned in #59, and scanned it on every render. Stage profiling on native x64 Windows PowerShell 5.1, driven from a native parent so no MSYS fork tax is included:

```
no markers      total  743 ms   state  471.8 ms  (63.5%)   config 161.4  render 56.8  json 31.3  cwd 21.5  git 0.2
1400 markers    total 1670 ms   state 1398.7 ms  (83.7%)   everything else unchanged
```

Claude Code re-renders once per second. One function was 64–84% of the render.

## Fix

The burn store is now the same mutable TSV the Bash runtime uses. Sampling appends one canonical row; the reader dedupes same-second rows, isolates the current reset window, trims to `BURN_TRIM` and heals implausible rows in a single pass; nothing on the render path enumerates or stats `burn.d`.

Removed: `ConvertFrom-BurnName`, `Get-BurnRetention`, `Test-BurnDeleteCandidate`, `Publish-BurnState`, `Read-LegacyState`, and the burn arm of the shared snapshot and GC helpers. The limit stores keep their compact directory design because the Bash runtime still uses exactly that. An existing `burn.d` tree is ignored and never read, written, renamed or deleted.

Same fixture, after:

```
1400 markers    total  745 ms   state  474.0 ms
```

`state` matches the empty-marker baseline, confirming the store is no longer touched.

## Three defects that only running it exposed

None of these were visible to static review.

**The script did not parse.** `$builder.Append(Format-BurnPct ([int]$row.Pct))` passes a function invocation in command syntax to a .NET method call. Now parenthesised as an expression.

**Appends never happened once the file existed.** Two conditions had the shape `if (Test-StateObjectExists $Path -and -not (Test-StateRegularFile $Path))`. PowerShell binds `-and`, `-not` and the parenthesised call as *arguments to the command*, so the condition collapsed to the function's return value. A fresh install would write exactly one row and never another. Single-render output parity still looked correct, because the estimate came from rows already on disk — byte parity of one render does not cover the write path.

**Concurrent appends dropped samples.** Measured with 16 concurrent renderers over 20 rounds:

| append implementation | rows lost of 320 |
|---|---|
| `[IO.File]::AppendAllText` (as ported) | 5 |
| `FileMode.Append` + `FileShare.ReadWrite` | 62 |
| exclusive open + bounded retry | **0** |
| `statusline.sh` (O_APPEND), for reference | 0 |

Widening the share mode makes it worse: .NET's `FileMode.Append` seeks to the end once at open rather than per write, so simultaneous writers share an offset and overwrite each other. The exclusive open is what keeps whole rows intact; what was missing was a bounded retry so a writer that finds the handle held waits its turn instead of discarding the row.

## Verification

Native x64 Windows, PowerShell 5.1.26100.8875. Fixture: 1400 markers and 1400 TSV rows, built from the real user config with the theme graph staged and a real cloned repository as the working directory.

| Check | Result |
|---|---|
| Output vs `statusline.sh` | byte-identical, both exit 0, stderr empty |
| `CORALLINE_NO_SAMPLE=1` | state tree unchanged in content and mtime |
| `burn.d` after a mutable render | byte-exact |
| Mutable render | appends exactly one row |
| 16 concurrent renderers × 20 rounds | 320 of 320 rows survive |
| Render cost | 1670 ms → 745 ms |

## Tests

`test/test-statusline-ps1.ps1` replaces the marker-store assertions with mutable-TSV equivalents and restores coverage the port had dropped: retained rows keep sample order, no record is written partially, no `.burn.tmp` or `.burn.bak` residue survives a rewrite, a NUL byte inside a record neither aborts the render nor rewrites history, an overlong record is refused without consuming the file, and a TSV beyond the byte ceiling is refused rather than truncated.

## Known gaps

That suite still cannot execute. It aborts during setup on `main` as well, because its Bash splice markers reference `state_scan`, `state_prepare` and `_PUB_BURN_PATH`, removed in #59. Repairing the harness is separate work.

Concurrency is covered by the direct measurement above rather than by a suite case. There is no existing cohort helper in that file to follow, and an unexecutable concurrency test written blind is worth less than the numbers.
