### PR TITLE
feat: add VL_CTX_ALWAYS_SHOW / VL_COST_ALWAYS_SHOW

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,8 @@ Everything lives in `~/.claude/coralline.conf` (plain bash, sourced by the scrip
 | `VL_PATH_DEPTH` | `4` | collapse paths deeper than this |
 | `VL_NAME_MAX` | `0` | max chars for the `project` / `git` names before `…` truncation (`0` = off) |
 | `VL_COST_DECIMALS` | `2` | decimal places for the cost segment |
+| `VL_CTX_ALWAYS_SHOW` | `0` | `1` = show an object JSON payload's missing, `null`, or exact-empty context value as a 0% gauge with zero token counts; malformed or non-object payloads do not trigger it, and non-empty context values keep normal percentage handling |
+| `VL_COST_ALWAYS_SHOW` | `0` | `1` = show an object JSON payload's missing, `null`, or exact-empty cost as `$0.00`; invalid types and values stay hidden |
 | `VL_WARN_PCT` / `VL_HOT_PCT` | `50` / `75` | gauge color thresholds |
 | `VL_ASCII` | `0` | `1` disables Nerd Font glyphs |
 | `VL_RUNTIME_PROBE` | `0` | `node` / `python`: `1` = also detect via `node` / `python3` on `PATH` when no pin file (forks per render) |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -392,6 +392,8 @@ bootstrap 會驗證兩者、在下載 `install.ps1` 前解析可變 Ref，再把
 | `VL_PATH_DEPTH` | `4` | 路徑超過此深度即摺疊 |
 | `VL_NAME_MAX` | `0` | `project` / `git` 名稱超過此字數即以 `…` 截斷（`0` = 關閉） |
 | `VL_COST_DECIMALS` | `2` | 費用顯示的小數位數 |
+| `VL_CTX_ALWAYS_SHOW` | `0` | 設為 `1` 時，頂層為物件的 JSON 中缺少、`null` 或精確空字串的 context 值會顯示 0% 量表與零 token 數；JSON 格式錯誤或頂層非物件時不會觸發，非空 context 值仍沿用一般百分比處理 |
+| `VL_COST_ALWAYS_SHOW` | `0` | 設為 `1` 時，頂層為物件的 JSON 中缺少、`null` 或精確空字串的費用會顯示 `$0.00`；無效型別與數值仍隱藏 |
 | `VL_WARN_PCT` / `VL_HOT_PCT` | `50` / `75` | 量表變色門檻 |
 | `VL_ASCII` | `0` | 設為 `1` 停用 Nerd Font 字符 |
 | `VL_RUNTIME_PROBE` | `0` | `node` / `python`：設為 `1` 時，若無 pin 檔則改用 `PATH` 上的 `node` / `python3` 偵測（每次繪製會 fork） |

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -2398,7 +2398,7 @@ function Get-JsonMember($Object, [string]$Name) {
     try {
         $property = $Object.PSObject.Properties[$Name]
         if ($null -eq $property) { return $null }
-        return $property.Value
+        return ,$property.Value
     } catch { return $null }
 }
 
@@ -2424,12 +2424,40 @@ function To-InvariantString($Value) {
     return ''
 }
 
-try { $J = $rawInput | ConvertFrom-Json -ErrorAction Stop } catch { $J = $null }
+$JsonParsed = $false
+try {
+    if ($rawInput -cnotmatch '\A[ \t\r\n]*\{') { throw 'non-object JSON root' }
+    $J = $rawInput | ConvertFrom-Json -ErrorAction Stop
+    $JsonParsed = ($J -is [pscustomobject] -or $J -is [System.Collections.IDictionary])
+    if (-not $JsonParsed) { $J = $null }
+} catch { $J = $null }
 
 $cwd = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('workspace', 'current_dir')))
 if ([string]::IsNullOrEmpty($cwd)) { $cwd = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('cwd'))) }
 $model = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('model', 'display_name')))
-$ctxPct = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('context_window', 'used_percentage')))
+$ctxParent = Get-JsonMember $J 'context_window'
+$ctxNode = $null
+$ctxEmpty = $false
+if ($null -eq $ctxParent) {
+    $ctxPct = ''
+    $ctxEmpty = $true
+} elseif ($ctxParent -is [pscustomobject] -or $ctxParent -is [System.Collections.IDictionary]) {
+    $ctxNode = Get-JsonMember $ctxParent 'used_percentage'
+    if ($null -eq $ctxNode) {
+        $ctxPct = ''
+        $ctxEmpty = $true
+    } elseif ($ctxNode -is [string]) {
+        $ctxRaw = [string]$ctxNode
+        $ctxPct = Remove-ControlChars $ctxRaw
+        $ctxEmpty = $ctxRaw.Length -eq 0
+    } elseif ($ctxNode -is [bool] -or $ctxNode -is [System.Array] -or $ctxNode -is [System.Collections.IDictionary] -or $ctxNode -is [pscustomobject]) {
+        $ctxPct = ''
+    } else {
+        $ctxPct = Remove-ControlChars (To-InvariantString $ctxNode)
+    }
+} else {
+    $ctxPct = ''
+}
 $tokIn = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('context_window', 'total_input_tokens')))
 $tokOut = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('context_window', 'total_output_tokens')))
 $tokCr = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('context_window', 'current_usage', 'cache_read_input_tokens')))
