### PR TITLE
docs: refresh pinned --ref examples from v0.9.1 to v0.13.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -95,7 +95,7 @@ curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.s
 
 This path is non-interactive, so it installs from `main` and skips the version prompt. To
 install a tagged release instead, ask the user which they want and pass `--ref`, e.g.
-`--ref v0.9.1` (latest release) or leave it as `main` (latest development).
+`--ref v0.13.0` (latest release) or leave it as `main` (latest development).
 
 If the user is testing a fork, keep the downloaded installer and runtime files on the same
 repo:

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.s
 
 When run interactively it asks which version to install — the latest tagged release
 (recommended) or `main` (latest development). To skip the prompt, pin one explicitly with
-`--ref`, e.g. `... | bash -s -- --ref v0.9.1` or `--ref main`.
+`--ref`, e.g. `... | bash -s -- --ref v0.13.0` or `--ref main`.
 
 ### Manual
 
@@ -305,7 +305,7 @@ that skepticism is inspection, not trust:
   [install.sh](./install.sh); PowerShell-only Windows uses [install.ps1](./install.ps1).
   [INSTALL.md](./INSTALL.md) routes the AI between them. The PowerShell bootstrap is not
   `irm | iex`: it bounds and parses a temporary installer, then launches it as a file.
-- **Pin a release.** `... | bash -s -- --ref v0.9.1` installs a tagged release instead of
+- **Pin a release.** `... | bash -s -- --ref v0.13.0` installs a tagged release instead of
   `main`, so what you audited is what you run. The interactive installer already offers the
   latest tag by default.
 - **What gets written, exactly:** Bash setup writes its runtime, your approved config, and

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -155,7 +155,7 @@ curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.s
 ```
 
 互動執行時會詢問要裝哪個版本 —— 最新的 release tag（建議）或 `main`（最新開發版）。
-想略過詢問就用 `--ref` 直接指定，例如 `... | bash -s -- --ref v0.9.1` 或 `--ref main`。
+想略過詢問就用 `--ref` 直接指定，例如 `... | bash -s -- --ref v0.13.0` 或 `--ref main`。
 
 ### 手動安裝
 
@@ -285,7 +285,7 @@ curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.s
   [install.ps1](./install.ps1)，[INSTALL.md](./INSTALL.md) 負責替 AI 判斷路徑。
   PowerShell bootstrap 不是 `irm | iex`：它會限制下載大小、先解析暫存 installer，
   再把它當檔案啟動。
-- **釘選版本。** `... | bash -s -- --ref v0.9.1` 安裝打過 tag 的 release 而非 `main`，
+- **釘選版本。** `... | bash -s -- --ref v0.13.0` 安裝打過 tag 的 release 而非 `main`，
   你審過的就是你跑的。互動式安裝本來就預設建議最新 tag。
 - **確切會寫入什麼：** Bash 流程會依前述規則寫入 runtime、經你同意的 config 與
   Claude settings。原生 installer 只會在 `~/.claude/coralline` 寫入


### PR DESCRIPTION
The `--ref` examples showing how to pin the installer to a tagged release were still quoting `v0.9.1`, four releases behind the current `v0.13.0` tag.

| File | Line | Context |
|---|---|---|
| README.md | 168 | Skipping the interactive version prompt |
| README.md | 308 | "Pin a release" bullet, audit-before-you-run section |
| README.zh-TW.md | 158, 288 | The parallel passages |
| INSTALL.md | 98 | Non-interactive AI-driven install path |

INSTALL.md is the only one that was outright wrong rather than merely stale. It annotates the example as `--ref v0.9.1` (latest release), so an agent following that document verbatim installs a four-release-old runtime while believing it installed the newest. The README occurrences are illustrative, so they were misleading rather than incorrect.

Nothing in `install.sh`, `install.ps1`, or `configure.sh` needed to change: none carries a default ref of its own, the interactive installer resolves the latest tag at run time, and the documented default for the non-interactive path is still `main`.

The version numbers in BENCHMARK.md and BENCHMARK.zh-TW.md are deliberately untouched. Those name the specific commits and tags an experiment ran against, so they are historical records rather than examples to copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvmMkHPVJjwREkUg3Lan6f