### PR TITLE
perf: cache git status/paths, resolved binaries, and harden stdin decoding

### DIFF
--- a/statusline.ps1
+++ b/statusline.ps1
@@ -2678,9 +2678,18 @@ function Get-ApplicationPath([string]$Name) {
     }
     if ($script:AppPathDiskCache.ContainsKey($Name)) {
         $entry = $script:AppPathDiskCache[$Name]
-        if (-not [string]::IsNullOrEmpty($sig) -and [string]$entry.Sig -ceq $sig) {
-            $AppCache[$Name] = [string]$entry.Value
-            return [string]$entry.Value
+        $cachedValue = [string]$entry.Value
+        # A matching PATH signature only proves PATH itself is unchanged, not
+        # that the resolved file is still there (it can be uninstalled while
+        # something else earlier/later on PATH stays put) - so a non-empty
+        # cached path is re-verified with a cheap File.Exists before being
+        # trusted. Empty ("not found") results are never persisted below, so
+        # there is no negative-cache case to honor here either: installing
+        # the tool later without touching PATH must be observed on the very
+        # next render, not hidden behind a stale miss.
+        if (-not [string]::IsNullOrEmpty($sig) -and [string]$entry.Sig -ceq $sig -and -not [string]::IsNullOrEmpty($cachedValue) -and [IO.File]::Exists($cachedValue)) {
+            $AppCache[$Name] = $cachedValue
+            return $cachedValue
         }
     }
     $path = ''
@@ -2689,7 +2698,7 @@ function Get-ApplicationPath([string]$Name) {
         if ($null -ne $cmd) { $path = [string]$cmd.Source }
     } catch { $path = '' }
     $AppCache[$Name] = $path
-    if (-not [string]::IsNullOrEmpty($sig)) {
+    if (-not [string]::IsNullOrEmpty($sig) -and -not [string]::IsNullOrEmpty($path)) {
         $script:AppPathDiskCache[$Name] = [pscustomobject]@{ Sig = $sig; Value = $path }
         Write-AppPathCacheFile $AppPathCacheFile $script:AppPathDiskCache
     }
@@ -2778,37 +2787,63 @@ function Resolve-GitRelativePath([string]$BaseDir, [string]$Raw) {
     } catch { return $null }
 }
 
-function Resolve-GitCommonDir([string]$GitDir) {
+function Resolve-GitCommonDir([string]$Cwd, [string]$GitDir) {
+    $envCommonDir = [string]$env:GIT_COMMON_DIR
+    if (-not [string]::IsNullOrEmpty($envCommonDir)) {
+        # An explicit override is resolved against the effective working
+        # directory, not against GitDir. That mirrors GIT_DIR/GIT_WORK_TREE
+        # below and is distinct from the on-disk commondir file, whose
+        # relative entries are always relative to the .git directory that
+        # contains it. Git does not fall back to that file when the override
+        # is present but wrong, so an override that cannot resolve to a real
+        # directory is reported as invalid ($null) rather than silently
+        # ignored - the caller is expected to treat that as "not found".
+        $resolvedEnv = Resolve-GitRelativePath $Cwd $envCommonDir
+        if ($null -ne $resolvedEnv -and [IO.Directory]::Exists($resolvedEnv)) { return $resolvedEnv }
+        return $null
+    }
     $commonDir = $GitDir
     $commonRaw = Read-GitPointerFile ([IO.Path]::Combine($GitDir, 'commondir'))
     if (-not [string]::IsNullOrEmpty($commonRaw)) {
         $resolved = Resolve-GitRelativePath $GitDir $commonRaw
         if ($null -ne $resolved -and [IO.Directory]::Exists($resolved)) { $commonDir = $resolved }
     }
-    $envCommonDir = [string]$env:GIT_COMMON_DIR
-    if (-not [string]::IsNullOrEmpty($envCommonDir)) {
-        $resolvedEnv = Resolve-GitRelativePath $GitDir $envCommonDir
-        if ($null -ne $resolvedEnv -and [IO.Directory]::Exists($resolvedEnv)) { $commonDir = $resolvedEnv }
-    }
     return $commonDir
 }
 
+function Resolve-GitIndexFile([string]$Cwd, [string]$GitDir) {
+    $default = [IO.Path]::Combine($GitDir, 'index')
+    $envIndexFile = [string]$env:GIT_INDEX_FILE
+    if ([string]::IsNullOrEmpty($envIndexFile)) { return $default }
+    # Unlike GIT_DIR/GIT_COMMON_DIR, a missing index file is not an error
+    # (a fresh repo has no index yet), so this only substitutes the override
+    # when it resolves at all; it does not require the file to already exist.
+    $resolved = Resolve-GitRelativePath $Cwd $envIndexFile
+    if ($null -eq $resolved) { return $default }
+    return $resolved
+}
+
 function Find-GitPaths([string]$Cwd) {
-    $none = [pscustomobject]@{ Found = $false; GitDir = ''; CommonDir = ''; WorktreeRoot = '' }
+    $none = [pscustomobject]@{ Found = $false; GitDir = ''; CommonDir = ''; WorktreeRoot = ''; IndexFile = '' }
     if ([string]::IsNullOrEmpty($Cwd)) { return $none }
 
     $envGitDir = [string]$env:GIT_DIR
     if (-not [string]::IsNullOrEmpty($envGitDir)) {
+        # A non-empty GIT_DIR is authoritative even when it is invalid: Git
+        # does not fall back to upward repository discovery in that case, so
+        # neither do we - an unresolvable override must report "not found",
+        # not silently surface a parent repository Git itself would reject.
         $resolved = Resolve-GitRelativePath $Cwd $envGitDir
-        if ($null -ne $resolved -and [IO.Directory]::Exists($resolved)) {
-            $worktreeRoot = $Cwd
-            $envWorkTree = [string]$env:GIT_WORK_TREE
-            if (-not [string]::IsNullOrEmpty($envWorkTree)) {
-                $resolvedWt = Resolve-GitRelativePath $Cwd $envWorkTree
-                if ($null -ne $resolvedWt) { $worktreeRoot = $resolvedWt }
-            }
-            return [pscustomobject]@{ Found = $true; GitDir = $resolved; CommonDir = (Resolve-GitCommonDir $resolved); WorktreeRoot = $worktreeRoot }
+        if ($null -eq $resolved -or -not [IO.Directory]::Exists($resolved)) { return $none }
+        $commonDir = Resolve-GitCommonDir $Cwd $resolved
+        if ($null -eq $commonDir) { return $none }
+        $worktreeRoot = $Cwd
+        $envWorkTree = [string]$env:GIT_WORK_TREE
+        if (-not [string]::IsNullOrEmpty($envWorkTree)) {
+            $resolvedWt = Resolve-GitRelativePath $Cwd $envWorkTree
+            if ($null -ne $resolvedWt) { $worktreeRoot = $resolvedWt }
         }
+        return [pscustomobject]@{ Found = $true; GitDir = $resolved; CommonDir = $commonDir; WorktreeRoot = $worktreeRoot; IndexFile = (Resolve-GitIndexFile $Cwd $resolved) }
     }
 
     $dir = $null
@@ -2825,14 +2860,18 @@ function Find-GitPaths([string]$Cwd) {
         $isDir = [IO.Directory]::Exists($candidate)
         $isFile = (-not $isDir) -and [IO.File]::Exists($candidate)
         if ($isDir) {
-            return [pscustomobject]@{ Found = $true; GitDir = $candidate; CommonDir = (Resolve-GitCommonDir $candidate); WorktreeRoot = $dir.FullName }
+            $commonDir = Resolve-GitCommonDir $Cwd $candidate
+            if ($null -eq $commonDir) { return $none }
+            return [pscustomobject]@{ Found = $true; GitDir = $candidate; CommonDir = $commonDir; WorktreeRoot = $dir.FullName; IndexFile = (Resolve-GitIndexFile $Cwd $candidate) }
         }
         if ($isFile) {
             $pointerRaw = Read-GitPointerFile $candidate
             if ($null -ne $pointerRaw -and $pointerRaw.StartsWith('gitdir: ', [StringComparison]::Ordinal)) {
                 $target = Resolve-GitRelativePath $dir.FullName $pointerRaw.Substring(8)
                 if ($null -ne $target -and [IO.Directory]::Exists($target)) {
-                    return [pscustomobject]@{ Found = $true; GitDir = $target; CommonDir = (Resolve-GitCommonDir $target); WorktreeRoot = $dir.FullName }
+                    $commonDir = Resolve-GitCommonDir $Cwd $target
+                    if ($null -eq $commonDir) { return $none }
+                    return [pscustomobject]@{ Found = $true; GitDir = $target; CommonDir = $commonDir; WorktreeRoot = $dir.FullName; IndexFile = (Resolve-GitIndexFile $Cwd $target) }
                 }
             }
             return $none
@@ -2903,18 +2942,28 @@ function Get-GitCacheSignatureText([object]$Paths, [object]$Head) {
         $refTicks = Get-FileTicksSafe ([IO.Path]::Combine($Paths.CommonDir, ($Head.RefName -replace '/', '\')))
     }
     $packedTicks = Get-FileTicksSafe ([IO.Path]::Combine($Paths.CommonDir, 'packed-refs'))
-    $indexTicks = Get-FileTicksSafe ([IO.Path]::Combine($Paths.GitDir, 'index'))
+    $indexTicks = Get-FileTicksSafe $Paths.IndexFile
     return ([string]$headTicks) + '|' + ([string]$refTicks) + '|' + ([string]$packedTicks) + '|' + ([string]$indexTicks)
 }
 
-function Get-GitCacheFilePath([string]$CommonDir) {
-    if ([string]::IsNullOrEmpty($CommonDir)) { return $null }
-    $norm = $CommonDir.Replace('/', '\').TrimEnd('\').ToLowerInvariant()
+function Get-GitCacheFilePath([object]$Paths) {
+    if ($null -eq $Paths -or [string]::IsNullOrEmpty($Paths.CommonDir)) { return $null }
+    # Two sessions can share GIT_DIR/index while pointing GIT_WORK_TREE at
+    # different worktrees (or vice versa): CommonDir alone collapses them
+    # onto the same cache file, letting one worktree's dirty state leak into
+    # the other's render. GitDir and WorktreeRoot are folded into the key
+    # alongside CommonDir so each distinct combination gets its own entry;
+    # the index path already varies with GIT_INDEX_FILE and feeds the
+    # signature text above, so it does not need to be part of the key too.
+    $normCommon = $Paths.CommonDir.Replace('/', '\').TrimEnd('\').ToLowerInvariant()
+    $normGitDir = ([string]$Paths.GitDir).Replace('/', '\').TrimEnd('\').ToLowerInvariant()
+    $normWorktree = ([string]$Paths.WorktreeRoot).Replace('/', '\').TrimEnd('\').ToLowerInvariant()
+    $key = $normCommon + '|' + $normGitDir + '|' + $normWorktree
     $hex = ''
     try {
         $sha = [System.Security.Cryptography.SHA256]::Create()
         try {
-            $bytes = $sha.ComputeHash($Utf8NoBom.GetBytes($norm))
+            $bytes = $sha.ComputeHash($Utf8NoBom.GetBytes($key))
             $sb = New-Object Text.StringBuilder
             foreach ($b in $bytes) { [void]$sb.Append($b.ToString('x2')) }
             $hex = $sb.ToString()
@@ -2962,9 +3011,10 @@ function Get-GitCacheMaxAgeTicks {
     return $script:GitCacheMaxAgeTicksCache
 }
 
-# Every distinct repo ever rendered gets its own cache file (named by a hash
-# of its common-dir) that would otherwise live forever, so a deleted, moved,
-# or simply not-revisited-in-months repo's entry accumulates indefinitely.
+# Every distinct repo/worktree combination ever rendered gets its own cache
+# file (named by a hash of its common-dir, git-dir, and worktree root) that
+# would otherwise live forever, so a deleted, moved, or simply
+# not-revisited-in-months repo's entry accumulates indefinitely.
 # This sweep deletes any cache file not refreshed within
 # CORALLINE_GIT_CACHE_MAX_AGE_DAYS (default 30) - age alone is sufficient
 # (no need to verify the source repo still exists): a still-active repo gets
@@ -2994,6 +3044,15 @@ function Invoke-GitCacheSweep {
         foreach ($file in [IO.Directory]::EnumerateFiles($GitCacheDir, '*.tsv')) {
             $seen++
             if ($seen -gt 8192 -or $removed -ge 2048) { break }
+            # CORALLINE_GITCACHE_DIR can be pointed at a pre-existing,
+            # possibly shared directory, so '*.tsv' alone is not a safe
+            # deletion filter - it would let a cache miss age out and delete
+            # some unrelated old *.tsv file that happens to live there too.
+            # Only basenames coralline itself writes (a 64-hex-digit SHA-256
+            # cache key) are eligible; anything else is left untouched no
+            # matter how old it is.
+            $baseName = [IO.Path]::GetFileName($file)
+            if ($baseName -notmatch '^[0-9a-f]{64}\.tsv$') { continue }
             if (-not (Test-StateRegularFile $file)) { continue }
             try {
                 if (($now.Ticks - [IO.File]::GetLastWriteTimeUtc($file).Ticks) -gt $maxAgeTicks) {
@@ -3020,15 +3079,18 @@ function Get-GitInfoCached([string]$Cwd) {
     $result.Project = Get-GitProjectNameNative $paths
 
     $sigText = Get-GitCacheSignatureText $paths $head
-    $cachePath = Get-GitCacheFilePath $paths.CommonDir
-    # A signature match means the exact tracked-file state (HEAD/ref/index/
-    # packed-refs) that produced the cached Marks/Ab/Dirty is still the
-    # current state, so that data is exact, not merely "recent" - the TTL
-    # below only controls how eagerly we re-check for the one thing the
-    # signature can't see (a new/removed untracked file). A cache hit is
-    # therefore always applied first; a stale-by-TTL refresh attempt that
-    # then fails (git.exe missing, transient error) must never blank out
-    # already-known-good data.
+    $cachePath = Get-GitCacheFilePath $paths
+    # A signature match means HEAD/ref/index/packed-refs are byte-for-byte
+    # what produced the cached Marks/Ab/Dirty, but that is not the complete
+    # set of things that can change dirty state: editing a tracked file
+    # without staging it changes neither the index nor any of those files,
+    # so the signature cannot see it. The TTL below is therefore the real
+    # staleness bound for every worktree-only change the signature misses -
+    # untracked files AND unstaged edits to tracked ones - not merely a
+    # nice-to-have for new/removed untracked files. A cache hit is always
+    # applied first; a stale-by-TTL refresh attempt that then fails (git.exe
+    # missing, transient error) must never blank out already-known-good data,
+    # so it degrades to trusting the last good result past its TTL instead.
     $sigMatches = $false
     if (-not [string]::IsNullOrEmpty($cachePath)) {
         $cached = Read-GitStatusCache $cachePath

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -15,27 +15,47 @@ $ErrorActionPreference = 'SilentlyContinue'
 $ProgressPreference = 'SilentlyContinue'
 
 $StrictUtf8 = New-Object System.Text.UTF8Encoding($false, $true)
+$LenientUtf8 = New-Object System.Text.UTF8Encoding($false, $false)
 $Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
 $InputStream = [Console]::OpenStandardInput()
-if ($SubagentMode) {
-    # Read one byte beyond the limit before allocating a decoded string. This
-    # distinguishes an exact-cap stream from a longer one without unbounded I/O.
-    $inputCap = 4194304
-    $inputBytes = New-Object byte[] ($inputCap + 1)
+
+# Read one byte beyond the limit before allocating a decoded string. This
+# distinguishes an exact-cap stream from a longer one without unbounded I/O.
+# Both modes capture raw bytes up front (rather than decoding straight off
+# the stream) specifically so a decode failure below has something left to
+# retry against - stdin is a non-seekable console handle, so once the bytes
+# are gone there is no re-reading it.
+$inputCap = 4194304
+$inputBytes = New-Object byte[] ($inputCap + 1)
+$inputLength = 0
+try {
+    while ($inputLength -lt $inputBytes.Length) {
+        $read = $InputStream.Read($inputBytes, $inputLength, $inputBytes.Length - $inputLength)
+        if ($read -le 0) { break }
+        $inputLength += $read
+    }
+} catch { $inputLength = 0 }
+if ($inputLength -gt $inputCap) {
+    if ($SubagentMode) { [Environment]::Exit(0) }
     $inputLength = 0
-    try {
-        while ($inputLength -lt $inputBytes.Length) {
-            $read = $InputStream.Read($inputBytes, $inputLength, $inputBytes.Length - $inputLength)
-            if ($read -le 0) { break }
-            $inputLength += $read
-        }
-        if ($inputLength -gt $inputCap) { [Environment]::Exit(0) }
-        $rawInput = $StrictUtf8.GetString($inputBytes, 0, $inputLength)
-    } catch { [Environment]::Exit(0) }
-} else {
-    $InputReader = New-Object System.IO.StreamReader($InputStream, $StrictUtf8, $false, 4096, $false)
-    try { $rawInput = $InputReader.ReadToEnd() } catch { $rawInput = '' }
-    $InputReader.Dispose()
+}
+
+# A BOM is valid UTF-8 - it decodes without throwing straight into a literal
+# U+FEFF character, which then silently breaks JSON parsing further down
+# rather than raising anything here. Strip it from the bytes up front so
+# neither decode path below has to special-case it separately.
+$inputStart = 0
+if ($inputLength -ge 3 -and $inputBytes[0] -eq 0xEF -and $inputBytes[1] -eq 0xBB -and $inputBytes[2] -eq 0xBF) { $inputStart = 3 }
+
+# Genuinely invalid byte sequences previously meant an empty $rawInput and a
+# near-blank render (or a silent exit in --subagent mode). Falling back to a
+# non-throwing decode of the same captured bytes recovers a usable string
+# instead of losing the whole render to one encoding hiccup.
+try {
+    $rawInput = $StrictUtf8.GetString($inputBytes, $inputStart, $inputLength - $inputStart)
+} catch {
+    try { $rawInput = $LenientUtf8.GetString($inputBytes, $inputStart, $inputLength - $inputStart) }
+    catch { $rawInput = '' }
 }
 
 $OutputStream = [Console]::OpenStandardOutput()
@@ -76,6 +96,14 @@ if ([string]::IsNullOrEmpty($DefaultRl5File)) {
 $DefaultRl7File = [string]$env:CORALLINE_RL7D_FILE
 if ([string]::IsNullOrEmpty($DefaultRl7File)) {
     $DefaultRl7File = [System.IO.Path]::Combine($HomeDir, '.claude\coralline\limit-7d.tsv')
+}
+$AppPathCacheFile = [string]$env:CORALLINE_APPPATH_CACHE
+if ([string]::IsNullOrEmpty($AppPathCacheFile)) {
+    $AppPathCacheFile = [System.IO.Path]::Combine($HomeDir, '.claude\coralline\apppath-cache.tsv')
+}
+$GitCacheDir = [string]$env:CORALLINE_GITCACHE_DIR
+if ([string]::IsNullOrEmpty($GitCacheDir)) {
+    $GitCacheDir = [System.IO.Path]::Combine($HomeDir, '.claude\coralline\git-cache')
 }
 
 $Defaults = [ordered]@{
@@ -2534,15 +2562,137 @@ function Get-DisplayPath([string]$Path) {
     return $short
 }
 
+function Get-PathEnvSignature {
+    if ($null -ne $script:PathEnvSignature) { return $script:PathEnvSignature }
+    $sig = ''
+    try {
+        $sha = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $bytes = $sha.ComputeHash($Utf8NoBom.GetBytes([string]$env:PATH))
+            $sb = New-Object System.Text.StringBuilder
+            foreach ($b in $bytes) { [void]$sb.Append($b.ToString('x2')) }
+            $sig = $sb.ToString()
+        } finally { $sha.Dispose() }
+    } catch { $sig = '' }
+    $script:PathEnvSignature = $sig
+    return $sig
+}
+
+# Atomic single-writer-wins temp+Replace, mirroring Write-BurnState. Concurrent
+# renders never see a torn read; a losing writer's update is simply discarded.
+function Write-AtomicStateFile([string]$Path, [string]$Text, [string]$TmpTag) {
+    $parent = $null
+    try { $parent = [System.IO.Path]::GetDirectoryName($Path) } catch { return }
+    if ([string]::IsNullOrEmpty($parent) -or -not (Test-NoReparseComponents $parent)) { return }
+    try { if (-not [IO.Directory]::Exists($parent)) { [void][IO.Directory]::CreateDirectory($parent) } } catch { return }
+    if (-not [IO.Directory]::Exists($parent)) { return }
+    if ((Test-StateObjectExists $Path) -and -not (Test-StateRegularFile $Path)) { return }
+    $temp = ''
+    $backup = ''
+    try {
+        for ($attempt = 0; $attempt -lt 8; $attempt++) {
+            $candidate = [IO.Path]::Combine($parent, ('.' + $TmpTag + '.tmp.' + [string]$PID + '.' + [guid]::NewGuid().ToString('N')))
+            if ($candidate.Length -gt 4096) { return }
+            $stream = $null
+            try {
+                $stream = New-Object IO.FileStream($candidate, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None, 4096, [IO.FileOptions]::WriteThrough)
+                $bytes = $Utf8NoBom.GetBytes($Text)
+                if ($bytes.Length -gt 0) { $stream.Write($bytes, 0, $bytes.Length) }
+                $stream.Flush($true)
+                $stream.Dispose()
+                $stream = $null
+                $temp = $candidate
+                break
+            } catch [IO.IOException] {
+                if ($null -ne $stream) { $stream.Dispose() }
+            } catch {
+                if ($null -ne $stream) { $stream.Dispose() }
+                return
+            }
+        }
+        if ([string]::IsNullOrEmpty($temp)) { return }
+        if (Test-StateObjectExists $Path) {
+            if (-not (Test-StateRegularFile $Path)) { return }
+            for ($attempt = 0; $attempt -lt 8; $attempt++) {
+                $backup = [IO.Path]::Combine($parent, ('.' + $TmpTag + '.bak.' + [string]$PID + '.' + [guid]::NewGuid().ToString('N')))
+                if ($backup.Length -gt 4096) { $backup = ''; return }
+                if (-not (Test-StateObjectExists $backup)) { break }
+                $backup = ''
+            }
+            if ([string]::IsNullOrEmpty($backup)) { return }
+            [IO.File]::Replace($temp, $Path, $backup)
+            if (Test-StateRegularFile $backup) { [IO.File]::Delete($backup); $backup = '' }
+            elseif (-not (Test-StateObjectExists $backup)) { $backup = '' }
+        } else {
+            [IO.File]::Move($temp, $Path)
+        }
+        $temp = ''
+    } catch { }
+    finally {
+        foreach ($leftover in @($temp, $backup)) {
+            if (-not [string]::IsNullOrEmpty($leftover)) {
+                try { if (Test-StateRegularFile $leftover) { [IO.File]::Delete($leftover) } } catch { }
+            }
+        }
+    }
+}
+
 $AppCache = @{}
+$script:AppPathDiskCache = @{}
+$script:AppPathDiskCacheLoaded = $false
+
+function Read-AppPathCacheFile([string]$Path) {
+    $map = @{}
+    $text = Read-StrictUtf8File $Path
+    if ($null -eq $text) { return $map }
+    foreach ($line in [regex]::Split($text, "`r`n|`n|`r")) {
+        if ([string]::IsNullOrEmpty($line)) { continue }
+        $fields = $line.Split("`t")
+        if ($fields.Length -ne 3) { continue }
+        $map[$fields[0]] = [pscustomobject]@{ Sig = $fields[1]; Value = $fields[2] }
+    }
+    return $map
+}
+
+function Write-AppPathCacheFile([string]$Path, [hashtable]$Map) {
+    $builder = New-Object Text.StringBuilder
+    foreach ($key in $Map.Keys) {
+        $entry = $Map[$key]
+        if ($key -match '[\t\r\n]' -or [string]$entry.Sig -match '[\t\r\n]' -or [string]$entry.Value -match '[\t\r\n]') { continue }
+        [void]$builder.Append($key).Append("`t").Append([string]$entry.Sig).Append("`t").Append([string]$entry.Value).Append("`n")
+    }
+    Write-AtomicStateFile $Path ($builder.ToString()) 'apppath'
+}
+
+# Resolving git.exe (or node/python3 when VL_RUNTIME_PROBE=1) via Get-Command
+# walks every PATH directory on the filesystem. That cost previously repeated
+# on every single render, since $AppCache only lives for one process. Caching
+# the resolution keyed by a hash of the live PATH string means an unchanged
+# PATH (the overwhelming common case) costs one small file read instead.
 function Get-ApplicationPath([string]$Name) {
     if ($AppCache.ContainsKey($Name)) { return [string]$AppCache[$Name] }
+    $sig = Get-PathEnvSignature
+    if (-not $script:AppPathDiskCacheLoaded) {
+        $script:AppPathDiskCache = Read-AppPathCacheFile $AppPathCacheFile
+        $script:AppPathDiskCacheLoaded = $true
+    }
+    if ($script:AppPathDiskCache.ContainsKey($Name)) {
+        $entry = $script:AppPathDiskCache[$Name]
+        if (-not [string]::IsNullOrEmpty($sig) -and [string]$entry.Sig -ceq $sig) {
+            $AppCache[$Name] = [string]$entry.Value
+            return [string]$entry.Value
+        }
+    }
     $path = ''
     try {
         $cmd = Get-Command -Name $Name -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
         if ($null -ne $cmd) { $path = [string]$cmd.Source }
     } catch { $path = '' }
     $AppCache[$Name] = $path
+    if (-not [string]::IsNullOrEmpty($sig)) {
+        $script:AppPathDiskCache[$Name] = [pscustomobject]@{ Sig = $sig; Value = $path }
+        Write-AppPathCacheFile $AppPathCacheFile $script:AppPathDiskCache
+    }
     return $path
 }
 
@@ -2593,39 +2743,320 @@ function Get-GitState([string]$Cwd) {
     return $state
 }
 
-function Get-GitRoot([string]$Cwd) {
-    if ([string]::IsNullOrEmpty($Cwd)) { return '' }
-    $git = Get-ApplicationPath 'git'
-    if ([string]::IsNullOrEmpty($git)) { return '' }
-    $root = ''
-    try {
-        $LASTEXITCODE = 0
-        $result = @(& $git -C $Cwd rev-parse --path-format=absolute --git-common-dir 2>$null)
-        if ($LASTEXITCODE -eq 0 -and $result.Count -gt 0) { $root = [string]$result[0] }
-        if ([string]::IsNullOrEmpty($root)) {
-            $LASTEXITCODE = 0
-            $result = @(& $git -C $Cwd rev-parse --show-toplevel 2>$null)
-            if ($LASTEXITCODE -ne 0 -or $result.Count -eq 0) { return '' }
-            $root = [string]$result[0]
-        }
-    } catch { return '' }
-    $root = (Remove-ControlChars $root).Replace('\', '/').TrimEnd('/')
-    if ($root.EndsWith('/.git', [System.StringComparison]::OrdinalIgnoreCase)) { $root = $root.Substring(0, $root.Length - 5) }
-    $parts = $root.Split(@('/'), [System.StringSplitOptions]::RemoveEmptyEntries)
-    if ($parts.Length -eq 0) { return '' }
-    return $parts[$parts.Length - 1]
+# --- Pure-.NET .git discovery (no git.exe) -------------------------------
+# Branch name, stash count, and the project folder name are all derivable by
+# reading git's own plumbing files directly, so they never need to fork
+# git.exe. Only dirty-state/ahead-behind (Get-GitState above) still shells
+# out, because faithfully reproducing git's own status computation (rename
+# detection, .gitignore, sparse-checkout, submodules...) is not something to
+# reimplement here; that call is instead cached below.
+
+function Read-GitPointerFile([string]$Path) {
+    # commondir/HEAD-target pointer files are absent far more often than
+    # present (plain non-worktree repos never have a commondir file at all).
+    # File.Exists() is a cheap boolean probe; routing the common "absent"
+    # case through GetAttributes/ReadAllBytes instead would mean paying a
+    # .NET exception unwind on every single render for something that isn't
+    # an error at all, just the normal shape of most repos.
+    if (-not [IO.File]::Exists($Path)) { return $null }
+    $text = Read-StrictUtf8File $Path
+    if ($null -eq $text) { return $null }
+    $line = ([regex]::Split($text, "`r`n|`n|`r"))[0]
+    if ($null -eq $line) { return $null }
+    $line = $line.TrimEnd()
+    if ($line.Length -eq 0) { return $null }
+    return $line
 }
 
-function Get-StashCount([string]$Cwd) {
-    if ([string]::IsNullOrEmpty($Cwd)) { return 0 }
-    $git = Get-ApplicationPath 'git'
-    if ([string]::IsNullOrEmpty($git)) { return 0 }
+function Resolve-GitRelativePath([string]$BaseDir, [string]$Raw) {
+    if ([string]::IsNullOrEmpty($Raw)) { return $null }
+    $p = $Raw.Trim()
+    if ($p.Length -eq 0 -or $p.Length -gt 4096) { return $null }
     try {
-        $LASTEXITCODE = 0
-        $result = @(& $git -C $Cwd rev-list --walk-reflogs --count refs/stash 2>$null)
-        if ($LASTEXITCODE -ne 0 -or $result.Count -eq 0) { return 0 }
-        return Get-BoundedInt ([string]$result[0]) 0 0 1000000
-    } catch { return 0 }
+        if (-not [IO.Path]::IsPathRooted($p)) { $p = [IO.Path]::Combine($BaseDir, $p) }
+        return [IO.Path]::GetFullPath($p)
+    } catch { return $null }
+}
+
+function Resolve-GitCommonDir([string]$GitDir) {
+    $commonDir = $GitDir
+    $commonRaw = Read-GitPointerFile ([IO.Path]::Combine($GitDir, 'commondir'))
+    if (-not [string]::IsNullOrEmpty($commonRaw)) {
+        $resolved = Resolve-GitRelativePath $GitDir $commonRaw
+        if ($null -ne $resolved -and [IO.Directory]::Exists($resolved)) { $commonDir = $resolved }
+    }
+    $envCommonDir = [string]$env:GIT_COMMON_DIR
+    if (-not [string]::IsNullOrEmpty($envCommonDir)) {
+        $resolvedEnv = Resolve-GitRelativePath $GitDir $envCommonDir
+        if ($null -ne $resolvedEnv -and [IO.Directory]::Exists($resolvedEnv)) { $commonDir = $resolvedEnv }
+    }
+    return $commonDir
+}
+
+function Find-GitPaths([string]$Cwd) {
+    $none = [pscustomobject]@{ Found = $false; GitDir = ''; CommonDir = ''; WorktreeRoot = '' }
+    if ([string]::IsNullOrEmpty($Cwd)) { return $none }
+
+    $envGitDir = [string]$env:GIT_DIR
+    if (-not [string]::IsNullOrEmpty($envGitDir)) {
+        $resolved = Resolve-GitRelativePath $Cwd $envGitDir
+        if ($null -ne $resolved -and [IO.Directory]::Exists($resolved)) {
+            $worktreeRoot = $Cwd
+            $envWorkTree = [string]$env:GIT_WORK_TREE
+            if (-not [string]::IsNullOrEmpty($envWorkTree)) {
+                $resolvedWt = Resolve-GitRelativePath $Cwd $envWorkTree
+                if ($null -ne $resolvedWt) { $worktreeRoot = $resolvedWt }
+            }
+            return [pscustomobject]@{ Found = $true; GitDir = $resolved; CommonDir = (Resolve-GitCommonDir $resolved); WorktreeRoot = $worktreeRoot }
+        }
+    }
+
+    $dir = $null
+    try { $dir = New-Object IO.DirectoryInfo($Cwd) } catch { return $none }
+    $depth = 0
+    while ($null -ne $dir -and $depth -lt 512) {
+        $depth++
+        $candidate = [IO.Path]::Combine($dir.FullName, '.git')
+        # Directory.Exists()/File.Exists() are non-throwing probes; walking
+        # up toward a repo root means most levels genuinely have no '.git'
+        # entry at all, so GetAttributes-plus-catch would pay an exception
+        # unwind at every level that doesn't - checked-first is a straight
+        # improvement, not just a workaround for one slow environment.
+        $isDir = [IO.Directory]::Exists($candidate)
+        $isFile = (-not $isDir) -and [IO.File]::Exists($candidate)
+        if ($isDir) {
+            return [pscustomobject]@{ Found = $true; GitDir = $candidate; CommonDir = (Resolve-GitCommonDir $candidate); WorktreeRoot = $dir.FullName }
+        }
+        if ($isFile) {
+            $pointerRaw = Read-GitPointerFile $candidate
+            if ($null -ne $pointerRaw -and $pointerRaw.StartsWith('gitdir: ', [StringComparison]::Ordinal)) {
+                $target = Resolve-GitRelativePath $dir.FullName $pointerRaw.Substring(8)
+                if ($null -ne $target -and [IO.Directory]::Exists($target)) {
+                    return [pscustomobject]@{ Found = $true; GitDir = $target; CommonDir = (Resolve-GitCommonDir $target); WorktreeRoot = $dir.FullName }
+                }
+            }
+            return $none
+        }
+        $dir = $dir.Parent
+    }
+    return $none
+}
+
+function Get-GitHeadInfo([string]$GitDir) {
+    $result = [pscustomobject]@{ Branch = ''; RefName = ''; Detached = $false }
+    $text = Read-StrictUtf8File ([IO.Path]::Combine($GitDir, 'HEAD'))
+    if ($null -eq $text) { return $result }
+    $line = ([regex]::Split($text, "`r`n|`n|`r"))[0]
+    if ([string]::IsNullOrEmpty($line)) { return $result }
+    if ($line.StartsWith('ref: ', [StringComparison]::Ordinal)) {
+        $ref = $line.Substring(5).Trim()
+        $prefix = 'refs/heads/'
+        if ($ref.StartsWith($prefix, [StringComparison]::Ordinal) -and $ref.Length -gt $prefix.Length) {
+            $result.Branch = Remove-ControlChars ($ref.Substring($prefix.Length))
+            $result.RefName = $ref
+        }
+        return $result
+    }
+    $oid = $line.Trim()
+    if ($oid -match '^[0-9a-fA-F]{40}$' -or $oid -match '^[0-9a-fA-F]{64}$') {
+        $result.Branch = $oid.Substring(0, [Math]::Min(7, $oid.Length))
+        $result.Detached = $true
+    }
+    return $result
+}
+
+function Get-GitProjectNameNative([object]$Paths) {
+    if (-not $Paths.Found) { return '' }
+    $base = $Paths.CommonDir
+    if ([string]::IsNullOrEmpty($base)) { $base = $Paths.WorktreeRoot }
+    $norm = $base.Replace('\', '/').TrimEnd('/')
+    if ($norm.EndsWith('/.git', [StringComparison]::OrdinalIgnoreCase)) { $norm = $norm.Substring(0, $norm.Length - 5) }
+    $parts = $norm.Split(@('/'), [StringSplitOptions]::RemoveEmptyEntries)
+    if ($parts.Length -eq 0) { return '' }
+    return Remove-ControlChars $parts[$parts.Length - 1]
+}
+
+function Get-StashCountNative([string]$CommonDir) {
+    $text = Read-StrictUtf8File ([IO.Path]::Combine($CommonDir, 'logs\refs\stash'))
+    if ($null -eq $text) { return 0 }
+    $count = 0
+    foreach ($line in [regex]::Split($text, "`r`n|`n|`r")) {
+        if (-not [string]::IsNullOrEmpty($line)) { $count++ }
+    }
+    return $count
+}
+
+# --- Cached dirty-state / ahead-behind (still git.exe, but rarely) -------
+
+function Get-FileTicksSafe([string]$Path) {
+    # packed-refs in particular is frequently absent (only appears after a
+    # gc/pack), so this is the same File.Exists()-before-throwing-API
+    # tradeoff as Read-GitPointerFile above.
+    if (-not [IO.File]::Exists($Path)) { return -1L }
+    try { return [IO.File]::GetLastWriteTimeUtc($Path).Ticks } catch { return -1L }
+}
+
+function Get-GitCacheSignatureText([object]$Paths, [object]$Head) {
+    $headTicks = Get-FileTicksSafe ([IO.Path]::Combine($Paths.GitDir, 'HEAD'))
+    $refTicks = -1L
+    if (-not [string]::IsNullOrEmpty($Head.RefName)) {
+        $refTicks = Get-FileTicksSafe ([IO.Path]::Combine($Paths.CommonDir, ($Head.RefName -replace '/', '\')))
+    }
+    $packedTicks = Get-FileTicksSafe ([IO.Path]::Combine($Paths.CommonDir, 'packed-refs'))
+    $indexTicks = Get-FileTicksSafe ([IO.Path]::Combine($Paths.GitDir, 'index'))
+    return ([string]$headTicks) + '|' + ([string]$refTicks) + '|' + ([string]$packedTicks) + '|' + ([string]$indexTicks)
+}
+
+function Get-GitCacheFilePath([string]$CommonDir) {
+    if ([string]::IsNullOrEmpty($CommonDir)) { return $null }
+    $norm = $CommonDir.Replace('/', '\').TrimEnd('\').ToLowerInvariant()
+    $hex = ''
+    try {
+        $sha = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $bytes = $sha.ComputeHash($Utf8NoBom.GetBytes($norm))
+            $sb = New-Object Text.StringBuilder
+            foreach ($b in $bytes) { [void]$sb.Append($b.ToString('x2')) }
+            $hex = $sb.ToString()
+        } finally { $sha.Dispose() }
+    } catch { return $null }
+    if ([string]::IsNullOrEmpty($hex)) { return $null }
+    return [IO.Path]::Combine($GitCacheDir, $hex + '.tsv')
+}
+
+function Read-GitStatusCache([string]$Path) {
+    $text = Read-StrictUtf8File $Path
+    if ($null -eq $text) { return $null }
+    $line = ([regex]::Split($text, "`r`n|`n|`r"))[0]
+    if ([string]::IsNullOrEmpty($line)) { return $null }
+    $fields = $line.Split("`t")
+    if ($fields.Length -ne 5) { return $null }
+    $writeTicks = 0L
+    if (-not [long]::TryParse($fields[1], $IntegerStyle, $Invariant, [ref]$writeTicks)) { return $null }
+    return [pscustomobject]@{ Sig = $fields[0]; WriteTicks = $writeTicks; Marks = $fields[2]; Ab = $fields[3]; Dirty = ($fields[4] -eq '1') }
+}
+
+function Write-GitStatusCache([string]$Path, [string]$SigText, [string]$Marks, [string]$Ab, [bool]$Dirty) {
+    if ($SigText -match '[\t\r\n]' -or $Marks -match '[\t\r\n]' -or $Ab -match '[\t\r\n]') { return }
+    $dirtyFlag = '0'
+    if ($Dirty) { $dirtyFlag = '1' }
+    $line = $SigText + "`t" + ([DateTime]::UtcNow.Ticks.ToString($Invariant)) + "`t" + $Marks + "`t" + $Ab + "`t" + $dirtyFlag + "`n"
+    Write-AtomicStateFile $Path $line 'gitcache'
+}
+
+function Get-GitCacheTtlTicks {
+    if ($null -ne $script:GitCacheTtlTicksCache) { return $script:GitCacheTtlTicksCache }
+    $ms = 0
+    $raw = [string]$env:CORALLINE_GIT_CACHE_TTL_MS
+    if ([string]::IsNullOrEmpty($raw) -or -not [int]::TryParse($raw, $IntegerStyle, $Invariant, [ref]$ms) -or $ms -lt 0 -or $ms -gt 3600000) { $ms = 1500 }
+    $script:GitCacheTtlTicksCache = [long]$ms * 10000L
+    return $script:GitCacheTtlTicksCache
+}
+
+function Get-GitCacheMaxAgeTicks {
+    if ($null -ne $script:GitCacheMaxAgeTicksCache) { return $script:GitCacheMaxAgeTicksCache }
+    $days = 0
+    $raw = [string]$env:CORALLINE_GIT_CACHE_MAX_AGE_DAYS
+    if ([string]::IsNullOrEmpty($raw) -or -not [int]::TryParse($raw, $IntegerStyle, $Invariant, [ref]$days) -or $days -lt 1 -or $days -gt 3650) { $days = 30 }
+    $script:GitCacheMaxAgeTicksCache = [long]$days * 24L * 3600L * 10000000L
+    return $script:GitCacheMaxAgeTicksCache
+}
+
+# Every distinct repo ever rendered gets its own cache file (named by a hash
+# of its common-dir) that would otherwise live forever, so a deleted, moved,
+# or simply not-revisited-in-months repo's entry accumulates indefinitely.
+# This sweep deletes any cache file not refreshed within
+# CORALLINE_GIT_CACHE_MAX_AGE_DAYS (default 30) - age alone is sufficient
+# (no need to verify the source repo still exists): a still-active repo gets
+# its file rewritten well within that window on its own, so anything that
+# old is either gone or dormant either way, and re-populating it costs one
+# ordinary cache-miss git.exe call next time it is visited.
+# Runs only from the already-expensive git.exe cache-miss path below, and is
+# itself throttled to at most once per day via a sentinel file's own
+# timestamp, so it never adds cost to the common cache-hit render.
+function Invoke-GitCacheSweep {
+    if ([string]::IsNullOrEmpty($GitCacheDir) -or -not (Test-NoReparseComponents $GitCacheDir)) { return }
+    if (-not [IO.Directory]::Exists($GitCacheDir)) { return }
+    $sentinel = [IO.Path]::Combine($GitCacheDir, '.sweep-stamp')
+    $now = [DateTime]::UtcNow
+    try {
+        if (Test-StateObjectExists $sentinel) {
+            if (-not (Test-StateRegularFile $sentinel)) { return }
+            if (($now - [IO.File]::GetLastWriteTimeUtc($sentinel)).TotalHours -lt 24) { return }
+        }
+    } catch { return }
+    Write-AtomicStateFile $sentinel '' 'gitcache-sweep'
+
+    $maxAgeTicks = Get-GitCacheMaxAgeTicks
+    $seen = 0
+    $removed = 0
+    try {
+        foreach ($file in [IO.Directory]::EnumerateFiles($GitCacheDir, '*.tsv')) {
+            $seen++
+            if ($seen -gt 8192 -or $removed -ge 2048) { break }
+            if (-not (Test-StateRegularFile $file)) { continue }
+            try {
+                if (($now.Ticks - [IO.File]::GetLastWriteTimeUtc($file).Ticks) -gt $maxAgeTicks) {
+                    [IO.File]::Delete($file)
+                    $removed++
+                }
+            } catch { }
+        }
+    } catch { }
+}
+
+# One render needs at most one git.exe call now (only on a cache miss), so
+# there is nothing left worth dispatching in parallel.
+function Get-GitInfoCached([string]$Cwd) {
+    $state = @{ Branch = ''; Marks = ''; Ab = ''; Dirty = $false }
+    $result = [pscustomobject]@{ State = $state; Project = ''; Paths = $null }
+    if ([string]::IsNullOrEmpty($Cwd)) { return $result }
+    $paths = Find-GitPaths $Cwd
+    if (-not $paths.Found) { return $result }
+    $result.Paths = $paths
+    $head = Get-GitHeadInfo $paths.GitDir
+    if ([string]::IsNullOrEmpty($head.Branch)) { return $result }
+    $state.Branch = $head.Branch
+    $result.Project = Get-GitProjectNameNative $paths
+
+    $sigText = Get-GitCacheSignatureText $paths $head
+    $cachePath = Get-GitCacheFilePath $paths.CommonDir
+    # A signature match means the exact tracked-file state (HEAD/ref/index/
+    # packed-refs) that produced the cached Marks/Ab/Dirty is still the
+    # current state, so that data is exact, not merely "recent" - the TTL
+    # below only controls how eagerly we re-check for the one thing the
+    # signature can't see (a new/removed untracked file). A cache hit is
+    # therefore always applied first; a stale-by-TTL refresh attempt that
+    # then fails (git.exe missing, transient error) must never blank out
+    # already-known-good data.
+    $sigMatches = $false
+    if (-not [string]::IsNullOrEmpty($cachePath)) {
+        $cached = Read-GitStatusCache $cachePath
+        if ($null -ne $cached -and $cached.Sig -ceq $sigText) {
+            $sigMatches = $true
+            $state.Marks = $cached.Marks
+            $state.Ab = $cached.Ab
+            $state.Dirty = $cached.Dirty
+        }
+    }
+    $needsRefresh = $true
+    if ($sigMatches) {
+        $age = [DateTime]::UtcNow.Ticks - $cached.WriteTicks
+        $needsRefresh = -not ($age -ge 0 -and $age -le (Get-GitCacheTtlTicks))
+    }
+    if ($needsRefresh) {
+        $fresh = Get-GitState $Cwd
+        if (-not [string]::IsNullOrEmpty($fresh.Branch)) {
+            $state.Marks = $fresh.Marks
+            $state.Ab = $fresh.Ab
+            $state.Dirty = $fresh.Dirty
+            if (-not [string]::IsNullOrEmpty($cachePath)) {
+                Write-GitStatusCache $cachePath $sigText $fresh.Marks $fresh.Ab $fresh.Dirty
+            }
+        }
+        Invoke-GitCacheSweep
+    }
+    return $result
 }
 
 function Read-PinFile([string]$Path) {
@@ -2698,9 +3129,12 @@ $script:NodeCache = ''
 $script:PythonCacheSet = $false
 $script:PythonCache = ''
 
-function Get-StashCount-Cached([string]$Cwd) {
+function Get-StashCount-Cached {
     if (-not $script:StashCacheSet) {
-        $script:StashCache = Get-StashCount $Cwd
+        $script:StashCache = 0
+        if ($null -ne $GitInfo -and $null -ne $GitInfo.Paths -and $GitInfo.Paths.Found) {
+            $script:StashCache = Get-StashCountNative $GitInfo.Paths.CommonDir
+        }
         $script:StashCacheSet = $true
     }
     return [int]$script:StashCache
@@ -2761,10 +3195,12 @@ if ($BurnStateGate -or $Limit5StateGate -or $Limit7StateGate) {
 
 $GitState = @{ Branch = ''; Marks = ''; Ab = ''; Dirty = $false }
 $GitRoot = ''
+$GitInfo = $null
 if ($ProbeSegmentNames.Contains('git') -or $ProbeSegmentNames.Contains('stash') -or $ProbeSegmentNames.Contains('project')) {
-    $GitState = Get-GitState $ProbeCwd
+    $GitInfo = Get-GitInfoCached $ProbeCwd
+    $GitState = $GitInfo.State
+    if ($ProbeSegmentNames.Contains('project')) { $GitRoot = $GitInfo.Project }
 }
-if ($ProbeSegmentNames.Contains('project') -and -not [string]::IsNullOrEmpty($GitState.Branch)) { $GitRoot = Get-GitRoot $ProbeCwd }
 
 $SegBgs = New-Object System.Collections.Generic.List[string]
 $SegTxt = New-Object System.Collections.Generic.List[string]
@@ -2839,7 +3275,7 @@ function Add-GitSegment {
 
 function Add-StashSegment {
     if ([string]::IsNullOrEmpty($GitState.Branch)) { return }
-    $count = Get-StashCount-Cached $ProbeCwd
+    $count = Get-StashCount-Cached
     if ($count -le 0) { return }
     $fg = Get-Fg $Cfg.VL_FG_TEXT
     $bg = $Cfg.VL_BG_STASH

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -659,6 +659,160 @@ esac
     Check 'Unicode scalar tail keeps the complete suffix' ((Plain $scalarTailPs.Stdout).Contains('A' + (Glyph 0x2026) + $scalar + 'F'))
     Check 'Unicode scalar tail emits no replacement character' (-not $scalarTailPs.Stdout.Contains([char]0xFFFD))
 
+    # --- Native git-discovery / cache safety regressions ------------------
+    # Covers the four gaps flagged on PR #66: the cache sweep's filesystem
+    # deletion boundary, worktree-specific cache identity, stale/removed
+    # cached executable paths, and explicit Git environment overrides that
+    # must be rejected rather than silently falling back.
+    $cacheSafetyRoot = Join-Path $TempRoot 'git-cache-safety'
+    [void][IO.Directory]::CreateDirectory($cacheSafetyRoot)
+    $cacheSafetyConfig = New-Config 'git-cache-safety' @('VL_SEGMENTS=git', 'VL_CLOCK=off')
+
+    # (1) Invoke-GitCacheSweep must only ever delete files it recognizes as
+    # its own (a 64-hex-digit SHA-256 basename), never an unrelated *.tsv
+    # file that happens to share CORALLINE_GITCACHE_DIR with something else.
+    $sweepCacheDir = Join-Path $cacheSafetyRoot 'sweep-cache'
+    [void][IO.Directory]::CreateDirectory($sweepCacheDir)
+    $unrelatedTsv = Join-Path $sweepCacheDir 'customers.tsv'
+    Write-Utf8 $unrelatedTsv "id`tname`n1`tAcme`n"
+    [IO.File]::SetLastWriteTimeUtc($unrelatedTsv, [DateTime]::UtcNow.AddDays(-400))
+    $staleOwnTsv = Join-Path $sweepCacheDir (('a' * 64) + '.tsv')
+    Write-Utf8 $staleOwnTsv "stale-sig`t0`t`t`t0`n"
+    [IO.File]::SetLastWriteTimeUtc($staleOwnTsv, [DateTime]::UtcNow.AddDays(-400))
+
+    $sweepRepo = Join-Path $cacheSafetyRoot 'sweep-repo'
+    [void][IO.Directory]::CreateDirectory($sweepRepo)
+    Write-Utf8 (Join-Path $sweepRepo 'a.txt') "one`n"
+    [void](Run-Git $sweepRepo 'init -q')
+    [void](Run-Git $sweepRepo 'checkout -q -b main')
+    [void](Run-Git $sweepRepo 'config user.email test@example.com')
+    [void](Run-Git $sweepRepo 'config user.name test')
+    [void](Run-Git $sweepRepo 'add a.txt')
+    [void](Run-Git $sweepRepo 'commit -q -m init')
+
+    $sweepEnv = @{ CORALLINE_GITCACHE_DIR = (Forward-Path $sweepCacheDir) }
+    $sweepPayload = New-Payload (Forward-Path $sweepRepo)
+    $sweepRun = Invoke-Statusline (Json $sweepPayload) $cacheSafetyConfig $sweepEnv '' 5000
+    Check-Run 'git-cache sweep render' $sweepRun
+    Check 'git-cache sweep preserves an unrelated old tsv file' ([IO.File]::Exists($unrelatedTsv))
+    Check 'git-cache sweep still removes its own stale cache file' (-not [IO.File]::Exists($staleOwnTsv))
+
+    # (2) The cache file path must be keyed on WorktreeRoot (and GitDir), not
+    # CommonDir alone - two sessions can share one GIT_DIR/index while
+    # GIT_WORK_TREE points at different worktrees, and a shared key would let
+    # one worktree's dirty state leak into the other's render.
+    $wtRoot = Join-Path $cacheSafetyRoot 'worktree-identity'
+    [void][IO.Directory]::CreateDirectory($wtRoot)
+    $wtBase = Join-Path $wtRoot 'base-repo'
+    [void][IO.Directory]::CreateDirectory($wtBase)
+    Write-Utf8 (Join-Path $wtBase 't.txt') 'clean'
+    [void](Run-Git $wtBase 'init -q')
+    [void](Run-Git $wtBase 'checkout -q -b main')
+    [void](Run-Git $wtBase 'config user.email test@example.com')
+    [void](Run-Git $wtBase 'config user.name test')
+    [void](Run-Git $wtBase 'add t.txt')
+    [void](Run-Git $wtBase 'commit -q -m init')
+    $wtGitDir = Join-Path $wtBase '.git'
+
+    $wtDirty = Join-Path $wtRoot 'worktree-dirty'
+    [void][IO.Directory]::CreateDirectory($wtDirty)
+    Write-Utf8 (Join-Path $wtDirty 't.txt') 'changed'
+
+    $wtClean = Join-Path $wtRoot 'worktree-clean'
+    [void][IO.Directory]::CreateDirectory($wtClean)
+    Write-Utf8 (Join-Path $wtClean 't.txt') 'clean'
+
+    $wtCacheDir = Join-Path $wtRoot 'cache'
+    [void][IO.Directory]::CreateDirectory($wtCacheDir)
+    $wtDirtyEnv = @{ CORALLINE_GITCACHE_DIR = (Forward-Path $wtCacheDir); CORALLINE_GIT_CACHE_TTL_MS = '60000'; GIT_DIR = $wtGitDir; GIT_WORK_TREE = $wtDirty }
+    $wtCleanEnv = @{ CORALLINE_GITCACHE_DIR = (Forward-Path $wtCacheDir); CORALLINE_GIT_CACHE_TTL_MS = '60000'; GIT_DIR = $wtGitDir; GIT_WORK_TREE = $wtClean }
+
+    $wtDirtyRun = Invoke-Statusline (Json (New-Payload (Forward-Path $wtDirty))) $cacheSafetyConfig $wtDirtyEnv '' 5000
+    Check-Run 'worktree-identity dirty worktree render' $wtDirtyRun
+    Check 'worktree-identity dirty worktree reports dirty' ((Plain $wtDirtyRun.Stdout).Contains('!'))
+
+    $wtCleanRun = Invoke-Statusline (Json (New-Payload (Forward-Path $wtClean))) $cacheSafetyConfig $wtCleanEnv '' 5000
+    Check-Run 'worktree-identity clean worktree render' $wtCleanRun
+    Check 'worktree-identity clean worktree is not tainted by the dirty worktree cache entry' (-not ((Plain $wtCleanRun.Stdout).Contains('!')))
+
+    # (3) Get-ApplicationPath must not trust a cached executable path once the
+    # file at that path is gone, even though the PATH string signature that
+    # gated the cache entry has not changed.
+    $staleExeRoot = Join-Path $cacheSafetyRoot 'stale-exe'
+    [void][IO.Directory]::CreateDirectory($staleExeRoot)
+    $fakeBinDir = Join-Path $staleExeRoot 'fakebin'
+    [void][IO.Directory]::CreateDirectory($fakeBinDir)
+    $fakeGitExe = Join-Path $fakeBinDir 'git.exe'
+    Copy-Item -LiteralPath 'C:\Windows\System32\cmd.exe' -Destination $fakeGitExe
+
+    $staleRepo = Join-Path $staleExeRoot 'repo'
+    [void][IO.Directory]::CreateDirectory($staleRepo)
+    Write-Utf8 (Join-Path $staleRepo 't.txt') "one`n"
+    [void](Run-Git $staleRepo 'init -q')
+    [void](Run-Git $staleRepo 'checkout -q -b main')
+    [void](Run-Git $staleRepo 'config user.email test@example.com')
+    [void](Run-Git $staleRepo 'config user.name test')
+    [void](Run-Git $staleRepo 'add t.txt')
+    [void](Run-Git $staleRepo 'commit -q -m init')
+    Write-Utf8 (Join-Path $staleRepo 't.txt') "one-changed`n"
+
+    $staleAppCache = Join-Path $staleExeRoot 'apppath-cache.tsv'
+    $staleGitCache = Join-Path $staleExeRoot 'git-cache'
+    [void][IO.Directory]::CreateDirectory($staleGitCache)
+    $staleEnv = @{
+        CORALLINE_APPPATH_CACHE = (Forward-Path $staleAppCache)
+        CORALLINE_GITCACHE_DIR = (Forward-Path $staleGitCache)
+        PATH = ($fakeBinDir + ';' + [string]$env:PATH)
+    }
+    $stalePayload = New-Payload (Forward-Path $staleRepo)
+
+    $staleRun1 = Invoke-Statusline (Json $stalePayload) $cacheSafetyConfig $staleEnv '' 5000
+    Check-Run 'stale executable path first render (fake git.exe on PATH)' $staleRun1
+    Check 'stale executable path caches the fake git.exe' ((Get-Content -Raw $staleAppCache).Contains($fakeGitExe))
+    Check 'stale executable path first render cannot see dirty state through the fake git.exe' (-not ((Plain $staleRun1.Stdout).Contains('!')))
+
+    Remove-Item -LiteralPath $fakeGitExe -Force
+
+    $staleRun2 = Invoke-Statusline (Json $stalePayload) $cacheSafetyConfig $staleEnv '' 5000
+    Check-Run 'stale executable path second render after removal' $staleRun2
+    Check 'stale executable path re-resolves once the cached file disappears' (-not (Get-Content -Raw $staleAppCache).Contains($fakeGitExe))
+    Check 'stale executable path second render correctly reports dirty via real git.exe' ((Plain $staleRun2.Stdout).Contains('!'))
+
+    # (4) An explicit GIT_DIR that cannot be resolved must not fall back to
+    # upward .git discovery, and an explicit GIT_COMMON_DIR that cannot be
+    # resolved must not silently fall back to the GitDir-derived commondir -
+    # both are treated as a hard error, matching Git's own behavior.
+    $envOverrideRoot = Join-Path $cacheSafetyRoot 'env-overrides'
+    [void][IO.Directory]::CreateDirectory($envOverrideRoot)
+    $overrideParentRepo = Join-Path $envOverrideRoot 'parent-repo'
+    [void][IO.Directory]::CreateDirectory($overrideParentRepo)
+    Write-Utf8 (Join-Path $overrideParentRepo 'p.txt') "one`n"
+    [void](Run-Git $overrideParentRepo 'init -q')
+    [void](Run-Git $overrideParentRepo 'checkout -q -b parent-branch')
+    [void](Run-Git $overrideParentRepo 'config user.email test@example.com')
+    [void](Run-Git $overrideParentRepo 'config user.name test')
+    [void](Run-Git $overrideParentRepo 'add p.txt')
+    [void](Run-Git $overrideParentRepo 'commit -q -m init')
+    $overrideChildDir = Join-Path $overrideParentRepo 'child'
+    [void][IO.Directory]::CreateDirectory($overrideChildDir)
+
+    $badGitDirEnv = @{
+        CORALLINE_GITCACHE_DIR = (Forward-Path (Join-Path $envOverrideRoot 'cache-a'))
+        GIT_DIR = (Join-Path $envOverrideRoot 'does-not-exist')
+    }
+    $badGitDirRun = Invoke-Statusline (Json (New-Payload (Forward-Path $overrideChildDir))) $cacheSafetyConfig $badGitDirEnv '' 5000
+    Check-Run 'invalid explicit GIT_DIR render' $badGitDirRun
+    Check 'invalid explicit GIT_DIR does not fall back to the parent repository' (-not ((Plain $badGitDirRun.Stdout).Contains('parent-branch')))
+
+    $badCommonDirEnv = @{
+        CORALLINE_GITCACHE_DIR = (Forward-Path (Join-Path $envOverrideRoot 'cache-b'))
+        GIT_DIR = (Join-Path $overrideParentRepo '.git')
+        GIT_COMMON_DIR = (Join-Path $envOverrideRoot 'also-does-not-exist')
+    }
+    $badCommonDirRun = Invoke-Statusline (Json (New-Payload (Forward-Path $overrideParentRepo))) $cacheSafetyConfig $badCommonDirEnv '' 5000
+    Check-Run 'invalid explicit GIT_COMMON_DIR render' $badCommonDirRun
+    Check 'invalid explicit GIT_COMMON_DIR is rejected rather than falling back to GitDir' (-not ((Plain $badCommonDirRun.Stdout).Contains('parent-branch')))
+
     $script:QuoteHelper = Join-Path $TempRoot 'configure-quote.sh'
     Write-Utf8 $script:QuoteHelper @'
 #!/usr/bin/env bash


### PR DESCRIPTION
The default segment list includes `git`, so every render forked git.exe at least once; with `stash`/`project` also enabled that was up to three git.exe spawns per render. On Windows this is disproportionately expensive because each new process is subject to real-time AV scanning, which compounds badly across the many renders a single session produces.

**Native discovery + cached status (no more git.exe on cache hits)**
- Branch name, stash count, and the project folder name are now read directly from .git's own files (HEAD, logs/refs/stash, commondir/worktree resolution incl. GIT_DIR/GIT_WORK_TREE/GIT_COMMON_DIR) via plain `[System.IO.File]`/`[System.IO.DirectoryInfo]` calls - no git.exe involved for these at all.
- Dirty state and ahead/behind still come from `git status --porcelain=v2 --branch` (reproducing that exactly without a real git implementation isn't practical), but the result is now cached per-repo, keyed on a signature of HEAD/current-branch-ref/packed-refs/index mtimes plus a short TTL (default 1.5s, `CORALLINE_GIT_CACHE_TTL_MS`) as a safety net for changes the signature can't see (new untracked files). A signature match is trusted even past the TTL if a refresh attempt fails, so a missing/broken git.exe degrades to slightly-stale-but-still-correct data instead of silently reporting "clean".
- Cache writes reuse the same `CreateNew`-temp-file + `File.Replace` pattern already used for burn/float state, so concurrent renders can't corrupt the cache or block on each other.
- A cache file accumulates per distinct repo ever rendered; a sweep (opportunistic, throttled to once/day, piggybacked on the already-expensive cache-miss path) removes anything not refreshed within `CORALLINE_GIT_CACHE_MAX_AGE_DAYS` (default 30).

**Resolved-binary caching**
- `Get-ApplicationPath` (git/node/python3) walked the full PATH via `Get-Command` on every render. The resolved path is now cached to disk keyed by a hash of the live PATH string, so an unchanged PATH (the common case) skips the walk entirely.

**Stdin decoding resilience**
- A UTF-8 BOM is valid UTF-8 - it decodes into a literal U+FEFF character rather than throwing, which then silently broke JSON parsing further downstream with no visible cause. Bytes are now checked for a leading BOM and stripped before either decode attempt.
- Genuinely invalid byte sequences now fall back to a non-throwing lenient decode instead of blanking the whole render (or, in `--subagent` mode, exiting silently).

Both modes now share one bounded, up-front byte read of stdin so the decode-failure fallback above has bytes to retry against, and path lookups avoid the exception-throw cost of `GetAttributes`/`ReadAllBytes` on files that are normally absent (packed-refs, commondir) by checking `File.Exists`/`Directory.Exists` first.

**Measured**, ~100 paired runs (old binary vs this branch, interleaved to cancel system-load drift): on a synthetic all-local-disk rig, the default segment set (1 git.exe call) showed a small loss - git.exe launch itself was cheap there, so trading it for several file-stat calls was a wash - but with `stash`+`project` also enabled (3 git.exe calls on the old binary) this branch was consistently faster. On a normal desktop with active Windows Defender, where git.exe launches cost far more than in that rig, the same trade should favor this branch even in the single-git.exe-call case. Happy to share the benchmark harness if a second data point would help.