@@ -2438,7 +2466,33 @@ $fhPct = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('rate_limits
 $fhRst = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('rate_limits', 'five_hour', 'resets_at')))
 $wdPct = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('rate_limits', 'seven_day', 'used_percentage')))
 $wdRst = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('rate_limits', 'seven_day', 'resets_at')))
-$cost = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('cost', 'total_cost_usd')))
+$costParent = Get-JsonMember $J 'cost'
+$costNode = $null
+$costKind = 'missing'
+$costRaw = ''
+$cost = ''
+if ($null -eq $costParent) {
+    $costKind = 'missing'
+} elseif ($costParent -is [pscustomobject] -or $costParent -is [System.Collections.IDictionary]) {
+    $costNode = Get-JsonMember $costParent 'total_cost_usd'
+    if ($null -eq $costNode) {
+        $costKind = 'missing'
+    } elseif ($costNode -is [string]) {
+        $costRaw = [string]$costNode
+        $cost = Remove-ControlChars $costRaw
+        if ($costRaw.Length -gt 0) { $costKind = 'scalar' }
+    } elseif ($costNode -is [bool] -or $costNode -is [System.Array] -or $costNode -is [System.Collections.IDictionary] -or $costNode -is [pscustomobject]) {
+        $costKind = 'invalid'
+    } elseif ($costNode -is [System.IFormattable]) {
+        $costKind = 'scalar'
+        $costRaw = To-InvariantString $costNode
+        $cost = $costRaw
+    } else {
+        $costKind = 'invalid'
+    }
+} else {
+    $costKind = 'invalid'
+}
 $linesAdd = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('cost', 'total_lines_added')))
 $linesDel = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('cost', 'total_lines_removed')))
 $outStyle = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('output_style', 'name')))
@@ -2867,7 +2921,7 @@ function Add-EffortSegment {
 function Add-CtxSegment {
     $pct = 0
     $known = Get-PctValue $ctxPct ([ref]$pct)
-    if (-not $known -and $Cfg.VL_CTX_ALWAYS_SHOW -ne '1') { return }
+    if (-not $known -and ($Cfg.VL_CTX_ALWAYS_SHOW -ne '1' -or -not $JsonParsed -or -not $ctxEmpty)) { return }
     $bar = New-Bar $pct ([int]$Cfg.VL_BAR_WIDTH)
     $pfg = Get-Fg (Get-PctFg $pct)
     $dfg = Get-Fg $Cfg.VL_FG_DIM
@@ -2980,8 +3034,51 @@ function Add-BurnSegment {
 
 function Add-CostSegment {
     $value = 0.0
-    $parsed = Try-BoundedDouble $cost 0 1000000000 ([ref]$value)
-    if (($value -eq 0 -or -not $parsed) -and $Cfg.VL_COST_ALWAYS_SHOW -ne '1') { return }
+    if ($costKind -eq 'missing') {
+        if (-not $JsonParsed -or $Cfg.VL_COST_ALWAYS_SHOW -ne '1') { return }
+    } elseif ($costKind -eq 'scalar') {
+        $raw = [string]$costRaw
+        if ($raw.Length -gt 128 -or $raw -cnotmatch '\A *[+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)? *\z') { return }
+        $trimmed = $raw.Trim(' ')
+        $eIndex = $trimmed.IndexOf('e')
+        $upperIndex = $trimmed.IndexOf('E')
+        if ($eIndex -lt 0 -or ($upperIndex -ge 0 -and $upperIndex -lt $eIndex)) { $eIndex = $upperIndex }
+        $significand = $trimmed
+        if ($eIndex -ge 0) { $significand = $trimmed.Substring(0, $eIndex) }
+        $lexicalNonZero = $significand -match '[1-9]'
+        if ($trimmed[0] -eq '-' -and $lexicalNonZero) { return }
+        $explicitExponent = 0
+        if ($eIndex -ge 0) {
+            $expText = $trimmed.Substring($eIndex + 1)
+            $expNegative = $expText[0] -eq '-'
+            if ($expText[0] -eq '+' -or $expNegative) { $expText = $expText.Substring(1) }
+            $expText = $expText.TrimStart('0')
+            if ([string]::IsNullOrEmpty($expText)) { $expText = '0' }
+            if ($expText.Length -gt 3) { return }
+            $expMagnitude = [int]$expText
+            if ($expMagnitude -gt 308) { return }
+            $explicitExponent = $expMagnitude
+            if ($expNegative) { $explicitExponent = -$explicitExponent }
+        }
+        if ($lexicalNonZero) {
+            $unsignedSignificand = $significand
+            if ($unsignedSignificand[0] -eq '+' -or $unsignedSignificand[0] -eq '-') { $unsignedSignificand = $unsignedSignificand.Substring(1) }
+            $dotIndex = $unsignedSignificand.IndexOf('.')
+            $integerDigits = $unsignedSignificand.Length
+            if ($dotIndex -ge 0) { $integerDigits = $dotIndex }
+            $digits = $unsignedSignificand.Replace('.', '')
+            $firstNonZero = $digits.IndexOfAny([char[]]'123456789')
+            $adjustedExponent = $explicitExponent + $integerDigits - $firstNonZero - 1
+            if ($adjustedExponent -lt -323 -or $adjustedExponent -gt 9) { return }
+            if ($adjustedExponent -eq 9 -and $digits.Substring($firstNonZero) -cnotmatch '\A10*\z') { return }
+        }
+        if (-not (Try-BoundedDouble $raw 0 1000000000 ([ref]$value))) { return }
+        if ($value -eq 0.0) {
+            if ($lexicalNonZero) { return }
+            $value = 0.0
+            if ($Cfg.VL_COST_ALWAYS_SHOW -ne '1') { return }
+        }
+    } else { return }
     $format = '$' + $value.ToString('F' + $Cfg.VL_COST_DECIMALS, $Invariant)
     $fg = Get-Fg $Cfg.VL_FG_TEXT
     Push-Segment $Cfg.VL_BG_COST "${fg} $format "

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -101,6 +101,8 @@ $Defaults = [ordered]@{
     VL_PATH_DEPTH = '4'
     VL_NAME_MAX = '0'
     VL_COST_DECIMALS = '2'
+    VL_CTX_ALWAYS_SHOW = '0'
+    VL_COST_ALWAYS_SHOW = '0'
     VL_WARN_PCT = '50'
     VL_HOT_PCT = '75'
     VL_ASCII = '0'
@@ -2864,7 +2866,8 @@ function Add-EffortSegment {
 
 function Add-CtxSegment {
     $pct = 0
-    if (-not (Get-PctValue $ctxPct ([ref]$pct))) { return }
+    $known = Get-PctValue $ctxPct ([ref]$pct)
+    if (-not $known -and $Cfg.VL_CTX_ALWAYS_SHOW -ne '1') { return }
     $bar = New-Bar $pct ([int]$Cfg.VL_BAR_WIDTH)
     $pfg = Get-Fg (Get-PctFg $pct)
     $dfg = Get-Fg $Cfg.VL_FG_DIM
@@ -2977,7 +2980,8 @@ function Add-BurnSegment {
 
 function Add-CostSegment {
     $value = 0.0
-    if (-not (Try-BoundedDouble $cost 0 1000000000 ([ref]$value)) -or $value -eq 0) { return }
+    $parsed = Try-BoundedDouble $cost 0 1000000000 ([ref]$value)
+    if (($value -eq 0 -or -not $parsed) -and $Cfg.VL_COST_ALWAYS_SHOW -ne '1') { return }
     $format = '$' + $value.ToString('F' + $Cfg.VL_COST_DECIMALS, $Invariant)
     $fg = Get-Fg $Cfg.VL_FG_TEXT
     Push-Segment $Cfg.VL_BG_COST "${fg} $format "

--- a/statusline.sh
+++ b/statusline.sh
@@ -57,6 +57,8 @@ VL_CLOCK_SECONDS=1
 VL_PATH_DEPTH=4                 # collapse paths deeper than this
 VL_NAME_MAX=0                   # max chars for project/git names before … truncation (0 = off)
 VL_COST_DECIMALS=2
+VL_CTX_ALWAYS_SHOW=0            # 1 = show an empty valid context window as 0%
+VL_COST_ALWAYS_SHOW=0            # 1 = show a missing valid cost as $0.00
 VL_WARN_PCT=50                  # percentage thresholds for bar colors
 VL_HOT_PCT=75
 VL_ASCII=0                      # 1 = no Nerd Font glyphs (plain colored blocks)
@@ -1268,9 +1270,14 @@ seg_model() {  # active Claude model
 }
 
 seg_ctx() {  # context-window gauge with input/output/cache token counts
-  [ -n "$ctx_pct" ] || return 0
+  if [ -z "$ctx_pct" ]; then
+    [ "$VL_CTX_ALWAYS_SHOW" = 1 ] && [ "${_JSON_OK:-0}" = 1 ] \
+      && [ "${_CTX_EMPTY:-0}" = 1 ] || return 0
+  fi
   local ci fgc fgd ti to tcr tcw
-  printf -v ci '%.0f' "$ctx_pct" 2>/dev/null || ci=0
+  if [ -n "$ctx_pct" ]; then printf -v ci '%.0f' "$ctx_pct" 2>/dev/null || ci=0
+  else ci=0
+  fi
   make_bar "$ci"; pct_fg "$ci"
   fg "$_PFG";       fgc="$_FG"
   fg "$VL_FG_DIM";  fgd="$_FG"
@@ -1362,9 +1369,74 @@ seg_limit7d() {  # 7d rate-limit gauge with reset countdown
 }
 
 seg_cost() {  # session cost in USD
-  [ -n "$cost" ] && [ "$cost" != "0" ] || return 0
-  local fmt
-  printf -v fmt "\$%.${VL_COST_DECIMALS}f" "$cost" 2>/dev/null || fmt="\$$cost"
+  local raw="${cost:-}" trimmed significand lexical_nonzero unsigned digits integer_part leading_zeroes significant exp_text exp_sign exp_value adjusted_exp fixed integer integer_len fraction parsed fmt LC_ALL=C
+  case "${_COST_KIND:-invalid}" in
+    missing)
+      [ "$VL_COST_ALWAYS_SHOW" = 1 ] && [ "${_JSON_OK:-0}" = 1 ] || return 0
+      raw=0
+      ;;
+    scalar) ;;
+    (*) return 0 ;;
+  esac
+
+  if [ "${_COST_KIND:-invalid}" = scalar ]; then
+    [ "${#raw}" -le 128 ] || return 0
+    [[ "$raw" =~ ^\ *[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)([eE][+-]?[0-9]+)?\ *$ ]] || return 0
+    trimmed="${raw#"${raw%%[! ]*}"}"
+    trimmed="${trimmed%"${trimmed##*[! ]}"}"
+    raw="$trimmed"
+    significand="${trimmed%%[eE]*}"
+    case "$significand" in (*[1-9]*) lexical_nonzero=1 ;; (*) lexical_nonzero=0 ;; esac
+    case "$trimmed" in (-*) [ "$lexical_nonzero" = 1 ] && return 0 ;; esac
+    case "$trimmed" in *[eE]*) exp_text="${trimmed##*[eE]}" ;; *) exp_text=0 ;; esac
+    case "$exp_text" in
+      (-*) exp_sign=-1; exp_text="${exp_text:1}" ;;
+      (+*) exp_sign=1; exp_text="${exp_text:1}" ;;
+      (*) exp_sign=1 ;;
+    esac
+    exp_text="${exp_text#"${exp_text%%[!0]*}"}"
+    [ -n "$exp_text" ] || exp_text=0
+    [ "${#exp_text}" -le 3 ] || return 0
+    [ "$exp_text" -le 308 ] 2>/dev/null || return 0
+    exp_value=$exp_text
+    [ "$exp_sign" = -1 ] && exp_value=$(( -exp_value ))
+    if [ "$lexical_nonzero" = 1 ]; then
+      unsigned="${significand#[-+]}"
+      case "$unsigned" in (*.*) integer_part="${unsigned%%.*}" ;; (*) integer_part="$unsigned" ;; esac
+      digits="${unsigned/./}"
+      leading_zeroes="${digits%%[1-9]*}"
+      adjusted_exp=$(( exp_value + ${#integer_part} - ${#leading_zeroes} - 1 ))
+      [ "$adjusted_exp" -ge -323 ] || return 0
+      [ "$adjusted_exp" -le 9 ] || return 0
+      if [ "$adjusted_exp" = 9 ]; then
+        significant="${digits:${#leading_zeroes}}"
+        [[ "$significant" =~ ^10*$ ]] || return 0
+      fi
+    fi
+    parsed=""
+    LC_ALL=C printf -v parsed '%.17g' "$raw" 2>/dev/null || :
+    case "$parsed" in (*inf*|*nan*|'') return 0 ;; esac
+    case "$parsed" in (-0) raw=0; parsed=0 ;; (-*) return 0 ;; esac
+    [ "$parsed" = 0 ] && [ "$lexical_nonzero" = 1 ] && return 0
+    fixed=""
+    LC_ALL=C printf -v fixed '%.17f' "$raw" 2>/dev/null || :
+    case "$fixed" in (*inf*|*nan*|'') return 0 ;; esac
+    integer="${fixed%%.*}"
+    integer="${integer#"${integer%%[!0]*}"}"
+    [ -n "$integer" ] || integer=0
+    integer_len=${#integer}
+    [ "$integer_len" -le 10 ] || return 0
+    [ "$integer_len" -ne 10 ] || { [ "$integer" \> 1000000000 ] && return 0; }
+    if [ "$integer" = 1000000000 ]; then
+      fraction="${fixed#*.}"
+      case "$fraction" in *[1-9]*) return 0 ;; esac
+    fi
+    [ "$parsed" = 0 ] && { [ "$VL_COST_ALWAYS_SHOW" = 1 ] && [ "${_JSON_OK:-0}" = 1 ] || return 0; raw=0; }
+  fi
+
+  fmt=""
+  LC_ALL=C printf -v fmt "\$%.${VL_COST_DECIMALS}f" "$raw" 2>/dev/null || :
+  [ -n "$fmt" ] || return 0
   fg "$VL_FG_TEXT"
   push "$VL_BG_COST" "${_FG} ${fmt} "
 }
@@ -1720,30 +1792,60 @@ fi
 # ── Parse JSON (single jq call) ──────────────────────────────────────────────
 # Fields are joined with \x1f (unit separator): unlike tab, a non-whitespace
 # IFS preserves empty fields instead of collapsing consecutive delimiters.
-IFS=$'\037' read -r cwd model ctx_pct tok_in tok_out tok_cr tok_cw \
-                 fh_pct fh_rst wd_pct wd_rst cost \
-                 lines_add lines_del out_style dur_ms effort <<JSON
-$(printf '%s' "$input" | jq -r '
+_JSON_OK=0; _CTX_EMPTY=0; _COST_KIND=invalid; _JSON_FIELDS=""
+if _JSON_FIELDS=$(printf '%s' "$input" | jq -r '
   def scrub: tostring | gsub("[\\x00-\\x1f\\x7f\u0080-\u009f]"; "");
+  def member($obj; $name):
+    if ($obj|type) == "object" and ($obj|has($name)) then $obj[$name] else null end;
+  def ctx_value:
+    member(member(.; "context_window"); "used_percentage") as $value |
+    if ($value|type) == "number" or ($value|type) == "string" then $value else null end;
+  def ctx_empty:
+    (member(.; "context_window")) as $ctx |
+    if $ctx == null then true
+    elif ($ctx|type) != "object" then false
+    elif (($ctx|has("used_percentage")) == false) then true
+    else (($ctx.used_percentage == null) or (($ctx.used_percentage|type) == "string" and $ctx.used_percentage == "")) end;
+  def cost_value:
+    member(member(.; "cost"); "total_cost_usd");
+  if type != "object" then error("non-object root") else
   [
-    (.workspace.current_dir // .cwd // ""),
-    (.model.display_name // ""),
-    (.context_window.used_percentage // "" | tostring),
-    (.context_window.total_input_tokens // 0),
-    (.context_window.total_output_tokens // 0),
-    (.context_window.current_usage.cache_read_input_tokens // 0),
-    (.context_window.current_usage.cache_creation_input_tokens // 0),
-    (.rate_limits.five_hour.used_percentage // "" | tostring),
-    (.rate_limits.five_hour.resets_at // "" | tostring),
-    (.rate_limits.seven_day.used_percentage // "" | tostring),
-    (.rate_limits.seven_day.resets_at // "" | tostring),
-    (.cost.total_cost_usd // "" | tostring),
-    (.cost.total_lines_added // 0),
-    (.cost.total_lines_removed // 0),
-    (.output_style.name // ""),
-    (.cost.total_duration_ms // 0),
-    (.effort.level // "")
-  ] | map(scrub) | join("")' 2>/dev/null)
+    (member(member(.; "workspace"); "current_dir") // member(.; "cwd") // ""),
+    (member(member(.; "model"); "display_name") // ""),
+    (ctx_value | if (. == null) or (. == false) then "" else tostring end),
+    (ctx_empty | if . then "1" else "0" end),
+    (member(member(.; "context_window"); "total_input_tokens") // 0),
+    (member(member(.; "context_window"); "total_output_tokens") // 0),
+    (member(member(member(.; "context_window"); "current_usage"); "cache_read_input_tokens") // 0),
+    (member(member(member(.; "context_window"); "current_usage"); "cache_creation_input_tokens") // 0),
+    (member(member(member(.; "rate_limits"); "five_hour"); "used_percentage") // "" | tostring),
+    (member(member(member(.; "rate_limits"); "five_hour"); "resets_at") // "" | tostring),
+    (member(member(member(.; "rate_limits"); "seven_day"); "used_percentage") // "" | tostring),
+    (member(member(member(.; "rate_limits"); "seven_day"); "resets_at") // "" | tostring),
+    (cost_value | if (. == null) or (. == false) then "" else tostring end),
+    ((member(.; "cost")) as $cost |
+      if $cost == null then "missing"
+      elif ($cost|type) != "object" then "invalid"
+      elif (($cost|has("total_cost_usd")) == false) then "missing"
+      else (member($cost; "total_cost_usd")) as $v |
+        if ($v == null) or (($v|type) == "string" and $v == "") then "missing"
+        elif (($v|type) == "string" and (($v|scrub) != $v)) then "invalid"
+        elif (($v|type) == "string") or (($v|type) == "number") then "scalar"
+        else "invalid" end
+      end),
+    (member(member(.; "cost"); "total_lines_added") // 0),
+    (member(member(.; "cost"); "total_lines_removed") // 0),
+    (member(member(.; "output_style"); "name") // ""),
+    (member(member(.; "cost"); "total_duration_ms") // 0),
+    (member(member(.; "effort"); "level") // "")
+  ] | map(scrub) | join("\u001f")
+  end' 2>/dev/null); then
+  _JSON_OK=1
+fi
+IFS=$'\037' read -r cwd model ctx_pct _CTX_EMPTY tok_in tok_out tok_cr tok_cw \
+                 fh_pct fh_rst wd_pct wd_rst cost _COST_KIND \
+                 lines_add lines_del out_style dur_ms effort <<JSON
+$_JSON_FIELDS
 JSON
 
 _SEG_SCAN=" $VL_SEGMENTS $VL_SEGMENTS2 $VL_SEGMENTS3 "

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -582,6 +582,24 @@ esac
     $repoLeaf = [System.IO.Path]::GetFileName($gitRoot)
     $basePayload = New-Payload $cwd
 
+    $compatPayload = Json $basePayload
+    $compatCases = @(
+        [pscustomobject]@{ Name='flags absent'; Lines=@('VL_SEGMENTS=ctx\ cost','VL_CLOCK=off','VL_NOCOLOR=1','VL_COST_DECIMALS=3') },
+        [pscustomobject]@{ Name='flags explicit zero'; Lines=@('VL_SEGMENTS=ctx\ cost','VL_CLOCK=off','VL_NOCOLOR=1','VL_COST_DECIMALS=3','VL_CTX_ALWAYS_SHOW=0','VL_COST_ALWAYS_SHOW=0') }
+    )
+    $compatPs = @{}
+    $compatBash = @{}
+    foreach ($compat in $compatCases) {
+        $config = New-Config ('ctx-cost-compat-' + ($compat.Name -replace ' ', '-')) $compat.Lines
+        $compatPs[$compat.Name] = Invoke-Statusline $compatPayload $config @{} '' 5000
+        $compatBash[$compat.Name] = Invoke-BashStatusline $compatPayload $config @{}
+        Check-Run ('candidate PowerShell ' + $compat.Name) ($compatPs[$compat.Name])
+        Check-Run ('candidate Bash ' + $compat.Name) ($compatBash[$compat.Name])
+        Check-Exact ('candidate ctx/cost differential ' + $compat.Name) ($compatPs[$compat.Name]) ($compatBash[$compat.Name])
+    }
+    Check-Exact 'PowerShell absent and explicit-zero flags are byte exact' ($compatPs['flags absent']) ($compatPs['flags explicit zero'])
+    Check-Exact 'Bash absent and explicit-zero flags are byte exact' ($compatBash['flags absent']) ($compatBash['flags explicit zero'])
+
     $gitParityConfig = New-Config 'git-edge-parity' @('VL_SEGMENTS=git\ project','VL_CLOCK=off')
     $unbornRoot = Join-Path $TempRoot 'empty-repo'
     [void][System.IO.Directory]::CreateDirectory($unbornRoot)
@@ -1439,6 +1457,160 @@ fi
     $tokenRun = Invoke-Statusline (Json $missingTokens) $tokenConfig @{} '' 5000
     Check-Run 'missing token values' $tokenRun
     Check 'missing token values render zero' ((Plain $tokenRun.Stdout).Contains((Glyph 0x2191) + '0 ' + (Glyph 0x2193) + '0 cr:0 cw:0'))
+
+    $ctxCostOffConfig = New-Config 'ctx-cost-matrix-off' @('VL_SEGMENTS=ctx\ cost','VL_CLOCK=off','VL_NOCOLOR=1','VL_COST_DECIMALS=3')
+    $ctxCostOnConfig = New-Config 'ctx-cost-matrix-on' @('VL_SEGMENTS=ctx\ cost','VL_CLOCK=off','VL_NOCOLOR=1','VL_COST_DECIMALS=3','VL_CTX_ALWAYS_SHOW=1','VL_COST_ALWAYS_SHOW=1')
+    $ctxCostMatrix = @(
+        [pscustomobject]@{ Name='missing'; Raw='{}'; OffCtx=$false; OffCost=$false; OnCtx=$true; OnCost=$true },
+        [pscustomobject]@{ Name='null parents'; Raw='{"context_window":null,"cost":null}'; OffCtx=$false; OffCost=$false; OnCtx=$true; OnCost=$true },
+        [pscustomobject]@{ Name='null leaves'; Raw='{"context_window":{"used_percentage":null},"cost":{"total_cost_usd":null}}'; OffCtx=$false; OffCost=$false; OnCtx=$true; OnCost=$true },
+        [pscustomobject]@{ Name='empty'; Raw='{"context_window":{"used_percentage":""},"cost":{"total_cost_usd":""}}'; OffCtx=$false; OffCost=$false; OnCtx=$true; OnCost=$true },
+        [pscustomobject]@{ Name='zero'; Raw='{"context_window":{"used_percentage":0,"total_input_tokens":0,"total_output_tokens":0,"current_usage":{"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"cost":{"total_cost_usd":0}}'; OffCtx=$true; OffCost=$false; OnCtx=$true; OnCost=$true }
+    )
+    foreach ($case in $ctxCostMatrix) {
+        $offPs = Invoke-Statusline $case.Raw $ctxCostOffConfig @{} '' 5000
+        $offBash = Invoke-BashStatusline $case.Raw $ctxCostOffConfig @{}
+        $onPs = Invoke-Statusline $case.Raw $ctxCostOnConfig @{} '' 5000
+        $onBash = Invoke-BashStatusline $case.Raw $ctxCostOnConfig @{}
+        Check-Run ('PowerShell ctx/cost matrix off ' + $case.Name) $offPs
+        Check-Run ('Bash ctx/cost matrix off ' + $case.Name) $offBash
+        Check-Run ('PowerShell ctx/cost matrix on ' + $case.Name) $onPs
+        Check-Run ('Bash ctx/cost matrix on ' + $case.Name) $onBash
+        Check-Exact ('ctx/cost matrix off differential ' + $case.Name) $offPs $offBash
+        Check-Exact ('ctx/cost matrix on differential ' + $case.Name) $onPs $onBash
+        $offText = Plain $offPs.Stdout
+        $onText = Plain $onPs.Stdout
+        Check ('ctx/cost matrix off ctx semantics ' + $case.Name) (($offText.Contains('0%') -and $offText.Contains((Glyph 0x2191) + '0 ' + (Glyph 0x2193) + '0 cr:0 cw:0')) -eq $case.OffCtx)
+        Check ('ctx/cost matrix off cost semantics ' + $case.Name) (($offText.Contains('$0.000')) -eq $case.OffCost)
+        Check ('ctx/cost matrix on ctx semantics ' + $case.Name) (($onText.Contains('0%') -and $onText.Contains((Glyph 0x2191) + '0 ' + (Glyph 0x2193) + '0 cr:0 cw:0')) -eq $case.OnCtx)
+        Check ('ctx/cost matrix on cost semantics ' + $case.Name) (($onText.Contains('$0.000')) -eq $case.OnCost)
+    }
+
+    $invalidParentMatrix = @(
+        [pscustomobject]@{ Name='context parent bool'; Raw='{"context_window":false}'; Ctx=$false; Cost=$true },
+        [pscustomobject]@{ Name='context parent array'; Raw='{"context_window":[]}'; Ctx=$false; Cost=$true },
+        [pscustomobject]@{ Name='context leaf bool'; Raw='{"context_window":{"used_percentage":false}}'; Ctx=$false; Cost=$true },
+        [pscustomobject]@{ Name='context leaf array'; Raw='{"context_window":{"used_percentage":[1]}}'; Ctx=$false; Cost=$true },
+        [pscustomobject]@{ Name='context leaf object'; Raw='{"context_window":{"used_percentage":{}}}'; Ctx=$false; Cost=$true },
+        [pscustomobject]@{ Name='context leaf float text'; Raw='{"context_window":{"used_percentage":"not-a-percent"}}'; Ctx=$true; Cost=$true },
+        [pscustomobject]@{ Name='cost parent bool'; Raw='{"cost":false}'; Ctx=$true; Cost=$false },
+        [pscustomobject]@{ Name='cost parent array'; Raw='{"cost":[]}'; Ctx=$true; Cost=$false }
+    )
+    foreach ($case in $invalidParentMatrix) {
+        $ps = Invoke-Statusline $case.Raw $ctxCostOnConfig @{} '' 5000
+        $bash = Invoke-BashStatusline $case.Raw $ctxCostOnConfig @{}
+        Check-Run ('PowerShell invalid parent ' + $case.Name) $ps
+        Check-Run ('Bash invalid parent ' + $case.Name) $bash
+        Check-Exact ('invalid parent differential ' + $case.Name) $ps $bash
+        $text = Plain $ps.Stdout
+        Check ('invalid parent ctx semantics ' + $case.Name) (($text.Contains('0%') -and $text.Contains((Glyph 0x2191) + '0 ' + (Glyph 0x2193) + '0 cr:0 cw:0')) -eq $case.Ctx)
+        Check ('invalid parent cost semantics ' + $case.Name) (($text.Contains('$0.000')) -eq $case.Cost)
+        if ($case.Name -eq 'context leaf float text') {
+            Check 'non-empty invalid ctx scalar keeps ordinary 0% parsing' ($text.Contains('0%'))
+        }
+    }
+
+    foreach ($case in @(
+        [pscustomobject]@{ Name='false'; Raw='false' },
+        [pscustomobject]@{ Name='array'; Raw='[]' },
+        [pscustomobject]@{ Name='single-object array'; Raw='[{}]' },
+        [pscustomobject]@{ Name='string'; Raw='"root"' }
+    )) {
+        $ps = Invoke-Statusline $case.Raw $ctxCostOnConfig @{} '' 5000
+        $bash = Invoke-BashStatusline $case.Raw $ctxCostOnConfig @{}
+        Check-Run ('PowerShell non-object root ' + $case.Name) $ps
+        Check-Run ('Bash non-object root ' + $case.Name) $bash
+        Check-Exact ('non-object root differential ' + $case.Name) $ps $bash
+        Check ('non-object root stays silent ' + $case.Name) ($ps.StdoutBytes.Length -eq 0)
+    }
+
+    $malformedCtxCost = '{"context_window":'
+    $malformedOnPs = Invoke-Statusline $malformedCtxCost $ctxCostOnConfig @{} '' 5000
+    $malformedOnBash = Invoke-BashStatusline $malformedCtxCost $ctxCostOnConfig @{}
+    Check-Run 'malformed whole JSON PowerShell always-show' $malformedOnPs
+    Check-Run 'malformed whole JSON Bash always-show' $malformedOnBash
+    Check-Exact 'malformed whole JSON differential is byte exact' $malformedOnPs $malformedOnBash
+    Check 'malformed whole JSON never always-shows' ($malformedOnPs.StdoutBytes.Length -eq 0)
+
+    $costOffConfig = New-Config 'cost-validation-off' @('VL_SEGMENTS=cost','VL_CLOCK=off','VL_NOCOLOR=1','VL_COST_DECIMALS=3')
+    $costOnConfig = New-Config 'cost-validation-on' @('VL_SEGMENTS=cost','VL_CLOCK=off','VL_NOCOLOR=1','VL_COST_DECIMALS=3','VL_COST_ALWAYS_SHOW=1')
+    $validCostCases = @(
+        [pscustomobject]@{ Name='spaced integer'; Literal='" 1 "'; Expected='$1.000'; Zero=$false },
+        [pscustomobject]@{ Name='explicit plus'; Literal='"+1"'; Expected='$1.000'; Zero=$false },
+        [pscustomobject]@{ Name='leading decimal'; Literal='".5"'; Expected='$0.500'; Zero=$false },
+        [pscustomobject]@{ Name='trailing decimal'; Literal='"1."'; Expected='$1.000'; Zero=$false },
+        [pscustomobject]@{ Name='leading zero integer'; Literal='"01"'; Expected='$1.000'; Zero=$false },
+        [pscustomobject]@{ Name='positive exponent'; Literal='"1e+2"'; Expected='$100.000'; Zero=$false },
+        [pscustomobject]@{ Name='exact maximum'; Literal='"1000000000"'; Expected='$1000000000.000'; Zero=$false },
+        [pscustomobject]@{ Name='exponent-equivalent maximum'; Literal='"0.1e10"'; Expected='$1000000000.000'; Zero=$false },
+        [pscustomobject]@{ Name='minimum normalized exponent'; Literal='"0.000000000000001e-308"'; Expected='$0.000'; Zero=$false },
+        [pscustomobject]@{ Name='string negative zero'; Literal='"-0"'; Zero=$true },
+        [pscustomobject]@{ Name='string negative decimal zero'; Literal='"-0.0"'; Zero=$true },
+        [pscustomobject]@{ Name='string negative exponent zero'; Literal='"-0e10"'; Zero=$true },
+        [pscustomobject]@{ Name='number negative zero'; Literal='-0'; Zero=$true },
+        [pscustomobject]@{ Name='number negative decimal zero'; Literal='-0.0'; Zero=$true },
+        [pscustomobject]@{ Name='number negative exponent zero'; Literal='-0e10'; Zero=$true },
+        [pscustomobject]@{ Name='large exponent zero'; Literal='"0e308"'; Zero=$true },
+        [pscustomobject]@{ Name='128-character zero'; Literal=('"' + (('0' * 128) -join '') + '"'); Zero=$true }
+    )
+    foreach ($case in $validCostCases) {
+        $raw = '{"cost":{"total_cost_usd":' + $case.Literal + '}}'
+        $offPs = Invoke-Statusline $raw $costOffConfig @{} '' 5000
+        $offBash = Invoke-BashStatusline $raw $costOffConfig @{}
+        $onPs = Invoke-Statusline $raw $costOnConfig @{} '' 5000
+        $onBash = Invoke-BashStatusline $raw $costOnConfig @{}
+        Check-Run ('PowerShell valid cost ' + $case.Name) $offPs
+        Check-Run ('Bash valid cost ' + $case.Name) $offBash
+        Check-Run ('PowerShell valid cost always-show ' + $case.Name) $onPs
+        Check-Run ('Bash valid cost always-show ' + $case.Name) $onBash
+        Check-Exact ('valid cost differential ' + $case.Name) $offPs $offBash
+        Check-Exact ('valid cost always-show differential ' + $case.Name) $onPs $onBash
+        if ($case.Zero) {
+            Check ('valid zero off suppresses ' + $case.Name) ($offPs.StdoutBytes.Length -eq 0)
+            Check ('valid zero on formats positive zero ' + $case.Name) ((Plain $onPs.Stdout).Contains('$0.000'))
+        } else {
+            Check ('valid nonzero off formats expected value ' + $case.Name) ((Plain $offPs.Stdout).Contains($case.Expected))
+            Check ('valid nonzero on formats expected value ' + $case.Name) ((Plain $onPs.Stdout).Contains($case.Expected))
+        }
+    }
+
+    $invalidCostLiterals = @(
+        [pscustomobject]@{ Name='bool'; Literal='false' },
+        [pscustomobject]@{ Name='array'; Literal='[]' },
+        [pscustomobject]@{ Name='object'; Literal='{}' },
+        [pscustomobject]@{ Name='whitespace'; Literal='" "' },
+        [pscustomobject]@{ Name='negative'; Literal='-1' },
+        [pscustomobject]@{ Name='negative-underflow'; Literal='"-0.00000000000000000001e-308"' },
+        [pscustomobject]@{ Name='positive-underflow'; Literal='"0.00000000000000000001e-308"' },
+        [pscustomobject]@{ Name='nan'; Literal='"NaN"' },
+        [pscustomobject]@{ Name='infinity'; Literal='"Infinity"' },
+        [pscustomobject]@{ Name='exponent-overflow-string'; Literal='"1e999"' },
+        [pscustomobject]@{ Name='exponent-overflow-number'; Literal='1e999' },
+        [pscustomobject]@{ Name='fraction-above-range'; Literal='"1000000000.000000001"' },
+        [pscustomobject]@{ Name='exponent-fraction-above-range'; Literal='"0.10000000001e10"' },
+        [pscustomobject]@{ Name='range'; Literal='1000000001' },
+        [pscustomobject]@{ Name='hex'; Literal='"0x10"' },
+        [pscustomobject]@{ Name='partial'; Literal='"1x"' },
+        [pscustomobject]@{ Name='spaced'; Literal='"1 2"' },
+        [pscustomobject]@{ Name='exponent-cap'; Literal='"0e309"' },
+        [pscustomobject]@{ Name='negative-exponent-cap'; Literal='"1e-323"' },
+        [pscustomobject]@{ Name='length-over'; Literal=('"' + (('0' * 129) -join '') + '"') }
+    )
+    foreach ($case in $invalidCostLiterals) {
+        $raw = '{"cost":{"total_cost_usd":' + $case.Literal + '}}'
+        $offPs = Invoke-Statusline $raw $costOffConfig @{} '' 5000
+        $offBash = Invoke-BashStatusline $raw $costOffConfig @{}
+        $onPs = Invoke-Statusline $raw $costOnConfig @{} '' 5000
+        $onBash = Invoke-BashStatusline $raw $costOnConfig @{}
+        Check-Run ('PowerShell invalid cost ' + $case.Name) $offPs
+        Check-Run ('Bash invalid cost ' + $case.Name) $offBash
+        Check-Run ('PowerShell invalid cost always-show ' + $case.Name) $onPs
+        Check-Run ('Bash invalid cost always-show ' + $case.Name) $onBash
+        Check-Exact ('invalid cost differential ' + $case.Name) $offPs $offBash
+        Check-Exact ('invalid cost always-show differential ' + $case.Name) $onPs $onBash
+        Check ('invalid cost off is silent ' + $case.Name) ($offPs.StdoutBytes.Length -eq 0)
+        Check ('invalid cost always-show is silent ' + $case.Name) ($onPs.StdoutBytes.Length -eq 0)
+    }
 
     $largeTokens = Clone-Object $basePayload
     $largeTokens.context_window.total_input_tokens = '9999999999999999'


### PR DESCRIPTION
\`ctx\` and \`cost\` currently disappear entirely whenever their source JSON fields are absent or (for cost) zero - e.g. early in a session before Claude Code has anything to report for either. That's sometimes surprising if you're used to those segments always occupying a fixed spot in the bar.

Two new opt-in config keys, both defaulting to \`'0'\` (today's behavior, unchanged):
- \`VL_CTX_ALWAYS_SHOW=1\` renders \`ctx\` with a 0% bar and zeroed token counts instead of hiding it when \`context_window\` data isn't in the payload.
- \`VL_COST_ALWAYS_SHOW=1\` renders \`cost\` as \`\$0.00\` instead of hiding it when cost is absent or genuinely zero.

Existing configs are unaffected either way.