### PR TITLE
docs: condense bilingual READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,16 @@ Passing `--ref <SHA>` to an installer already downloaded from `main` pins only t
 
 ```bash
 SHA=YOUR_AUDITED_40_CHARACTER_COMMIT_SHA
-curl -fsSL "https://raw.githubusercontent.com/Nanako0129/coralline/$SHA/install.sh" | bash -s -- --ref "$SHA"
+audit_dir=$(mktemp -d "${TMPDIR:-/tmp}/coralline-audit.XXXXXX") || exit 1
+(
+  set -o pipefail
+  trap 'cd / && rm -rf "$audit_dir"' EXIT
+  cd "$audit_dir" || exit 1
+  curl -fsSL "https://raw.githubusercontent.com/Nanako0129/coralline/$SHA/install.sh" | bash -s -- --ref "$SHA"
+)
 ```
 
-Bash `--install-only` and updates do not edit `coralline.conf`; the wizard or AI changes it only after showing and receiving approval for the proposed change. Bash backs up `settings.json` and performs a semantic `jq` merge, so unrelated settings are retained but original formatting is not promised. The native installer follows the narrower managed/unmanaged boundary described above. Both renderers make no network requests after installation.
+The unique temporary directory prevents stdin-executed Bash from treating a surrounding coralline checkout as its local source. Bash `--install-only` and updates do not edit `coralline.conf`; the wizard or AI changes it only after showing and receiving approval for the proposed change. Bash backs up `settings.json` and performs a semantic `jq` merge, so unrelated settings are retained but original formatting is not promised. The native installer follows the narrower managed/unmanaged boundary described above. Both renderers make no network requests after installation.
 
 ## Configuration
 
@@ -186,7 +192,7 @@ Or update a Bash install directly:
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash -s -- --install-only
 ```
 
-The URLs above fetch mutable `main` playbook or bootstrap code. The Bash installer keeps `main` in non-interactive runs. In an interactive `--install-only` run, it asks which payload ref to install and defaults to the latest tagged release when that tag can be resolved; if release lookup fails, it keeps `main` without prompting. Pass `--ref main` to request the development payload explicitly. A previously pinned install does not make a later unpinned update immutable. For an audited update, fetch `UPGRADE.md` from one reviewed 40-character SHA, use `install.sh` from that same SHA, and pass the same SHA through `--ref`. Re-run the native bootstrap with the same selected ref for PowerShell-only Windows. The installer reports new opt-ins but preserves existing choices unless approved; see [issue #31](https://github.com/Nanako0129/coralline/issues/31) and the current [`UPGRADE.md`](./UPGRADE.md).
+The URLs above fetch mutable `main` playbook or bootstrap code. The Bash installer keeps `main` in non-interactive runs. In an interactive `--install-only` run, it asks which payload ref to install and defaults to the latest tagged release when that tag can be resolved; if release lookup fails, it keeps `main` without prompting. Pass `--ref main` to request the development payload explicitly. A previously pinned install does not make a later unpinned update immutable. For an audited update, fetch `UPGRADE.md` from one reviewed 40-character SHA, then run `install.sh` from that same SHA and a neutral temporary directory as above, passing the same SHA through `--ref`. Re-run the native bootstrap with the same selected ref for PowerShell-only Windows. The installer reports new opt-ins but preserves existing choices unless approved; see [issue #31](https://github.com/Nanako0129/coralline/issues/31) and the current [`UPGRADE.md`](./UPGRADE.md).
 
 ### Reconfigure
 

--- a/README.md
+++ b/README.md
@@ -1,143 +1,46 @@
 # coralline
 
-> A [Powerlevel10k](https://github.com/romkatv/powerlevel10k)-inspired statusline for Claude
-> Code with one installer entrypoint for humans and AI: run it directly, or ask Claude to run
-> it and handle the setup for you.
+> A [Powerlevel10k](https://github.com/romkatv/powerlevel10k)-inspired statusline for Claude Code, with native Bash and Windows PowerShell renderers.
 
 [繁體中文說明](./README.zh-TW.md)
 
-![All six coralline themes rendered side by side](./assets/hero.png)
+![The original six coralline themes rendered side by side](./assets/hero.png)
 
 ## What you get
 
-```text
-╭ ~/side-project/coralline  ⬢ coralline  ⎇ main+!  ◆ Fable 5  ψ high  ⬡ ▰▰▰▱▱ 62% ↑1.2M ↓45.6k  5h ▰▰▱▱▱ 41% ↺2h44m  7d ▰▰▰▰▱ 79% ↺1d11h  +321 −87  $1.23  ✎ Explanatory  ⧖ 47m  ⚑ 1  ⊙ 02:45 pm ╮
-```
-
-| Segment | Shows |
-|---|---|
-| `dir` | current directory, long paths collapsed to `~/a/…/z` |
-| `project` | repo name (`⬢`), stable across every worktree; hidden outside a git repo |
-| `git` | branch, staged `+` / modified `!` / untracked `?`, ahead `⇡` behind `⇣` |
-| `node` | active Node version (Nerd Font `nf-dev-nodejs_small`) from `.nvmrc` / `.node-version` (or `node` on `PATH` with `VL_RUNTIME_PROBE=1`); hidden when undetected; opt-in |
-| `python` | active Python env (Nerd Font `nf-dev-python`) — `$VIRTUAL_ENV` / conda (skips `base`) / `.python-version` (or `python3` on `PATH` with `VL_RUNTIME_PROBE=1`); hidden when undetected; opt-in |
-| `model` | active Claude model |
-| `effort` | reasoning effort level (`ψ`) — `low` / `med` / `high` / `xhigh` / `max` |
-| `ctx` | context-window gauge, input/output/cache token counts |
-| `limit5h` / `limit7d` | rate-limit gauges with reset countdown |
-| `burn` | range-to-empty: projected time until the binding limit (5h or 7d) hits 100% at the recent burn rate (`↗`); opt-in by adding `burn` to `VL_SEGMENTS` |
-| `lines` | lines added/removed this session |
-| `cost` | session cost in USD |
-| `style` | active output style |
-| `duration` | session wall-clock duration |
-| `stash` | git stash count |
-| `clock` | time, 12h or 24h |
-
-Gauges change color as they fill: green → yellow at 50% → red at 75% (thresholds configurable).
-
-## Subagent panel
-
-Claude Code shows an agent panel below the prompt while subagents run; each row
-defaults to `name · description · token count`. coralline can theme the
-**subagent rows** and add the per-task model, a context gauge, and elapsed time:
+This is the runtime default rendered from the bundled sample in a clean `main` worktree:
 
 ```text
- scout · Explore config sources ◆ gpt-5.6-luna ⬡ ▰▰▱▱▱ 21% 42.0k ⧖ 2m05s
- executor · Apply R2 fixes ◆ Fable 5 ⬡ ▰▰▰▰▱ 77% 155.0k ⧖ 45s
+ ~/side-project/coralline  ⎇ main  ◆ Fable 5  ⬡ ▰▰▰▱▱ 62% ↑1.2M ↓45.6k cr:98.7k cw:4.3k  5h ▰▰▱▱▱ 41% ↺2h44m  7d ▰▰▰▰▱ 79% ↺1d11h  $1.23  ⊙ 01:37:35 pm 
 ```
 
-![coralline's main statusline above five themed subagent panel rows, one per task status](./assets/subagent-panel.png)
-
-Claude Code v2.1.211 does not include its internal `agentType` role in the
-`subagentStatusLine` payload, but local Agent tasks have a small metadata
-sidecar next to the session transcript. coralline reads that local file without
-starting another process, so roles such as `scout` and `executor` return. The
-row keeps both identity and task label: an explicit per-task `name` is retained
-alongside the role when both exist, followed by `label` or `description`. If the
-sidecar is absent or unreadable, the payload fields still render normally.
-
-The model comes directly from Claude Code's per-task `model` payload field;
-coralline never infers it from the main-session model or the agent role. Known
-Claude IDs are shortened (`claude-haiku-4-5-…` → `Haiku 4.5`), while unknown or
-gateway IDs such as `gpt-5.6-luna` are shown verbatim.
-
-Enable or disable the renderer directly:
-
-```bash
-bash ~/.claude/coralline/configure.sh --subagent-rows=on
-bash ~/.claude/coralline/configure.sh --subagent-rows=off
-```
-
-The setup wizard offers the same toggle. Disabling removes only the
-`subagentStatusLine` entry and preserves every other Claude setting.
-On PowerShell-only Windows, rerun the native one-line installer below with
-`$subagentRows="on"` or `$subagentRows="off"`. Its default
-`$subagentRows="preserve"` leaves any existing `subagentStatusLine` untouched.
-
-Per-task `model` and `contextWindowSize` need Claude Code **v2.1.205+**. Missing
-fields degrade one segment at a time: no model hides only the model segment;
-`tokenCount` still renders as a bare count without `contextWindowSize`; and the
-rest of the row remains themed. Refresh is panel-event-driven rather than a
-fixed one-second poll, so elapsed time changes when Claude Code redraws the
-panel.
-
-Live payloads currently expose no per-task *effort*. coralline does not reuse
-the main-session effort or guess from the role; effort can be added only if
-Claude Code exposes it later. The panel's native **main-session row remains
-visible** because it is outside the `subagentStatusLine` protocol; only the
-subagent rows are replaced and themed.
-
-`VL_SUB_SEGMENTS` (default `"name model ctx elapsed"`) picks and orders the row
-segments. These four are the complete set:
-
-| Segment | Shows | Hidden when |
+| Segment | Default | Shows |
 |---|---|---|
-| `name` | task identity plus task label: explicit `name` and sidecar `agentType` compose when both exist, followed by payload `label` or `description`; `type` is the final fallback; colored by status via `VL_FG_SUB_*` — running: text color, completed: ok, failed: hot, missing/unknown: dim | every source is empty or unavailable |
-| `model` | `◆` model from Claude Code's per-task payload; known Claude IDs are shortened and unknown/gateway IDs are shown verbatim | model not resolved yet, or pre-v2.1.205 |
-| `ctx` | `⬡` context gauge + token count; bare count without `contextWindowSize` | no `tokenCount` |
-| `elapsed` | `⧖` wall-clock since `startTime`, shown to the second (epoch s/ms or UTC ISO) | `startTime` missing or unparseable |
+| `dir` | yes | current directory, with long paths collapsed |
+| `project` | no | repository name, stable across worktrees; hidden outside git |
+| `git` | yes | branch, staged `+`, modified `!`, untracked `?`, ahead `⇡`, behind `⇣` |
+| `node` | no | active Node version from a pin file, or `PATH` with `VL_RUNTIME_PROBE=1`; hidden when undetected |
+| `python` | no | active virtualenv, conda, or pinned Python version, or `PATH` with `VL_RUNTIME_PROBE=1`; hidden when undetected |
+| `model` | yes | active Claude model |
+| `effort` | no | reasoning effort: `low`, `med`, `high`, `xhigh`, or `max` |
+| `ctx` | yes | context gauge and input, output, and cache token counts |
+| `limit5h` | yes | five-hour rate-limit gauge and reset countdown |
+| `limit7d` | yes | seven-day rate-limit gauge and reset countdown |
+| `burn` | no | projected time until the binding 5h or 7d limit reaches 100% |
+| `lines` | no | lines added and removed in this session |
+| `cost` | yes | session cost in USD |
+| `style` | no | active output style |
+| `duration` | no | session wall-clock duration |
+| `stash` | no | git stash count |
+| `clock` | yes | 12- or 24-hour clock |
 
-The renderer shares your config file but reads only the knobs that shape a row:
-`VL_STYLE` with its per-style knobs — the pill caps and separator (`VL_CAP_L`,
-`VL_CAP_R`, `VL_SEP`) and the lean/classic family (`VL_LEAN_SEP`, `VL_LEAN_BG`,
-`VL_LEAN_CAP_L`/`VL_LEAN_CAP_R`, `VL_LEAN_FG`, `VL_BG_BAR`) — `VL_ASCII`,
-`VL_NAME_MAX` (recommended — panel labels are long, and overlong rows are
-clipped from the right, hiding model/ctx first), the gauge knobs
-(`VL_BAR_WIDTH`, `VL_BAR_FILL`, `VL_BAR_EMPTY`, `VL_CTX_GLYPH`, `VL_WARN_PCT`,
-`VL_HOT_PCT`),
-the shared palette (`VL_FG_TEXT`, `VL_FG_DIM`, `VL_FG_OK`, `VL_FG_WARN`,
-`VL_FG_HOT`), the row colors `VL_BG_SUB_NAME` / `VL_BG_SUB_MODEL` /
-`VL_BG_SUB_CTX` / `VL_BG_SUB_ELAPSED` (empty = fall back to `VL_BG_DIR` /
-`VL_BG_MODEL` / `VL_BG_CTX` / `VL_BG_DURATION`), and the name pill's per-status
-text colors `VL_FG_SUB_TEXT` / `VL_FG_SUB_OK` / `VL_FG_SUB_HOT` /
-`VL_FG_SUB_DIM` (empty = fall back to `VL_FG_TEXT` / `VL_FG_OK` / `VL_FG_HOT` /
-`VL_FG_DIM`). The main palette is tuned for the gauge segments' dark ground, so
-the built-in defaults and every bundled theme give the name pill that same dark
-ground via `VL_BG_SUB_NAME` and keep the theme's own light inks; without it the
-completed, failed, and unknown tints drop as low as 1.0:1 on a light pill. The
-targets are checked against both that pill and the uniform bar `VL_STYLE="classic"`
-paints instead. Setting `VL_BG_SUB_NAME=""` restores the light pill.
-Everything else —
-`VL_SEGMENTS*`, layout (`VL_LAYOUT`, `VL_MAX_LINES`, `VL_WRAP_MARGIN`), clock,
-cost, lines, float, limit-sync, burn, git, and the runtime segments — is
-main-bar-only and ignored here. To theme panel rows independently of the main
-bar, point the registration at its own config file. For example, the Bash
-registration can use:
-`CORALLINE_CONFIG=~/.claude/coralline-subagent.conf bash ~/.claude/coralline/statusline.sh --subagent`.
-The native renderer honors the same `CORALLINE_CONFIG` environment variable.
+Gauges change from green to yellow at 50% and red at 75%; both thresholds are configurable.
 
 ## Install
 
-On macOS, Linux, and Windows environments with Bash, the install routes use `install.sh`.
-PowerShell-only Windows uses the recommended native `install.ps1` route under
-[Windows without Git Bash](#windows-without-git-bash). It needs only Windows PowerShell 5.1:
-no Bash, Git, `jq`, WSL, or archive extractor.
+Bash environments on macOS, Linux, and Windows use `install.sh`. Windows without Git Bash or WSL uses the native Windows PowerShell 5.1 path below. Bash requires `jq` and a [Nerd Font](https://www.nerdfonts.com/); set `VL_ASCII=1` for a glyph-free rendering. Git is optional and only enables git-backed segments.
 
-> **Bash requirements:** `jq` and a [Nerd Font](https://www.nerdfonts.com/) terminal. No Nerd
-> Font? Set `VL_ASCII=1` in your config for a glyph-free rendering. The native PowerShell
-> renderer below does not require `jq`.
-
-### Ask Claude (recommended)
+### Ask Claude
 
 Paste this into Claude Code:
 
@@ -147,134 +50,129 @@ fetch https://raw.githubusercontent.com/Nanako0129/coralline/main/INSTALL.md
 and follow the playbook in it.
 ```
 
-Claude checks the environment first. In a Bash environment it uses `install.sh`, interviews
-you, and can open the visual wizard. On PowerShell-only Windows it uses `install.ps1`, which
-installs the native renderer and themes but does not provide a wizard or create
-`coralline.conf`.
+Claude routes by environment, asks before changing preferences, and uses the appropriate installer. This fetches a mutable `main/INSTALL.md`; review it first or pin the playbook, installer, and payload to the same audited commit as described under [Trust and security](#trust-and-security).
 
-If your Claude flags the playbook and wants to inspect things first, that is the right
-instinct, not an obstacle: see [Trust and security](#trust-and-security).
+### Bash
 
-### Install it yourself
-
-Run the Bash installer in your terminal:
+Run the interactive installer:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
 ```
 
-When run interactively it asks which version to install — the latest tagged release
-(recommended) or `main` (latest development). To skip the prompt, pin one explicitly with
-`--ref`, e.g. `... | bash -s -- --ref v0.13.0` or `--ref main`.
-
-### Manual
-
-```bash
-git clone https://github.com/Nanako0129/coralline ~/.claude/coralline-src
-mkdir -p ~/.claude/coralline/themes
-cp ~/.claude/coralline-src/statusline.sh ~/.claude/coralline/
-cp ~/.claude/coralline-src/configure.sh ~/.claude/coralline/
-cp ~/.claude/coralline-src/install.sh ~/.claude/coralline/
-cp ~/.claude/coralline-src/themes/claude-coral.conf ~/.claude/coralline/themes/
-```
-
-Then add to `~/.claude/settings.json`:
-
-```json
-{
-  "statusLine": {
-    "type": "command",
-    "command": "bash ~/.claude/coralline/statusline.sh",
-    "refreshInterval": 1
-  }
-}
-```
-
-> **Note:** the commands above copy only the `claude-coral` theme. The Ask-Claude and one-line
-> installers bundle every theme; after a manual install, copy the rest of
-> `~/.claude/coralline-src/themes/*.conf` into `~/.claude/coralline/themes/` to switch themes.
+It recommends the latest tagged release or lets you choose mutable `main`. Skip the prompt with `--ref v0.13.0` or another ref. If the one-line path cannot run, use the [manual fallback in `INSTALL.md`](./INSTALL.md#manual-fallback).
 
 ### Windows without Git Bash
 
-`statusline.sh` needs a bash to run it, so a PowerShell-only Windows machine (no Git for
-Windows, no WSL) cannot use it at all — `install.sh` is itself a bash script. `statusline.ps1` is
-a native Windows PowerShell 5.1 port that needs neither: no bash, no `jq`, only `git.exe` on
-`PATH` for the `git`/`stash`/`project` segments (already required for those segments in the bash
-version too).
+`statusline.ps1` is the native Windows PowerShell 5.1 renderer. It needs no Bash, `jq`, WSL, archive extractor, or Git; `git.exe` is optional and only enables `git`, `stash`, and `project`. It supports the same main segments, styles, layouts, state-backed features, float output, and themed subagent rows as Bash.
 
-It reads the exact same `~/.claude/coralline.conf` (and theme file) a bash install already
-wrote, so nothing about the config format changes; only the renderer is new. The native main
-bar supports the same segments, `pill`/`lean`/`classic` styles, `fixed`/`auto` layouts, burn
-history, limit sync, float publication, and themed `--subagent` panel rows as the bash
-renderer.
-
-The following is the **mutable `main`** one-line installer. It resolves `main` to a commit SHA,
-downloads `install.ps1` from that SHA with a bounded `HttpWebRequest`, parses it before
-execution, and launches the absolute `$PSHOME\powershell.exe` with the same SHA:
+The following bootstrap follows mutable `main`, resolves it to a commit before downloading executable installer code, then passes the same commit to `install.ps1`:
 
 ```powershell
 & { $ErrorActionPreference='Stop';$repo='Nanako0129/coralline';$ref='main';$subagentRows="preserve";if($subagentRows -cnotin @("preserve","on","off")){throw "invalid SubagentRows"};if($repo -notmatch '^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})/[A-Za-z0-9._-]{1,100}$' -or $ref -notmatch '^[A-Za-z0-9][A-Za-z0-9._/-]*$' -or $ref.Length -gt 200 -or $ref.Contains('..') -or $ref.Contains('//') -or $ref.Contains('@{') -or $ref.EndsWith('/') -or $ref.EndsWith('.') -or $ref -match '(?i)(^|/)[^/]*\.lock($|/)'){throw 'invalid Repo or Ref'};$safe={param([string]$p,[string]$label,[bool]$cmd=$false);if([string]::IsNullOrWhiteSpace($p) -or $p -match '[\x00-\x1f\x7f-\x9f]' -or $p.StartsWith('\\') -or $p.StartsWith('//') -or $p.IndexOf(':',2) -ge 0){throw "$label is not a safe local path"};$full=[IO.Path]::GetFullPath($p).Replace('/','\');$root=[IO.Path]::GetPathRoot($full);if($root -notmatch '^[A-Za-z]:\\$'){throw "$label is not on a local drive"};$drive=New-Object IO.DriveInfo($root);if($drive.DriveType -eq [IO.DriveType]::Network){throw "$label is on a network drive"};if($cmd -and ($full.Contains('"') -or $full.Contains('%') -or $full.Contains('!'))){throw "$label is not cmd-safe"};$current=$root;foreach($part in $full.Substring($root.Length).Split(@([char]'\'),[StringSplitOptions]::RemoveEmptyEntries)){$current=[IO.Path]::Combine($current,$part);$item=Get-Item -LiteralPath $current -Force -ErrorAction SilentlyContinue;if($null -eq $item){break};if(($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0){throw "$label contains a reparse point"}};if($full.Length -gt $root.Length){$full=$full.TrimEnd('\')};return $full};$fetch={param([uri]$uri,[long]$cap,[string]$label);if($uri.Scheme -cne 'https' -or ($uri.Host -cne 'api.github.com' -and $uri.Host -cne 'raw.githubusercontent.com') -or $uri.UserInfo -or $uri.Query -or $uri.Fragment){throw "unexpected $label URI"};$request=[Net.HttpWebRequest]::Create($uri);$request.Method='GET';$request.AllowAutoRedirect=$false;$request.Timeout=15000;$request.ReadWriteTimeout=15000;$request.UserAgent='coralline-bootstrap';$response=$null;try{$response=[Net.HttpWebResponse]$request.GetResponse();if($response.StatusCode -ne [Net.HttpStatusCode]::OK -or $response.ResponseUri.AbsoluteUri -cne $uri.AbsoluteUri){throw "$label request failed or redirected"};if($response.ContentLength -gt $cap){throw "$label Content-Length exceeds limit"};$input=$response.GetResponseStream();$memory=New-Object IO.MemoryStream;try{$buffer=New-Object byte[] 8192;$total=0L;while(($read=$input.Read($buffer,0,$buffer.Length)) -gt 0){$total+=$read;if($total -gt $cap){throw "$label stream exceeds limit"};$memory.Write($buffer,0,$read)};if($response.ContentLength -ge 0 -and $total -ne $response.ContentLength){throw "$label download was truncated"};return ,$memory.ToArray()}finally{if($null -ne $input){$input.Dispose()};$memory.Dispose()}}finally{if($null -ne $response){$response.Dispose()}}};$old=[Net.ServicePointManager]::SecurityProtocol;$tmp=$null;$made=$false;$code=0;try{[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12;$parts=$repo.Split('/');$commit=$ref;if($commit -cnotmatch '^[0-9a-f]{40}$'){$api=[uri]('https://api.github.com/repos/'+[uri]::EscapeDataString($parts[0])+'/'+[uri]::EscapeDataString($parts[1])+'/commits/'+[uri]::EscapeDataString($ref));$strict=New-Object Text.UTF8Encoding($false,$true);try{$payload=$strict.GetString((& $fetch $api 1MB 'commit resolution'))|ConvertFrom-Json}catch{throw ('commit resolution response is invalid: '+$_.Exception.Message)};if($null -eq $payload -or $payload.PSObject.Properties.Name -notcontains 'sha'){throw 'commit resolution response has no sha'};$commit=[string]$payload.sha;if($commit -cnotmatch '^[0-9a-f]{40}$'){throw 'commit resolution returned an invalid sha'}};$uri=[uri]('https://raw.githubusercontent.com/'+[uri]::EscapeDataString($parts[0])+'/'+[uri]::EscapeDataString($parts[1])+'/'+$commit+'/install.ps1');$bytes=& $fetch $uri 1MB 'installer';$tempRoot=& $safe ([IO.Path]::GetTempPath()) 'TEMP';$tmp=& $safe ([IO.Path]::Combine($tempRoot,('coralline-install-'+[guid]::NewGuid().ToString('N')+'.ps1'))) 'installer temp';$output=[IO.File]::Open($tmp,[IO.FileMode]::CreateNew,[IO.FileAccess]::Write,[IO.FileShare]::None);$made=$true;try{$output.Write($bytes,0,$bytes.Length);$output.Flush($true)}finally{$output.Dispose()};$checked=& $safe $tmp 'downloaded installer';if($checked -cne $tmp){throw 'installer temp identity changed'};$tokens=$null;$errors=$null;[void][Management.Automation.Language.Parser]::ParseFile($tmp,[ref]$tokens,[ref]$errors);if($errors.Count -ne 0){throw ('downloaded installer parse failed: '+$errors[0].Message)};$exe=& $safe ([IO.Path]::Combine($PSHOME,'powershell.exe')) 'PowerShell executable' $true;if(-not [IO.File]::Exists($exe)){throw 'trusted powershell.exe is missing'};$psi=New-Object Diagnostics.ProcessStartInfo;$psi.FileName=$exe;$psi.UseShellExecute=$false;$psi.Arguments='-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "'+$tmp+'" -Repo "'+$repo+'" -Ref "'+$commit+'"';$psi.Arguments+=" -SubagentRows "+[char]34+$subagentRows+[char]34;$process=New-Object Diagnostics.Process;$process.StartInfo=$psi;try{if(-not $process.Start()){throw 'installer child did not start'};$process.WaitForExit();$code=$process.ExitCode}finally{$process.Dispose()}}finally{[Net.ServicePointManager]::SecurityProtocol=$old;if($made -and $null -ne $tmp -and [IO.File]::Exists($tmp)){$checked=& $safe $tmp 'installer cleanup';if($checked -cne $tmp){throw 'refusing unexpected cleanup path'};$item=Get-Item -LiteralPath $tmp -Force;if(($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0){throw 'refusing reparse-point cleanup'};[IO.File]::Delete($tmp)}};if($code -ne 0){exit $code} }
 ```
 
-For an audited release or commit, copy the same line and replace only
-`$ref='main'` with `$ref='AUDITED_TAG_OR_40_CHARACTER_COMMIT_SHA'`. A tag names a release but
-can technically be moved; only an audited 40-character commit SHA makes the bootstrap URL
-immutable. The bootstrap resolves a mutable name or tag before downloading executable code,
-then the installer downloads every managed file from that same commit.
+For an audited release or commit, copy the line and replace only `$ref='main'` with the selected tag or 40-character SHA. A branch or tag can move; the bootstrap resolves it before downloading. The native installer manages `statusline.ps1` and the ten shipped themes, precisely merges the top-level `statusLine`, preserves `subagentStatusLine` unless `on` or `off` is explicit, never creates or edits `coralline.conf`, and leaves custom themes, state, and float output outside its replacement set. See the current [`INSTALL.md`](./INSTALL.md) contract and the historical [native installer PR #55](https://github.com/Nanako0129/coralline/pull/55).
 
-`install.ps1` installs `statusline.ps1` plus all ten themes, then losslessly merges the
-exact-case top-level `statusLine` member in `$HOME\.claude\settings.json`. The
-`-SubagentRows preserve|on|off` option leaves `subagentStatusLine` untouched by default,
-registers the native `statusline.ps1 --subagent` command when set to `on`, or removes only
-that exact-case top-level member when set to `off`. It preserves
-`$HOME\.claude\coralline.conf` byte-for-byte and never creates it. Existing runtime and settings
-are backed up with timestamped sibling names when their managed content changes. Installer
-invocations are serialized. Single-file runtime rollback refuses to overwrite concurrent edits and
-retains displaced installer bytes; multi-file rollback fails closed with current files and backups
-left for manual recovery. The exact 11-file payload and merged settings bytes are rechecked before
-reporting success.
-The atomic settings backup is the actual displaced file, so even an open editor handle that writes
-after replacement updates the retained backup instead of losing data. Conflicts observed during
-commit make the installer fail without overwriting the external bytes.
+### Trust and security
 
-Rerun the same command to update. An identical rerun is a true no-op: no managed-file
-replacement, settings rewrite, backup, or timestamp change. PowerShell-only installs do not include a
-wizard; reuse an existing `coralline.conf` or edit one manually.
+The default `main/INSTALL.md`, `main/UPGRADE.md`, and `main/install.sh` URLs are mutable remote inputs. Read the selected [`INSTALL.md`](./INSTALL.md), [`install.sh`](./install.sh), and [`install.ps1`](./install.ps1) before running them.
 
-If the one-line bootstrap cannot run, download a GitHub source archive in the browser, inspect
-it, extract it locally, and run the checked-out installer without network access:
+Passing `--ref <SHA>` to an installer already downloaded from `main` pins only the files it downloads next. To pin the initial Bash installer and its payload to the same audited commit, replace the placeholder below with one reviewed 40-character SHA:
 
-```powershell
-& "$PSHOME\powershell.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File C:\path\to\coralline\install.ps1 -SourceDirectory C:\path\to\coralline -InstallRoot "$HOME\.claude\coralline" -SettingsPath "$HOME\.claude\settings.json" -SubagentRows preserve
+```bash
+SHA=YOUR_AUDITED_40_CHARACTER_COMMIT_SHA
+curl -fsSL "https://raw.githubusercontent.com/Nanako0129/coralline/$SHA/install.sh" | bash -s -- --ref "$SHA"
 ```
 
-All three local-mode paths must be drive-absolute (`C:\...` or `C:/...`); drive-relative forms
-such as `C:folder` are rejected.
+Bash `--install-only` and updates do not edit `coralline.conf`; the wizard or AI changes it only after showing and receiving approval for the proposed change. Bash backs up `settings.json` and performs a semantic `jq` merge, so unrelated settings are retained but original formatting is not promised. The native installer follows the narrower managed/unmanaged boundary described above. Both renderers make no network requests after installation.
 
-Run the wizard-written config from a bash install, or write `~/.claude/coralline.conf` by hand
-(see any file under `themes/` for the shape); both work with `statusline.ps1` unchanged. The
-per-process `ExecutionPolicy Bypass` lets the unsigned local renderer start when the normal
-session default would otherwise be `Restricted`; it does not change any persisted policy, and
-an enforced Group Policy still takes precedence.
+## Configuration
+
+Bash reads `~/.claude/coralline.conf`; the native renderer can read the same file. It is sourced shell syntax, usually starting with one bundled theme:
+
+```bash
+. "$HOME/.claude/coralline/themes/claude-coral.conf"
+```
+
+| Variable | Runtime default | Meaning |
+|---|---|---|
+| `VL_STYLE` | `pill` | `pill`, `lean`, or `classic` |
+| `VL_LAYOUT` | `fixed` | one row per `VL_SEGMENTS*`; `auto` wraps one list responsively |
+| `VL_MAX_LINES` / `VL_WRAP_MARGIN` | `3` / `4` | line cap and right margin for `auto` |
+| `VL_SEGMENTS` | `dir git model ctx limit5h limit7d cost clock` | first row, and the complete list in `auto` |
+| `VL_SEGMENTS2` / `VL_SEGMENTS3` | empty | optional fixed second and third rows |
+| `VL_CLOCK` / `VL_CLOCK_SECONDS` | `12h` / `1` | `12h`, `24h`, or `off`; seconds toggle |
+| `VL_BAR_WIDTH` | `5` | gauge width |
+| `VL_BAR_FILL` / `VL_BAR_EMPTY` | `▰` / `▱` | gauge glyphs |
+| `VL_CTX_GLYPH` / `VL_PROJECT_GLYPH` | `⬡` / `⬢` | context and project glyphs |
+| `VL_PATH_DEPTH` / `VL_NAME_MAX` | `4` / `0` | path collapsing and optional name truncation |
+| `VL_COST_DECIMALS` | `2` | cost precision |
+| `VL_CTX_ALWAYS_SHOW` / `VL_COST_ALWAYS_SHOW` | `0` / `0` | show valid missing/empty context or cost as zero |
+| `VL_WARN_PCT` / `VL_HOT_PCT` | `50` / `75` | gauge color thresholds |
+| `VL_ASCII` | `0` | disable Nerd Font glyphs when `1` |
+| `VL_RUNTIME_PROBE` | `0` | let `node` and `python` probe `PATH` when no pin exists; adds forks per render |
+| `VL_BG_*` / `VL_FG_*` | theme | 256-color index or `"R,G,B"` |
+
+### Layout and styles
+
+`VL_LAYOUT="auto"` measures display columns and wraps up to `VL_MAX_LINES`; Claude Code v2.1.153+ supplies `$COLUMNS`, with a terminal fallback outside Claude Code. The display-width implementation and portability rationale live in [PR #10](https://github.com/Nanako0129/coralline/pull/10).
+
+| Style | Result |
+|---|---|
+| `pill` | powerline pills with per-segment backgrounds |
+| `lean` | flat colored text with optional separators, uniform background, and caps |
+| `classic` | one-word preset for the p10k uniform dark bar and trailing cap ([PR #40](https://github.com/Nanako0129/coralline/pull/40)) |
+
+The installer can import selected style, color, and clock values from `~/.p10k.zsh`; see the [`INSTALL.md` mapping](./INSTALL.md#ai-interview).
+
+### Themes
+
+Bundled themes: `claude-coral`, `catppuccin-mocha`, `nord`, `gruvbox-dark`, `tokyo-night`, `mono`, `dracula`, `lunar-pink`, `reverie`, and `morning-haze`. A theme is a `.conf` file assigning `VL_BG_*` and `VL_FG_*`; the wizard discovers `.conf` files recursively under [`themes/`](./themes/).
+
+## Optional features
+
+### Subagent panel
+
+![coralline's main statusline above themed subagent panel rows](./assets/subagent-panel.png)
+
+Enable or disable themed subagent rows explicitly:
+
+```bash
+bash ~/.claude/coralline/configure.sh --subagent-rows=on
+bash ~/.claude/coralline/configure.sh --subagent-rows=off
+```
+
+Bash install-only and ordinary updates do not add or remove `subagentStatusLine`; only the wizard choice or explicit commands above change it. The native installer defaults to `-SubagentRows preserve`, and changes the setting only with explicit `on` or `off`.
+
+Per-task model and context fields require Claude Code v2.1.205+. On v2.1.211, coralline recovers a missing local `agentType` role from the task sidecar; without the sidecar it still uses payload names and labels. Missing model, context size, token count, or start time hides only the affected segment. Rows redraw on panel events, not a one-second poll; the native main-session row remains, and per-task effort is not inferred. The design and current fallback behavior are traced in [issue #45](https://github.com/Nanako0129/coralline/issues/45) and [PR #44](https://github.com/Nanako0129/coralline/pull/44).
+
+| `VL_SUB_SEGMENTS` value | Shows |
+|---|---|
+| `name` | task identity and label, colored by status |
+| `model` | per-task model |
+| `ctx` | context gauge and token count |
+| `elapsed` | elapsed wall-clock time |
+
+The default order is `name model ctx elapsed`.
+
+### Burn-rate segment
+
+Add `burn` to `VL_SEGMENTS` to show the projected time until the binding 5h or 7d limit reaches 100%. It is off by default; while listed, it samples to `~/.claude/coralline/burn-5h.tsv`, and removing it stops writes. `CORALLINE_BURN_WINDOW` defaults to 600 seconds. The motivation and estimator contract are in [issue #17](https://github.com/Nanako0129/coralline/issues/17).
+
+### Cross-session limit sync (optional)
+
+Set `VL_LIMIT_SYNC=1` to let sessions that redraw share the account's open 5h and 7d windows through `limit-5h.d` and `limit-7d.d`. A session's valid reading always wins its own window; the store wins for a strictly newer window or when the session has no reading, using only a still-open stored window. It is off by default, has no API access, and cannot refresh an idle session. See the original redraw-only contract in [PR #24](https://github.com/Nanako0129/coralline/pull/24) and the no-reading fallback in [PR #64](https://github.com/Nanako0129/coralline/pull/64).
+
+### Float readout (optional)
+
+Set `VL_FLOAT=1` to write a plain-text line to `~/.claude/coralline/float.txt` on each render. The default `VL_FLOAT_SEGMENTS` is `model ctx cost`. coralline ships no display carrier; the file is the integration seam, with an unsupported [iTerm2 example](./example/float-display-iterm2/) included. The design boundary is documented in [issue #15](https://github.com/Nanako0129/coralline/issues/15).
+
+## Update, reconfigure, and uninstall
 
 ### Updating
 
-The two installer-driven routes below update Bash-based installs. Either way your
-`~/.claude/coralline.conf` is preserved and the previous `statusline.sh` is backed up
-under `~/.claude/coralline/` (the 3 newest are kept).
-
-#### PowerShell-only update
-
-Re-run the native one-line under [Windows without Git Bash](#windows-without-git-bash), using
-the same `Repo` and `Ref`. It atomically replaces only managed files whose bytes changed, merges
-the exact managed settings object only when needed, retains timestamped backups, and always
-leaves `~/.claude/coralline.conf` untouched. Unmanaged files already under the runtime directory,
-including burn/limit history, `float.txt`, and custom themes, remain in place and are never part
-of the replacement transaction.
-
-#### Ask Claude (recommended)
-
-Paste this into Claude Code:
+Ask Claude to follow the upgrade playbook:
 
 ```text
 Please update coralline for me:
@@ -282,370 +180,67 @@ fetch https://raw.githubusercontent.com/Nanako0129/coralline/main/UPGRADE.md
 and follow the playbook in it.
 ```
 
-Claude re-runs the installer, reads the "new since your installed copy" report, and
-offers to turn on any new opt-in features for you.
-
-#### Update it yourself
-
-Re-run the installer — it prints a short "new since your installed copy" report when
-something new shipped:
+Or update a Bash install directly:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash -s -- --install-only
 ```
 
-## Trust and security
-
-The Ask-Claude install is a remote document that instructs an AI to run `curl | bash` and
-touch `~/.claude/settings.json`. That shape is exactly what a prompt-injection attack looks
-like, so a Claude that red-flags it before proceeding is behaving correctly. The answer to
-that skepticism is inspection, not trust:
-
-- **Read what runs.** Everything is in this repo. Bash environments use
-  [install.sh](./install.sh); PowerShell-only Windows uses [install.ps1](./install.ps1).
-  [INSTALL.md](./INSTALL.md) routes the AI between them. The PowerShell bootstrap is not
-  `irm | iex`: it bounds and parses a temporary installer, then launches it as a file.
-- **Pin a release.** `... | bash -s -- --ref v0.13.0` installs a tagged release instead of
-  `main`, so what you audited is what you run. The interactive installer already offers the
-  latest tag by default.
-- **What gets written, exactly:** Bash setup writes its runtime, your approved config, and
-  Claude settings as described above. The native installer writes only `statusline.ps1` and
-  ten themes under `~/.claude/coralline`, plus the exact top-level `statusLine` value in
-  `settings.json`. It never creates or edits `coralline.conf`; `subagentStatusLine` is
-  preserved unless the explicit native opt-in or opt-out is selected. Changed existing
-  runtime/settings get timestamped sibling backups.
-- **What runs afterwards:** the registered Bash or PowerShell renderer runs on every prompt
-  and makes zero network requests. The native command quotes the absolute trusted
-  `$PSHOME\powershell.exe` and the absolute renderer path; it never searches the workspace
-  for `powershell.exe`.
-- **Why INSTALL.md addresses the AI:** humans get the visual wizard, AIs get an interview
-  script, so the playbook speaks to the reader that executes it. A document that opens by
-  addressing your AI deserves scrutiny, which is why every artifact it references lives in
-  this repo where both of you can read it first.
-
-### Uninstall
-
-For a Bash-capable install, remove themed subagent rows before deleting the tools:
-
-```bash
-bash ~/.claude/coralline/configure.sh --subagent-rows=off
-rm -rf ~/.claude/coralline ~/.claude/coralline.conf
-```
-
-Then delete the `statusLine` block from `~/.claude/settings.json` (or restore the newest
-`settings.json.bak.*`). If you skipped the first command, also delete `subagentStatusLine`.
-
-For a PowerShell-only native archive install, close Claude Code and back up the settings file:
-
-```powershell
-$settings = Join-Path $HOME '.claude\settings.json'
-Copy-Item -LiteralPath $settings -Destination "$settings.bak.$(Get-Date -Format yyyyMMddHHmmss)"
-notepad.exe $settings
-```
-
-In Notepad, delete the `statusLine` object whose command points to
-`~/.claude/coralline/statusline.ps1`. Also delete `subagentStatusLine` if its command points
-into coralline, then save valid JSON. Finally remove the installed runtime and optional config:
-
-```powershell
-Remove-Item -LiteralPath (Join-Path $HOME '.claude\coralline') -Recurse -Force
-Remove-Item -LiteralPath (Join-Path $HOME '.claude\coralline.conf') -Force -ErrorAction SilentlyContinue
-```
-
-## Setup
-
-Both Bash setup paths use the same installer. Humans run it with no mode and get the visual
-setup. Claude uses it with `--install-only`, then follows `INSTALL.md` to interview you and
-write config. The native PowerShell installer has no wizard and never writes config; it reads
-the same `coralline.conf`, which can come from an existing Bash setup or be written manually.
-
-### Setup modes
-
-| Mode | Use when |
-|---|---|
-| Default | You want the coralline default immediately |
-| Powerlevel10k import | You already have `~/.p10k.zsh` and want to carry over its style, time format, and main colors |
-| Visual wizard | You want to preview themes, style, segments, wrapping, clock, and font compatibility before writing config |
-
-Running the installer yourself with no mode opens the interactive setup. Claude should not
-operate that TUI unless you explicitly ask for visual customization.
+Both default paths use mutable `main`. A previously pinned install does not make a later unpinned update immutable. For an audited update, fetch `UPGRADE.md` from one reviewed 40-character SHA, use `install.sh` from that same SHA, and pass the same SHA through `--ref`. Re-run the native bootstrap with the same selected ref for PowerShell-only Windows. The installer reports new opt-ins but preserves existing choices unless approved; see [issue #31](https://github.com/Nanako0129/coralline/issues/31) and the current [`UPGRADE.md`](./UPGRADE.md).
 
 ### Reconfigure
 
-Both Bash install paths copy the wizard into `~/.claude/coralline`, so Bash-capable users can
-rerun it anytime to restyle:
+Bash-capable installs include the visual wizard:
 
 ```bash
 bash ~/.claude/coralline/configure.sh
 ```
 
-PowerShell-only installs do not include a native wizard. Back up and edit
-`$HOME\.claude\coralline.conf` manually, or reuse a config produced on a Bash-capable host.
+PowerShell-only installs have no native wizard; back up and edit `coralline.conf` manually or reuse one created on a Bash-capable host.
 
-### Testing a fork
+### Uninstall
 
-Point the installer at the same fork:
+The runtime directory can contain custom themes, burn and limit history, `float.txt`, and other unmanaged files. Back up anything you want to keep before deleting it. Also back up the current `~/.claude/settings.json`, then remove `statusLine` or `subagentStatusLine` only if its command still points to coralline; do not restore an old whole-file backup without comparing unrelated changes made since it was created.
+
+For Bash-capable systems, inspect and edit the current settings before removing the runtime:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/YOU/coralline/main/install.sh | bash -s -- --repo YOU/coralline
+settings="$HOME/.claude/settings.json"
+cp "$settings" "$settings.bak.$(date +%Y%m%d%H%M%S)"
+"${EDITOR:-vi}" "$settings"
+rm -rf "$HOME/.claude/coralline"
+# Optional: remove your saved preferences too.
+rm -f "$HOME/.claude/coralline.conf"
 ```
 
-For PowerShell-only Windows, change both `$repo` and `$ref` in the native bootstrap. The
-bootstrap validates them, resolves a mutable ref before downloading `install.ps1`, and passes
-the resulting commit SHA to the installer for the fixed runtime allowlist.
+For PowerShell-only systems:
 
-## Configuration
-
-Everything lives in `~/.claude/coralline.conf` (plain bash, sourced by the script):
-
-| Variable | Default | Meaning |
-|---|---|---|
-| `VL_STYLE` | `pill` | `pill`: powerline pills · `lean`: flat colored text · `classic`: lean on a uniform dark bar (p10k classic) |
-| `VL_LAYOUT` | `fixed` | `fixed`: one line per `VL_SEGMENTS*` var · `auto`: responsive |
-| `VL_MAX_LINES` | `3` | `auto` only — wrap into at most this many lines (`1` = never wrap) |
-| `VL_WRAP_MARGIN` | `4` | `auto` only — columns kept free on the right so segments never touch the edge |
-| `VL_SEGMENTS` | `dir git model ctx limit5h limit7d cost clock` | segments on line 1, in order (the full list in `auto` mode) |
-| `VL_SEGMENTS2` / `VL_SEGMENTS3` | _(empty)_ | `fixed` only — optional second/third line |
-| `VL_CLOCK` | `12h` | `12h` / `24h` / `off` |
-| `VL_CLOCK_SECONDS` | `1` | show seconds in the clock |
-| `VL_BAR_WIDTH` | `5` | gauge width in cells |
-| `VL_BAR_FILL` / `VL_BAR_EMPTY` | `▰` / `▱` | gauge glyphs |
-| `VL_CTX_GLYPH` | `⬡` | glyph for the `ctx` segment |
-| `VL_PROJECT_GLYPH` | `⬢` | glyph for the `project` segment |
-| `VL_PATH_DEPTH` | `4` | collapse paths deeper than this |
-| `VL_NAME_MAX` | `0` | max chars for the `project` / `git` names before `…` truncation (`0` = off) |
-| `VL_COST_DECIMALS` | `2` | decimal places for the cost segment |
-| `VL_CTX_ALWAYS_SHOW` | `0` | `1` = show an object JSON payload's missing, `null`, or exact-empty context value as a 0% gauge with zero token counts; malformed or non-object payloads do not trigger it, and non-empty context values keep normal percentage handling |
-| `VL_COST_ALWAYS_SHOW` | `0` | `1` = show an object JSON payload's missing, `null`, or exact-empty cost as `$0.00`; invalid types and values stay hidden |
-| `VL_WARN_PCT` / `VL_HOT_PCT` | `50` / `75` | gauge color thresholds |
-| `VL_ASCII` | `0` | `1` disables Nerd Font glyphs |
-| `VL_RUNTIME_PROBE` | `0` | `node` / `python`: `1` = also detect via `node` / `python3` on `PATH` when no pin file (forks per render) |
-| `VL_BG_*` / `VL_FG_*` | theme | colors — `256`-color index or `"R,G,B"` |
-
-The four glyph settings above — `VL_BAR_FILL`, `VL_BAR_EMPTY`, `VL_CTX_GLYPH`,
-`VL_PROJECT_GLYPH` — are plain Unicode, not Nerd Font icons, so Nerd Fonts does not patch
-them in and a font that lacks them leaves the substitution to your terminal's own font
-fallback. If the substitute is wider than one cell it shoves the rest of the row out
-of alignment — a squashed gauge, or a missing space before the percentage. Override them
-with characters your terminal font actually carries. `▪` / `▫` for the gauge and `◔` for
-`ctx` are present at exactly one cell in both Meslo and JetBrainsMono Nerd Font:
-
-```sh
-VL_BAR_FILL="▪" ; VL_BAR_EMPTY="▫" ; VL_CTX_GLYPH="◔"
+```powershell
+$settings = Join-Path $HOME '.claude\settings.json'
+Copy-Item -LiteralPath $settings -Destination "$settings.bak.$(Get-Date -Format yyyyMMddHHmmss)"
+notepad.exe $settings
+Remove-Item -LiteralPath (Join-Path $HOME '.claude\coralline') -Recurse -Force
+# Optional: remove your saved preferences too.
+Remove-Item -LiteralPath (Join-Path $HOME '.claude\coralline.conf') -Force -ErrorAction SilentlyContinue
 ```
 
-### Burn-rate segment
+## Platform and performance
 
-![The burn segment in a full statusline, and each of its states](./assets/burn-segment.png)
-
-Off by default. Add `burn` to `VL_SEGMENTS` to show a "range to empty" — the projected
-time until whichever rate limit (5h or 7d) binds first, e.g. `↗ 5h ⇢ 1h58m`. Keys:
-`CORALLINE_BURN_WINDOW` (recent-slope lookback, default 600s), `VL_BURN_GLYPH` (default
-`↗`), `VL_BG_BURN` (defaults to the 5h background). While `burn` is in the segment list,
-coralline writes samples to `~/.claude/coralline/burn-5h.tsv`; drop it from the list and
-nothing is written.
-
-The ETA is coloured by urgency against the window reset, and collapses to a glyph when a
-number would be noise:
-
-| You see | When |
+| Platform | Support |
 |---|---|
-| `↗ 5h ⇢ 1h58m` **red** | you'd empty *before* the window resets |
-| `↗ 5h ⇢ 1h58m` **yellow** | reset and empty are a close call |
-| `↗ 5h ⇢ 1h58m` **green** | the window resets with room to spare |
-| **bright** `↗ ✓` | at this pace a full window can't run dry — a number like `24d15h` would just be noise |
-| **dim** `↗ ✓` | idle: you've stopped burning, nothing in flight |
-| **dim** `↗ …` | warming up: a cold start with no samples yet (deliberately *not* a green check, so a fresh install doesn't read as healthy) |
+| macOS | stock Bash 3.2 |
+| Linux | Bash 4+ / 5 |
+| Windows with Git Bash | Bash renderer |
+| Windows without Git Bash | native Windows PowerShell 5.1 renderer |
 
-The label tells you which limit binds — whichever of `5h`/`7d` will hit 100% soonest.
-`5h` only appears once you're burning hard enough to register at least two integer-%
-steps within the recent window; at a light or steady pace there's no short-term slope to
-fit, so the 7d projection binds and you see `↗ 7d`.
+The renderer is local: no network or API calls and zero token use. The Bash main bar parses its payload with one `jq` call; both renderers use at most one `git status --porcelain=v2 --branch` call per render and no per-field subprocesses. Reproducible measurement guidance is in [BENCHMARK.md](./BENCHMARK.md), introduced in [PR #65](https://github.com/Nanako0129/coralline/pull/65).
 
-### Cross-session limit sync (optional)
+## Support, acknowledgements, and license
 
-`VL_LIMIT_SYNC=1` helps a session that is lagging a window boundary catch up to one that has already rolled over. Each render records its `5h` / `7d` value to a small per-host store (`limit-5h.d` / `limit-7d.d`), and a session that holds a valid but older window follows a stored reading for a newer one. Off by default.
-
-Your own reading always wins your own window. The store is what a session falls back to when it has no reading of its own: the payload carries rate limits only after the session has received an API response, so a freshly started, resumed, or idle session would otherwise draw no gauge at all even though the account-level window is known. The store only ever holds windows that are still open, and a reading stops standing in for the current window once its own window closed more than six hours ago for `5h` or eight days ago for `7d`. Those are the same ceilings that validate a future reset, so they carry the same skew margin over the nominal window.
-
-This exists because Claude Code re-renders a session's statusline only when that session is active, and the rate-limit numbers it passes are that session's last-seen values, so a session lagging a window boundary shows a stale one. It cannot refresh a session that is not redrawing at all.
-
-**Your own reading is never overridden by another session's.** Sync will not replace your reading with a higher one from elsewhere. A percentage can legitimately fall inside a single window (an upstream limit reset, a plan upgrade, any server-side adjustment) and nothing in the payload timestamps an observation, so a stale high reading is indistinguishable from a current one.
-
-The store wins in exactly two cases: it holds a strictly newer window, which is the roll-over catch-up, or you have no reading at all, where there is nothing of yours to prefer and the alternative is drawing no gauge for a window your account is plainly inside. A borrowed value is always for the window that is currently open, because an entry is admitted only while its reset is still ahead and every entry it outranks is retired. It is the highest percentage any session recorded for that window, so it over-estimates while sessions disagree.
-
-> **It only updates on redraw.** It cannot refresh a session that is not redrawing at all, and "latest known" is only as fresh as your most recently active session. coralline has no API access. So this narrows the gap between sessions, it does not make a fully idle bar live.
-
-A single session gains only the fallback, where its own earlier renders keep the gauge populated across a restart or resume; the catch-up needs a second session to catch up to. So it stays opt-in.
-
-### Responsive layout
-
-With `VL_LAYOUT="auto"` the bar stays on a single line while it fits, and greedily wraps into
-up to `VL_MAX_LINES` rows when the window gets narrow. Once the line cap is reached, remaining
-segments overflow on the last line. `VL_WRAP_MARGIN` keeps a few columns free on the right so
-wrapped lines never butt against the window edge — raise it if your terminal adds padding.
-
-Width comes from `$COLUMNS`. Claude Code v2.1.153+ sets `COLUMNS` to the current terminal width
-before running the status line, so wrapping responds to window resizing out of the box. Outside
-Claude Code the script falls back to `stty size` on the controlling terminal; if neither is
-available it stays on one line.
-
-```text
-wide window:    ~/dev/app  ⎇ main  ◆ Fable 5  ⬡ ▰▰▰▱▱ 62%  5h ▰▰▱▱▱ 41%  $1.23  ⊙ 14:45
-
-narrow window:  ~/dev/app  ⎇ main  ◆ Fable 5
-                ⬡ ▰▰▰▱▱ 62%  5h ▰▰▱▱▱ 41%  $1.23  ⊙ 14:45
-```
-
-Prefer a layout that never moves? Keep `VL_LAYOUT="fixed"` and pin rows with
-`VL_SEGMENTS` / `VL_SEGMENTS2` / `VL_SEGMENTS3`.
-
-### Lean style
-
-Prefer Powerlevel10k's *lean* look — no backgrounds, just colored text? Set
-`VL_STYLE="lean"` and each segment's `VL_BG_*` color becomes its text accent instead:
-
-![Lean style compared with pill style](./assets/style-lean.png)
-
-| Variable | Default | Meaning |
-|---|---|---|
-| `VL_STYLE` | `pill` | set to `lean` for the flat look |
-| `VL_LEAN_SEP` | _(empty)_ | extra text between segments, e.g. `·` |
-| `VL_LEAN_FG` | _(empty)_ | force a text color; empty = inherit each segment's accent |
-| `VL_LEAN_BG` | _(empty)_ | paint one uniform background behind the row — `"R,G,B"` or 256 index. For the full p10k *classic* look, prefer the `VL_STYLE="classic"` preset below — it wires this up for you |
-| `VL_LEAN_CAP_R` | _(empty)_ | trailing cap glyph drawn in the `VL_LEAN_BG` color to bevel the bar's end into the terminal (p10k's end separator, e.g. `$''`); needs `VL_LEAN_BG` |
-| `VL_LEAN_CAP_L` | _(empty)_ | leading cap glyph — the left-facing mirror of `VL_LEAN_CAP_R` at the bar's start (e.g. `$''`); needs `VL_LEAN_BG`. Stock p10k *classic* leaves it flat |
-
-> **Tip:** already a p10k user? Tell the AI installer or the visual wizard to import your
-> `~/.p10k.zsh` — it will carry over your style, colors, and time format after you opt in.
-> See the [AI interview notes in INSTALL.md](./INSTALL.md#ai-interview).
-
-### Classic style
-
-Want Powerlevel10k's stock *classic* prompt — one uniform dark bar with colored
-text and a solid end cap? Set `VL_STYLE="classic"`. It's a one-word preset: it
-renders like `lean` on a dark bar (p10k's `POWERLEVEL9K_BACKGROUND`) with a
-trailing powerline cap, no other knobs required.
-
-![Classic style](./assets/style-classic.png)
-
-| Variable | Default | Meaning |
-|---|---|---|
-| `VL_STYLE` | `pill` | set to `classic` for the p10k dark-bar look |
-| `VL_BG_BAR` | _(empty → `238`)_ | the uniform bar color behind the row — `"R,G,B"` or 256 index. Any theme's palette rides this bar; grayscale palettes (e.g. `mono`) want an explicit `VL_BG_BAR` for contrast |
-
-Under the hood `classic` is `lean` plus a `VL_LEAN_BG` (from `VL_BG_BAR`) and a
-`VL_LEAN_CAP_R` end cap, so an explicit `VL_LEAN_BG` or cap still wins. Importing
-a p10k *classic* config carries over your exact bar color and separator.
-
-## Float readout (optional)
-
-`VL_FLOAT=1` makes `statusline.sh` write a one-line **plain-text** readout to
-`~/.claude/coralline/float.txt` on every render (segments from
-`VL_FLOAT_SEGMENTS`, default `model ctx cost`). That's all coralline does —
-it ships **no display carrier**. The file is the seam: pipe it wherever you want
-a glanceable readout that stays visible without looking at Claude Code's bottom
-statusline (a terminal status bar, tmux, a menu-bar app, …).
-
-The readout is **plain text** (no ANSI color), so the default favors stable,
-glance-friendly segments and leaves the color-driven limit warnings
-(`limit5h` / `limit7d`) in the bottom statusline, where threshold colors work.
-You can still add them to `VL_FLOAT_SEGMENTS` if you want the numbers up top.
-
-**Config keys**
-
-| Key | Default | Meaning |
-|---|---|---|
-| `VL_FLOAT` | `0` | `1` = write `float.txt` each render |
-| `VL_FLOAT_SEGMENTS` | `model ctx cost` | segments rendered into the readout (plain text, no color) |
-| `VL_FLOAT_SEP` | `  ·  ` | separator between segments |
-| `VL_FLOAT_FILE` | `~/.claude/coralline/float.txt` | where the readout is written |
-
-(Or toggle `VL_FLOAT` via "float readout" in `configure.sh`'s Details menu.)
-
-A worked iTerm2 carrier (the `coralline-float` companion + setup steps) lives in
-[`example/float-display-iterm2/`](example/float-display-iterm2/) — copy it into
-your dotfiles and adapt. Other terminals (tmux, WezTerm, a menu-bar app, …) just
-need to read `float.txt` the same way.
-
-## Themes
-
-| | |
-|---|---|
-| **`claude-coral`** — steel blue · mauve · Claude coral (default)<br>![claude-coral theme preview](./assets/theme-claude-coral.png) | **`catppuccin-mocha`** — soft pastels on dark<br>![catppuccin-mocha theme preview](./assets/theme-catppuccin-mocha.png) |
-| **`nord`** — arctic frost<br>![nord theme preview](./assets/theme-nord.png) | **`gruvbox-dark`** — warm retro<br>![gruvbox-dark theme preview](./assets/theme-gruvbox-dark.png) |
-| **`tokyo-night`** — neon on deep navy<br>![tokyo-night theme preview](./assets/theme-tokyo-night.png) | **`mono`** — grayscale minimalism<br>![mono theme preview](./assets/theme-mono.png) |
-| **`dracula`** — cyan · pink · purple on charcoal<br>![dracula theme preview](./assets/theme-dracula.png) | **`lunar-pink`** — pink · cyan · yellow on near-black<br>![lunar-pink theme preview](./assets/theme-lunar-pink.png) |
-| **`reverie`** — soft pastels · plum text on warm-dark<br>![reverie theme preview](./assets/theme-reverie.png) | **`morning-haze`** — hazy periwinkle · sage · sandstone on slate<br>![morning-haze theme preview](./assets/theme-morning-haze.png) |
-
-A theme is just a `.conf` file assigning `VL_BG_*` / `VL_FG_*` — copy one, change the colors,
-and source yours from `coralline.conf` instead. PRs with new themes are welcome.
-The wizard discovers themes automatically from `themes/*.conf` and nested collections such as
-`themes/best-themes/*.conf`, so adding a theme file does not require editing `configure.sh`.
-
-> **Adding a theme?** Copy an existing `.conf`, set every `VL_BG_*` / `VL_FG_*`
-> (including `VL_BG_EFFORT`; `VL_BG_BAR` is optional — only grayscale palettes need
-> it, to keep the classic bar readable), keep the `_VL_SUB_*` block at the end
-> (panel-row candidates plus the `_VL_SUB_FP` fingerprint, which lets a config that
-> retints the palette after sourcing your theme fall back safely), add its name to
-> the `THEMES` list in
-> [`tools/render-screenshots.py`](./tools/render-screenshots.py), re-run it to generate
-> `assets/theme-<name>.png`, and add a row to the table above. Please **don't regenerate
-> `hero.png`** — it's a fixed sampler of the original six themes, not a full catalog.
-
-## Platform support
-
-| Platform | Status |
-|---|---|
-| macOS | ✅ supported (works on the stock bash 3.2) |
-| Linux | ✅ supported |
-| Windows + Git Bash | ✅ supported — Claude Code runs the status line through Git Bash when it's installed |
-| Windows without Git Bash | ✅ supported through native Windows PowerShell 5.1 |
-
-> **Windows note:** the native PowerShell renderer needs neither Git Bash nor `jq`. `git.exe`
-> is optional and only enables the `git`, `stash`, and `project` segments. The interactive
-> wizard remains bash-only; main and themed `--subagent` rows are native.
-
-## Why it's fast
-
-The statusline is just a local renderer: it makes no network or API calls and uses zero
-tokens. Claude Code pipes the session JSON to it on stdin and renders whatever it prints.
-
-The main bar runs every second (`refreshInterval: 1`), while subagent rows redraw on panel
-events. The Bash renderer extracts every field with one `jq` call; the native PowerShell
-renderer parses in-process. Both use at most one `git status --porcelain=v2 --branch` call per
-render, and neither launches per-field subprocesses.
-
-How those numbers are produced, and the measurement traps that produced wrong ones along the
-way, is written down in [BENCHMARK.md](./BENCHMARK.md).
-
-## Support coralline
-
-coralline makes no network or API calls and uses zero tokens at runtime. The
-maintenance work is elsewhere: tracking Claude Code payload changes, optional
-live subagent-panel checks, shell regressions, nine-theme screenshot and font
-QA, and installer verification across macOS, Linux, and Windows with Git Bash.
-
-Sponsorship helps cover the Claude access and maintainer time behind that
-compatibility work while coralline remains MIT-licensed and free. If the
-statusline makes your daily sessions clearer, you can support its continued
-development on Patreon.
+If coralline improves your daily sessions, you can support its continued maintenance on Patreon.
 
 [![Support coralline on Patreon](https://img.shields.io/badge/Support_on_Patreon-FF424D?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/cw/Nanako0129/membership)
 
-## Acknowledgements
+coralline's visual language is a tribute to [Powerlevel10k](https://github.com/romkatv/powerlevel10k), the [powerline](https://github.com/powerline/powerline) lineage, and [Nerd Fonts](https://www.nerdfonts.com/).
 
-The visual language of coralline — segmented pills, powerline transitions, the `⇡⇣` git
-glyphs, gauges that shift color as they fill — is a loving tribute to
-[Powerlevel10k](https://github.com/romkatv/powerlevel10k) by
-[@romkatv](https://github.com/romkatv), which set the bar for what a fast, beautiful prompt
-can be. Thanks also to the wider [powerline](https://github.com/powerline/powerline) lineage
-that started it all, and to [Nerd Fonts](https://www.nerdfonts.com/) for the glyphs that make
-the pill shapes possible.
-
-As for the name: coralline algae build reefs one thin, colorful layer at a time —
-and **coral·line** is exactly what this is: a line, in Claude's coral.
-
-## License
-
-[MIT](./LICENSE)
+[MIT License](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Or update a Bash install directly:
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash -s -- --install-only
 ```
 
-Both default paths use mutable `main`. A previously pinned install does not make a later unpinned update immutable. For an audited update, fetch `UPGRADE.md` from one reviewed 40-character SHA, use `install.sh` from that same SHA, and pass the same SHA through `--ref`. Re-run the native bootstrap with the same selected ref for PowerShell-only Windows. The installer reports new opt-ins but preserves existing choices unless approved; see [issue #31](https://github.com/Nanako0129/coralline/issues/31) and the current [`UPGRADE.md`](./UPGRADE.md).
+The URLs above fetch mutable `main` playbook or bootstrap code. The Bash installer keeps `main` in non-interactive runs. In an interactive `--install-only` run, it asks which payload ref to install and defaults to the latest tagged release when that tag can be resolved; if release lookup fails, it keeps `main` without prompting. Pass `--ref main` to request the development payload explicitly. A previously pinned install does not make a later unpinned update immutable. For an audited update, fetch `UPGRADE.md` from one reviewed 40-character SHA, use `install.sh` from that same SHA, and pass the same SHA through `--ref`. Re-run the native bootstrap with the same selected ref for PowerShell-only Windows. The installer reports new opt-ins but preserves existing choices unless approved; see [issue #31](https://github.com/Nanako0129/coralline/issues/31) and the current [`UPGRADE.md`](./UPGRADE.md).
 
 ### Reconfigure
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ bash ~/.claude/coralline/configure.sh --subagent-rows=off
 
 Bash install-only and ordinary updates do not add or remove `subagentStatusLine`; only the wizard choice or explicit commands above change it. The native installer defaults to `-SubagentRows preserve`, and changes the setting only with explicit `on` or `off`.
 
-Per-task model and context fields require Claude Code v2.1.205+. On v2.1.211, coralline recovers a missing local `agentType` role from the task sidecar; without the sidecar it still uses payload names and labels. Missing model, context size, token count, or start time hides only the affected segment. Rows redraw on panel events, not a one-second poll; the native main-session row remains, and per-task effort is not inferred. The design and current fallback behavior are traced in [issue #45](https://github.com/Nanako0129/coralline/issues/45) and [PR #44](https://github.com/Nanako0129/coralline/pull/44).
+Per-task model and context fields require Claude Code v2.1.205+. On v2.1.211, coralline recovers a missing local `agentType` role from the task sidecar; without the sidecar it still uses payload names and labels. Missing model or start time hides only the corresponding segment. `ctx` hides only when token count is missing or invalid; without a valid context size, it still shows the glyph and bare token count while omitting only the gauge and percentage. Rows redraw on panel events, not a one-second poll; the native main-session row remains, and per-task effort is not inferred. The design and current fallback behavior are traced in [issue #45](https://github.com/Nanako0129/coralline/issues/45) and [PR #44](https://github.com/Nanako0129/coralline/pull/44).
 
 | `VL_SUB_SEGMENTS` value | Shows |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -186,13 +186,13 @@ fetch https://raw.githubusercontent.com/Nanako0129/coralline/main/UPGRADE.md
 and follow the playbook in it.
 ```
 
-Or update a Bash install directly:
+Or update a Bash install directly from a directory outside any coralline checkout:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash -s -- --install-only
 ```
 
-The URLs above fetch mutable `main` playbook or bootstrap code. The Bash installer keeps `main` in non-interactive runs. In an interactive `--install-only` run, it asks which payload ref to install and defaults to the latest tagged release when that tag can be resolved; if release lookup fails, it keeps `main` without prompting. Pass `--ref main` to request the development payload explicitly. A previously pinned install does not make a later unpinned update immutable. For an audited update, fetch `UPGRADE.md` from one reviewed 40-character SHA, then run `install.sh` from that same SHA and a neutral temporary directory as above, passing the same SHA through `--ref`. Re-run the native bootstrap with the same selected ref for PowerShell-only Windows. The installer reports new opt-ins but preserves existing choices unless approved; see [issue #31](https://github.com/Nanako0129/coralline/issues/31) and the current [`UPGRADE.md`](./UPGRADE.md).
+The URLs above fetch mutable `main` playbook or bootstrap code. Run the direct updater outside a coralline checkout; inside one, the installer intentionally uses that checkout's files instead of downloading a remote payload. Outside a checkout, the Bash installer keeps `main` in non-interactive runs. In an interactive `--install-only` run, it asks which payload ref to install and defaults to the latest tagged release when that tag can be resolved; if release lookup fails, it keeps `main` without prompting. Pass `--ref main` to request the development payload explicitly. A previously pinned install does not make a later unpinned update immutable. For an audited update, fetch `UPGRADE.md` from one reviewed 40-character SHA, then run `install.sh` from that same SHA and a neutral temporary directory as above, passing the same SHA through `--ref`. Re-run the native bootstrap with the same selected ref for PowerShell-only Windows. The installer reports new opt-ins but preserves existing choices unless approved; see [issue #31](https://github.com/Nanako0129/coralline/issues/31) and the current [`UPGRADE.md`](./UPGRADE.md).
 
 ### Reconfigure
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -186,7 +186,7 @@ and follow the playbook in it.
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash -s -- --install-only
 ```
 
-兩個預設路徑都使用可變的 `main`。先前釘選的安裝，不會讓之後未釘選的更新自動變成 immutable。要做 audited update，請從同一個已檢閱的 40 字元 SHA 抓取 `UPGRADE.md` 與 `install.sh`，並把相同 SHA 傳給 `--ref`。僅有 PowerShell 的 Windows 則以同一個選定 ref 重跑原生 bootstrap。Installer 會報告新的 opt-in，但除非取得同意，否則保留既有選擇；見 [issue #31](https://github.com/Nanako0129/coralline/issues/31) 與現行 [`UPGRADE.md`](./UPGRADE.md)。
+上方 URL 會抓取可變的 `main` playbook 或 bootstrap code。Bash installer 在非互動執行時維持 `main`。互動式 `--install-only` 會在成功解析 latest release tag 時詢問要安裝哪個 payload ref，按 Enter 預設該 release；若 release 查詢失敗，則不提示並維持 `main`。只有明確要開發版 payload 時才傳入 `--ref main`。先前釘選的安裝，不會讓之後未釘選的更新自動變成 immutable。要做 audited update，請從同一個已檢閱的 40 字元 SHA 抓取 `UPGRADE.md` 與 `install.sh`，並把相同 SHA 傳給 `--ref`。僅有 PowerShell 的 Windows 則以同一個選定 ref 重跑原生 bootstrap。Installer 會報告新的 opt-in，但除非取得同意，否則保留既有選擇；見 [issue #31](https://github.com/Nanako0129/coralline/issues/31) 與現行 [`UPGRADE.md`](./UPGRADE.md)。
 
 ### 重新設定
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,135 +1,46 @@
 # coralline
 
-> 給 Claude Code 用、向 [Powerlevel10k](https://github.com/romkatv/powerlevel10k) 致敬的
-> statusline，特色是人類與 AI 共用同一個 installer 入口：你可以直接跑，也可以交給
-> Claude 幫你跑完設定。
+> 給 Claude Code 用、向 [Powerlevel10k](https://github.com/romkatv/powerlevel10k) 致敬的 statusline，同時提供原生 Bash 與 Windows PowerShell renderer。
 
 [English README](./README.md)
 
-![六種 coralline 主題總覽](./assets/hero.png)
+![並排顯示 coralline 最初六個主題](./assets/hero.png)
 
 ## 效果
 
-```text
-╭ ~/side-project/coralline  ⬢ coralline  ⎇ main+!  ◆ Fable 5  ψ high  ⬡ ▰▰▰▱▱ 62% ↑1.2M ↓45.6k  5h ▰▰▱▱▱ 41% ↺2h44m  7d ▰▰▰▰▱ 79% ↺1d11h  +321 −87  $1.23  ✎ Explanatory  ⧖ 47m  ⚑ 1  ⊙ 02:45 pm ╮
-```
-
-| 區段 | 顯示內容 |
-|---|---|
-| `dir` | 目前目錄，過長路徑摺疊為 `~/a/…/z` |
-| `project` | repo 名稱（`⬢`），在所有 worktree 都相同；非 git repo 時隱藏 |
-| `git` | 分支、已暫存 `+` / 已修改 `!` / 未追蹤 `?`、領先 `⇡` 落後 `⇣` |
-| `node` | 目前 Node 版本（Nerd Font `nf-dev-nodejs_small`），來自 `.nvmrc` / `.node-version`（或以 `VL_RUNTIME_PROBE=1` 讀取 `PATH` 上的 `node`）；偵測不到時隱藏；需手動開啟 |
-| `python` | 目前 Python 環境（Nerd Font `nf-dev-python`）—— `$VIRTUAL_ENV` / conda（略過 `base`）/ `.python-version`（或以 `VL_RUNTIME_PROBE=1` 讀取 `PATH` 上的 `python3`）；偵測不到時隱藏；需手動開啟 |
-| `model` | 目前使用的 Claude 模型 |
-| `effort` | 推理強度（`ψ`）—— `low` / `med` / `high` / `xhigh` / `max` |
-| `ctx` | context window 量表、輸入/輸出/快取 token 數 |
-| `limit5h` / `limit7d` | 用量限額量表與重置倒數 |
-| `burn` | 消耗時間預估：根據最近燒耗率推算，何時會達到限額上限（5h 或 7d）100%（`↗`）；把 `burn` 加入 `VL_SEGMENTS` 啟用 |
-| `lines` | 本次 session 修改行數 |
-| `cost` | 本次 session 花費（USD） |
-| `style` | 目前的 output style |
-| `duration` | session 經過時間 |
-| `stash` | git stash 數量 |
-| `clock` | 時鐘，12 或 24 小時制 |
-
-量表會隨用量變色：綠色 → 50% 轉黃 → 75% 轉紅（門檻可調）。
-
-## Subagent 面板
-
-Claude Code 在 subagent 執行時會於 prompt 下方顯示 agent 面板；每列預設為
-`name · description · token count`。coralline 可以為其中的 **subagent 列**
-套用主題，並加入該 task 的 model、context 用量條與執行時間：
+這是以乾淨的 `main` worktree 與內建 sample 實際 render 出來的 runtime 預設值：
 
 ```text
- scout · Explore config sources ◆ gpt-5.6-luna ⬡ ▰▰▱▱▱ 21% 42.0k ⧖ 2m05s
- executor · Apply R2 fixes ◆ Fable 5 ⬡ ▰▰▰▰▱ 77% 155.0k ⧖ 45s
+ ~/side-project/coralline  ⎇ main  ◆ Fable 5  ⬡ ▰▰▰▱▱ 62% ↑1.2M ↓45.6k cr:98.7k cw:4.3k  5h ▰▰▱▱▱ 41% ↺2h44m  7d ▰▰▰▰▱ 79% ↺1d11h  $1.23  ⊙ 01:37:35 pm 
 ```
 
-![coralline 主狀態列，下方是五列套用主題的 subagent 面板列，涵蓋各種 task 狀態](./assets/subagent-panel.png)
-
-Claude Code v2.1.211 沒有把內部的 `agentType` role 放進
-`subagentStatusLine` payload，但本機 Agent task 會在 session transcript
-旁留下小型 metadata sidecar。coralline 會直接讀取這個本機檔案，不會再啟動
-process，因此可恢復 `scout`、`executor` 等 role。列上會同時保留 identity 與
-task label：若另有明確的 per-task `name`，會和 role 一起顯示，後面再接 `label`
-或 `description`。sidecar 不存在或無法讀取時，payload 原有欄位仍會正常顯示。
-
-model 直接取自 Claude Code 傳入的 per-task `model` 欄位；coralline 不會從
-主 session model 或 agent role 推測。已知的 Claude ID 會縮短顯示
-（`claude-haiku-4-5-…` → `Haiku 4.5`），不認得的 ID 或 gateway ID（例如
-`gpt-5.6-luna`）則原樣顯示。
-
-可直接使用以下指令啟用或停用：
-
-```bash
-bash ~/.claude/coralline/configure.sh --subagent-rows=on
-bash ~/.claude/coralline/configure.sh --subagent-rows=off
-```
-
-設定 wizard 提供相同的開關。停用時只會移除 `subagentStatusLine`，其他 Claude
-設定都會保留。
-僅有 PowerShell 的 Windows 請重跑下方原生一行安裝指令，並把
-`$subagentRows` 設為 `"on"` 或 `"off"`。預設的 `"preserve"` 不會改動現有
-`subagentStatusLine`。
-
-每個 task 的 `model` 與 `contextWindowSize` 需要 Claude Code **v2.1.205+**。
-缺少欄位時會逐一降級：沒有 model 只會隱藏 model segment；沒有
-`contextWindowSize` 時，只要有 `tokenCount` 仍會顯示 token 數；其餘列內容
-仍由 coralline 套用主題。更新由 panel event 觸發，不是固定每秒輪詢，因此
-elapsed time 只會在 Claude Code 重繪面板時變動。
-
-目前 live payload 沒有提供 per-task *effort*。coralline 不會沿用主 session
-的 effort，也不會從 role 猜測；只有 Claude Code 未來新增欄位後才能支援。
-面板原生的 **main session 列仍會保留**，因為它不屬於
-`subagentStatusLine` 協定；coralline 只會取代並美化 subagent 列。
-
-`VL_SUB_SEGMENTS`（預設 `"name model ctx elapsed"`）決定列的內容與順序，
-可用的 segment 就是以下四個：
-
-| Segment | 顯示 | 隱藏條件 |
+| 區段 | 預設啟用 | 顯示內容 |
 |---|---|---|
-| `name` | task identity 加 task label：明確 `name` 與 sidecar `agentType` 同時存在時會組合顯示，後接 payload `label` 或 `description`，最後才以 `type` 退回；顏色由 `VL_FG_SUB_*` 反映狀態——running：一般文字色、completed：ok、failed：hot、缺失／未知：dim | 所有來源皆空或無法取得 |
-| `model` | `◆` Claude Code per-task payload 傳入的 model；已知 Claude ID 會縮短，不認得的 ID 或 gateway ID 原樣顯示 | model 尚未 resolve，或 v2.1.205 之前的版本 |
-| `ctx` | `⬡` context 用量條 + token 數；無 `contextWindowSize` 時只顯示 token 數 | 沒有 `tokenCount` |
-| `elapsed` | `⧖` 自 `startTime` 起的執行時間，精確到秒（epoch 秒／毫秒或 UTC ISO） | `startTime` 缺失或無法解析 |
+| `dir` | 是 | 目前目錄，過長路徑會摺疊 |
+| `project` | 否 | repo 名稱，在所有 worktree 都相同；非 git repo 時隱藏 |
+| `git` | 是 | 分支、已暫存 `+`、已修改 `!`、未追蹤 `?`、領先 `⇡`、落後 `⇣` |
+| `node` | 否 | pin 檔指定的 Node 版本，或以 `VL_RUNTIME_PROBE=1` 偵測 `PATH`；偵測不到時隱藏 |
+| `python` | 否 | 目前 virtualenv、conda 或 pin 檔指定的 Python 版本，或以 `VL_RUNTIME_PROBE=1` 偵測 `PATH`；偵測不到時隱藏 |
+| `model` | 是 | 目前使用的 Claude model |
+| `effort` | 否 | 推理強度：`low`、`med`、`high`、`xhigh` 或 `max` |
+| `ctx` | 是 | context 用量條與輸入、輸出、快取 token 數 |
+| `limit5h` | 是 | 五小時額度量表與重置倒數 |
+| `limit7d` | 是 | 七天額度量表與重置倒數 |
+| `burn` | 否 | 綁定中的 5h 或 7d 額度到達 100% 的預估時間 |
+| `lines` | 否 | 本次 session 新增與刪除的行數 |
+| `cost` | 是 | 本次 session 花費（USD） |
+| `style` | 否 | 目前 output style |
+| `duration` | 否 | session 經過時間 |
+| `stash` | 否 | git stash 數量 |
+| `clock` | 是 | 12 或 24 小時制時鐘 |
 
-subagent renderer 與主列共用同一份 config，但只讀取與「單列外觀」有關的參數：
-`VL_STYLE` 及各 style 自己的參數——pill 的圓角與分隔（`VL_CAP_L`、`VL_CAP_R`、
-`VL_SEP`）、lean/classic 家族（`VL_LEAN_SEP`、`VL_LEAN_BG`、
-`VL_LEAN_CAP_L`/`VL_LEAN_CAP_R`、`VL_LEAN_FG`、`VL_BG_BAR`）——`VL_ASCII`、
-`VL_NAME_MAX`（建議設定——面板 label 通常很長，列過寬時 Claude Code 從右側裁切，
-最先消失的就是 model/ctx）、用量條參數（`VL_BAR_WIDTH`、`VL_BAR_FILL`、
-`VL_BAR_EMPTY`、`VL_CTX_GLYPH`、`VL_WARN_PCT`、`VL_HOT_PCT`）、共用色盤（`VL_FG_TEXT`、
-`VL_FG_DIM`、`VL_FG_OK`、`VL_FG_WARN`、`VL_FG_HOT`）、列顏色
-`VL_BG_SUB_NAME` / `VL_BG_SUB_MODEL` / `VL_BG_SUB_CTX` / `VL_BG_SUB_ELAPSED`
-（留空 = 分別退回 `VL_BG_DIR` / `VL_BG_MODEL` / `VL_BG_CTX` /
-`VL_BG_DURATION`），以及 name pill 各狀態的文字顏色 `VL_FG_SUB_TEXT` /
-`VL_FG_SUB_OK` / `VL_FG_SUB_HOT` / `VL_FG_SUB_DIM`（留空 = 分別退回
-`VL_FG_TEXT` / `VL_FG_OK` / `VL_FG_HOT` / `VL_FG_DIM`）。主色盤是為量表區段的深色底
-調的，所以內建預設與所有內建主題都用 `VL_BG_SUB_NAME` 讓 name pill 使用同一種深底，
-文字沿用主題原本的淺色；不這樣做的話，completed、failed、未知這三種色調在亮色 pill 上
-最低只有 1.0:1。對比同時對這個 pill 與 `VL_STYLE="classic"` 改用的整條橫條底色驗證。
-把 `VL_BG_SUB_NAME=""` 設空即可換回亮色 pill。其餘參數——`VL_SEGMENTS*`、版面（`VL_LAYOUT`、
-`VL_MAX_LINES`、`VL_WRAP_MARGIN`）、clock、cost、lines、float、limit-sync、
-burn、git 與 runtime segments——都只作用於主列，在 subagent 模式一律忽略。
-想讓面板列使用與主列不同的主題，把註冊的 command 指向獨立 config 即可。例如
-Bash 註冊可以使用：
-`CORALLINE_CONFIG=~/.claude/coralline-subagent.conf bash ~/.claude/coralline/statusline.sh --subagent`。
-原生 renderer 也會讀取相同的 `CORALLINE_CONFIG` 環境變數。
+量表會從綠色變成 50% 的黃色與 75% 的紅色；兩個門檻都能自訂。
 
 ## 安裝
 
-在 macOS、Linux，以及具有 Bash 的 Windows 環境中，安裝流程使用 `install.sh`。
-僅有 PowerShell 的 Windows 則使用下方[Windows 無 Git Bash](#windows-無-git-bash)
-推薦的原生 `install.ps1` 流程。它只需要 Windows PowerShell 5.1，不需要 Bash、
-Git、`jq`、WSL 或 archive 解壓工具。
+macOS、Linux 與有 Bash 的 Windows 使用 `install.sh`；沒有 Git Bash 或 WSL 的 Windows 使用下方原生 Windows PowerShell 5.1 流程。Bash 需要 `jq` 與 [Nerd Font](https://www.nerdfonts.com/)；設定 `VL_ASCII=1` 可改用無特殊字符的渲染。Git 是選用項目，只用來啟用 git 相關區段。
 
-> **Bash 需求：** `jq` 以及 [Nerd Font](https://www.nerdfonts.com/) 終端機字型。
-> 沒有 Nerd Font 的話，在設定檔加上 `VL_ASCII=1` 改用無特殊字符的渲染。下方原生
-> PowerShell renderer 不需要 `jq`。
-
-### 請 Claude 安裝（推薦）
+### 請 Claude 安裝
 
 把這段貼進 Claude Code：
 
@@ -139,124 +50,129 @@ fetch https://raw.githubusercontent.com/Nanako0129/coralline/main/INSTALL.md
 and follow the playbook in it.
 ```
 
-Claude 會先判斷環境。可使用 Bash 時，它會執行 `install.sh`、訪談外觀偏好，並可開啟
-視覺化 wizard；僅有 PowerShell 的 Windows 則執行 `install.ps1`。原生 installer
-會安裝 renderer 與 themes，但不提供 wizard，也不會建立 `coralline.conf`。
+Claude 會依環境選擇路徑、在更改偏好前詢問，並使用對應 installer。這會抓取可變的 `main/INSTALL.md`；請先檢閱，或依[信任與安全](#信任與安全)把 playbook、installer 與 payload 釘到同一個已稽核 commit。
 
-如果你的 Claude 對這份 playbook 亮紅旗、想先檢查內容，那是正確的直覺而不是阻礙：
-見[信任與安全](#信任與安全)。
+### Bash
 
-### 自己安裝
-
-在 Bash 終端機執行：
+執行互動式 installer：
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
 ```
 
-互動執行時會詢問要裝哪個版本 —— 最新的 release tag（建議）或 `main`（最新開發版）。
-想略過詢問就用 `--ref` 直接指定，例如 `... | bash -s -- --ref v0.13.0` 或 `--ref main`。
-
-### 手動安裝
-
-```bash
-git clone https://github.com/Nanako0129/coralline ~/.claude/coralline-src
-mkdir -p ~/.claude/coralline/themes
-cp ~/.claude/coralline-src/statusline.sh ~/.claude/coralline/
-cp ~/.claude/coralline-src/configure.sh ~/.claude/coralline/
-cp ~/.claude/coralline-src/install.sh ~/.claude/coralline/
-cp ~/.claude/coralline-src/themes/claude-coral.conf ~/.claude/coralline/themes/
-```
-
-接著在 `~/.claude/settings.json` 加入：
-
-```json
-{
-  "statusLine": {
-    "type": "command",
-    "command": "bash ~/.claude/coralline/statusline.sh",
-    "refreshInterval": 1
-  }
-}
-```
-
-> **注意：** 上面的指令只複製 `claude-coral` 一個主題。「請 Claude 安裝」與一行安裝會帶上全部主題；
-> 手動安裝後若要換主題，把 `~/.claude/coralline-src/themes/*.conf` 其餘的也複製進 `~/.claude/coralline/themes/`。
+它會建議最新 release tag，也能選擇可變的 `main`。使用 `--ref v0.13.0` 或其他 ref 可略過詢問。若一行安裝無法執行，使用 [`INSTALL.md` 的 manual fallback](./INSTALL.md#manual-fallback)。
 
 ### Windows 無 Git Bash
 
-`statusline.sh` 本身需要 bash，因此只有 Windows PowerShell 5.1、沒有 Git for Windows
-或 WSL 的電腦無法執行它。`statusline.ps1` 是原生 Windows PowerShell 5.1 renderer，
-不需要 bash 或 `jq`；只有啟用 `git`／`stash`／`project` segments 時才需要 `PATH`
-中有 `git.exe`。
+`statusline.ps1` 是原生 Windows PowerShell 5.1 renderer。它不需要 Bash、`jq`、WSL、archive 解壓工具或 Git；`git.exe` 是選用項目，只用來啟用 `git`、`stash` 與 `project`。它支援和 Bash 相同的主列區段、風格、版面、state-backed 功能、float 輸出與套用主題的 subagent 列。
 
-它會讀取 bash 版本相同的 `~/.claude/coralline.conf` 與 theme 檔。原生主列與 bash
-renderer 支援相同的 segments、`pill`／`lean`／`classic` styles、
-`fixed`／`auto` layouts、burn history、limit sync、float publication 與套用主題的
-`--subagent` 面板列。
-
-以下是會跟隨開發進度的 **mutable `main`** 一行安裝指令。它先把 `main` 解析成
-commit SHA，再以有上限的 `HttpWebRequest` 從該 SHA 下載 `install.ps1`，先解析語法，
-最後透過絕對路徑 `$PSHOME\powershell.exe` 啟動，並傳入相同 SHA：
+以下 bootstrap 會跟隨可變的 `main`，在下載可執行 installer 前先解析成 commit，再把同一個 commit 傳給 `install.ps1`：
 
 ```powershell
 & { $ErrorActionPreference='Stop';$repo='Nanako0129/coralline';$ref='main';$subagentRows="preserve";if($subagentRows -cnotin @("preserve","on","off")){throw "invalid SubagentRows"};if($repo -notmatch '^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})/[A-Za-z0-9._-]{1,100}$' -or $ref -notmatch '^[A-Za-z0-9][A-Za-z0-9._/-]*$' -or $ref.Length -gt 200 -or $ref.Contains('..') -or $ref.Contains('//') -or $ref.Contains('@{') -or $ref.EndsWith('/') -or $ref.EndsWith('.') -or $ref -match '(?i)(^|/)[^/]*\.lock($|/)'){throw 'invalid Repo or Ref'};$safe={param([string]$p,[string]$label,[bool]$cmd=$false);if([string]::IsNullOrWhiteSpace($p) -or $p -match '[\x00-\x1f\x7f-\x9f]' -or $p.StartsWith('\\') -or $p.StartsWith('//') -or $p.IndexOf(':',2) -ge 0){throw "$label is not a safe local path"};$full=[IO.Path]::GetFullPath($p).Replace('/','\');$root=[IO.Path]::GetPathRoot($full);if($root -notmatch '^[A-Za-z]:\\$'){throw "$label is not on a local drive"};$drive=New-Object IO.DriveInfo($root);if($drive.DriveType -eq [IO.DriveType]::Network){throw "$label is on a network drive"};if($cmd -and ($full.Contains('"') -or $full.Contains('%') -or $full.Contains('!'))){throw "$label is not cmd-safe"};$current=$root;foreach($part in $full.Substring($root.Length).Split(@([char]'\'),[StringSplitOptions]::RemoveEmptyEntries)){$current=[IO.Path]::Combine($current,$part);$item=Get-Item -LiteralPath $current -Force -ErrorAction SilentlyContinue;if($null -eq $item){break};if(($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0){throw "$label contains a reparse point"}};if($full.Length -gt $root.Length){$full=$full.TrimEnd('\')};return $full};$fetch={param([uri]$uri,[long]$cap,[string]$label);if($uri.Scheme -cne 'https' -or ($uri.Host -cne 'api.github.com' -and $uri.Host -cne 'raw.githubusercontent.com') -or $uri.UserInfo -or $uri.Query -or $uri.Fragment){throw "unexpected $label URI"};$request=[Net.HttpWebRequest]::Create($uri);$request.Method='GET';$request.AllowAutoRedirect=$false;$request.Timeout=15000;$request.ReadWriteTimeout=15000;$request.UserAgent='coralline-bootstrap';$response=$null;try{$response=[Net.HttpWebResponse]$request.GetResponse();if($response.StatusCode -ne [Net.HttpStatusCode]::OK -or $response.ResponseUri.AbsoluteUri -cne $uri.AbsoluteUri){throw "$label request failed or redirected"};if($response.ContentLength -gt $cap){throw "$label Content-Length exceeds limit"};$input=$response.GetResponseStream();$memory=New-Object IO.MemoryStream;try{$buffer=New-Object byte[] 8192;$total=0L;while(($read=$input.Read($buffer,0,$buffer.Length)) -gt 0){$total+=$read;if($total -gt $cap){throw "$label stream exceeds limit"};$memory.Write($buffer,0,$read)};if($response.ContentLength -ge 0 -and $total -ne $response.ContentLength){throw "$label download was truncated"};return ,$memory.ToArray()}finally{if($null -ne $input){$input.Dispose()};$memory.Dispose()}}finally{if($null -ne $response){$response.Dispose()}}};$old=[Net.ServicePointManager]::SecurityProtocol;$tmp=$null;$made=$false;$code=0;try{[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12;$parts=$repo.Split('/');$commit=$ref;if($commit -cnotmatch '^[0-9a-f]{40}$'){$api=[uri]('https://api.github.com/repos/'+[uri]::EscapeDataString($parts[0])+'/'+[uri]::EscapeDataString($parts[1])+'/commits/'+[uri]::EscapeDataString($ref));$strict=New-Object Text.UTF8Encoding($false,$true);try{$payload=$strict.GetString((& $fetch $api 1MB 'commit resolution'))|ConvertFrom-Json}catch{throw ('commit resolution response is invalid: '+$_.Exception.Message)};if($null -eq $payload -or $payload.PSObject.Properties.Name -notcontains 'sha'){throw 'commit resolution response has no sha'};$commit=[string]$payload.sha;if($commit -cnotmatch '^[0-9a-f]{40}$'){throw 'commit resolution returned an invalid sha'}};$uri=[uri]('https://raw.githubusercontent.com/'+[uri]::EscapeDataString($parts[0])+'/'+[uri]::EscapeDataString($parts[1])+'/'+$commit+'/install.ps1');$bytes=& $fetch $uri 1MB 'installer';$tempRoot=& $safe ([IO.Path]::GetTempPath()) 'TEMP';$tmp=& $safe ([IO.Path]::Combine($tempRoot,('coralline-install-'+[guid]::NewGuid().ToString('N')+'.ps1'))) 'installer temp';$output=[IO.File]::Open($tmp,[IO.FileMode]::CreateNew,[IO.FileAccess]::Write,[IO.FileShare]::None);$made=$true;try{$output.Write($bytes,0,$bytes.Length);$output.Flush($true)}finally{$output.Dispose()};$checked=& $safe $tmp 'downloaded installer';if($checked -cne $tmp){throw 'installer temp identity changed'};$tokens=$null;$errors=$null;[void][Management.Automation.Language.Parser]::ParseFile($tmp,[ref]$tokens,[ref]$errors);if($errors.Count -ne 0){throw ('downloaded installer parse failed: '+$errors[0].Message)};$exe=& $safe ([IO.Path]::Combine($PSHOME,'powershell.exe')) 'PowerShell executable' $true;if(-not [IO.File]::Exists($exe)){throw 'trusted powershell.exe is missing'};$psi=New-Object Diagnostics.ProcessStartInfo;$psi.FileName=$exe;$psi.UseShellExecute=$false;$psi.Arguments='-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "'+$tmp+'" -Repo "'+$repo+'" -Ref "'+$commit+'"';$psi.Arguments+=" -SubagentRows "+[char]34+$subagentRows+[char]34;$process=New-Object Diagnostics.Process;$process.StartInfo=$psi;try{if(-not $process.Start()){throw 'installer child did not start'};$process.WaitForExit();$code=$process.ExitCode}finally{$process.Dispose()}}finally{[Net.ServicePointManager]::SecurityProtocol=$old;if($made -and $null -ne $tmp -and [IO.File]::Exists($tmp)){$checked=& $safe $tmp 'installer cleanup';if($checked -cne $tmp){throw 'refusing unexpected cleanup path'};$item=Get-Item -LiteralPath $tmp -Force;if(($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0){throw 'refusing reparse-point cleanup'};[IO.File]::Delete($tmp)}};if($code -ne 0){exit $code} }
 ```
 
-若要安裝已稽核的 release 或 commit，複製同一行，只把 `$ref='main'` 改成
-`$ref='AUDITED_TAG_OR_40_CHARACTER_COMMIT_SHA'`。tag 代表具名 release，但技術上仍可
-被移動；只有已稽核的 40 字元 commit SHA 能讓 bootstrap URL 不可變。無論選哪一種，
-bootstrap 都會在下載可執行程式碼前先解析可變名稱或 tag，再由 installer 從同一個
-commit 下載全部受管理檔案。
+要安裝已稽核的 release 或 commit，請複製同一行，只把 `$ref='main'` 換成選定的 tag 或 40 字元 SHA。branch 或 tag 都可能移動；bootstrap 會先解析再下載。原生 installer 管理 `statusline.ps1` 與十個 shipped themes、精確合併最上層 `statusLine`、除非明確指定 `on` 或 `off` 否則保留 `subagentStatusLine`、永不建立或修改 `coralline.conf`，且不會把 custom themes、state 與 float 輸出納入替換。現行契約見 [`INSTALL.md`](./INSTALL.md)，歷史設計見[原生 installer PR #55](https://github.com/Nanako0129/coralline/pull/55)。
 
-`install.ps1` 會安裝 `statusline.ps1` 與全部十個 themes，並對
-`$HOME\.claude\settings.json` 最上層、大小寫完全相符的 `statusLine` 做無損合併。
-`-SubagentRows preserve|on|off` 預設保留 `subagentStatusLine`；設為 `on` 才註冊原生
-`statusline.ps1 --subagent` command，設為 `off` 只移除大小寫完全相符的最上層欄位。
-`$HOME\.claude\coralline.conf` 會逐 byte 保留，而且 installer 永遠不會建立它。
-受管理的 runtime 或 settings 確實變更時，舊版本會保留為帶時間戳的同層備份。
-Installer 會序列化執行。單檔 runtime rollback 不會覆寫同時發生的編輯，並會保留
-被移出的 installer bytes；多檔 rollback 會 fail closed，保留現有檔案與備份供手動
-復原。Installer 會在回報成功前重新逐 byte 檢查 11 個檔案與合併後的 settings。
-Atomic settings backup 就是實際被移出的檔案，因此即使 editor 的 open handle 在
-replace 後才寫入，內容仍會進入保留的備份，不會遺失。Installer 在 commit 期間
-觀察到衝突時會回報失敗，不會覆寫外部內容。
+### 信任與安全
 
-更新時重跑同一行即可。內容完全相同時會是 true no-op：不替換受管理檔案、不重寫
-settings、不建立備份，也不改 timestamp。PowerShell-only 安裝不含 wizard；請沿用既有
-`coralline.conf`，或自行手動編輯。
+預設的 `main/INSTALL.md`、`main/UPGRADE.md` 與 `main/install.sh` URL 都是可變的遠端輸入。執行前請讀取選定的 [`INSTALL.md`](./INSTALL.md)、[`install.sh`](./install.sh) 與 [`install.ps1`](./install.ps1)。
 
-若一行 bootstrap 無法執行，請在瀏覽器下載 GitHub source archive、先檢查內容並解壓到
-本機，再以零網路的 local mode 執行：
+把 `--ref <SHA>` 傳給已經從 `main` 下載並開始執行的 installer，只會釘選它接著下載的檔案。要把最初的 Bash installer 與 payload 都釘到同一個已稽核 commit，請以一個已檢閱的 40 字元 SHA 取代下方 placeholder：
 
-```powershell
-& "$PSHOME\powershell.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File C:\path\to\coralline\install.ps1 -SourceDirectory C:\path\to\coralline -InstallRoot "$HOME\.claude\coralline" -SettingsPath "$HOME\.claude\settings.json" -SubagentRows preserve
+```bash
+SHA=YOUR_AUDITED_40_CHARACTER_COMMIT_SHA
+curl -fsSL "https://raw.githubusercontent.com/Nanako0129/coralline/$SHA/install.sh" | bash -s -- --ref "$SHA"
 ```
 
-Local mode 的三個路徑都必須是 drive-absolute（`C:\...` 或 `C:/...`）；`C:folder`
-這類 drive-relative 寫法會被拒絕。
+Bash `--install-only` 與更新不會修改 `coralline.conf`；wizard 或 AI 只會在顯示變更並取得同意後修改。Bash 會先備份 `settings.json`，再以 `jq` 做語意合併，因此會保留無關設定，但不承諾原始格式不變。原生 installer 則遵守上方更窄的 managed／unmanaged 邊界。兩種 renderer 在安裝後都不會發出網路請求。
 
-可以沿用 bash wizard 已寫好的設定，或參考 `themes/` 內任一檔案手動建立
-`~/.claude/coralline.conf`。per-process `ExecutionPolicy Bypass` 讓未簽章的本機
-renderer 在一般 session 預設為 `Restricted` 時仍能啟動；它不會修改任何持久化 policy，
-且強制套用的 Group Policy 仍具有最高優先權。
+## 設定檔
+
+Bash 讀取 `~/.claude/coralline.conf`，原生 renderer 也能讀同一個檔案。它是會被 source 的 shell 語法，通常從一個內建主題開始：
+
+```bash
+. "$HOME/.claude/coralline/themes/claude-coral.conf"
+```
+
+| 變數 | Runtime 預設值 | 說明 |
+|---|---|---|
+| `VL_STYLE` | `pill` | `pill`、`lean` 或 `classic` |
+| `VL_LAYOUT` | `fixed` | 每個 `VL_SEGMENTS*` 固定一列；`auto` 會響應式折行單一清單 |
+| `VL_MAX_LINES` / `VL_WRAP_MARGIN` | `3` / `4` | `auto` 的行數上限與右側留白 |
+| `VL_SEGMENTS` | `dir git model ctx limit5h limit7d cost clock` | 第一列，亦是 `auto` 模式的完整清單 |
+| `VL_SEGMENTS2` / `VL_SEGMENTS3` | 空 | 選用的固定第二、三列 |
+| `VL_CLOCK` / `VL_CLOCK_SECONDS` | `12h` / `1` | `12h`、`24h` 或 `off`；秒數開關 |
+| `VL_BAR_WIDTH` | `5` | 量表寬度 |
+| `VL_BAR_FILL` / `VL_BAR_EMPTY` | `▰` / `▱` | 量表字符 |
+| `VL_CTX_GLYPH` / `VL_PROJECT_GLYPH` | `⬡` / `⬢` | context 與 project 字符 |
+| `VL_PATH_DEPTH` / `VL_NAME_MAX` | `4` / `0` | 路徑摺疊與選用的名稱截斷 |
+| `VL_COST_DECIMALS` | `2` | 費用顯示精度 |
+| `VL_CTX_ALWAYS_SHOW` / `VL_COST_ALWAYS_SHOW` | `0` / `0` | 把有效但缺失／空白的 context 或 cost 顯示為零 |
+| `VL_WARN_PCT` / `VL_HOT_PCT` | `50` / `75` | 量表變色門檻 |
+| `VL_ASCII` | `0` | 設為 `1` 停用 Nerd Font 字符 |
+| `VL_RUNTIME_PROBE` | `0` | 無 pin 時讓 `node` 與 `python` 偵測 `PATH`；每次 render 會增加 fork |
+| `VL_BG_*` / `VL_FG_*` | 依主題 | 256 色編號或 `"R,G,B"` |
+
+### 版面與風格
+
+`VL_LAYOUT="auto"` 會量測顯示欄寬並折成最多 `VL_MAX_LINES` 行；Claude Code v2.1.153+ 會提供 `$COLUMNS`，Claude Code 外則退回終端寬度。顯示寬度的實作與可攜性理由見 [PR #10](https://github.com/Nanako0129/coralline/pull/10)。
+
+| 風格 | 結果 |
+|---|---|
+| `pill` | 每個區段有獨立背景的 powerline 膠囊 |
+| `lean` | 純色文字，可選分隔、統一背景與端點 |
+| `classic` | p10k 統一深色橫條與尾端截角的一字 preset（[PR #40](https://github.com/Nanako0129/coralline/pull/40)） |
+
+Installer 可以從 `~/.p10k.zsh` 匯入選定的風格、色彩與時鐘設定；詳見 [`INSTALL.md` mapping](./INSTALL.md#ai-interview)。
+
+### 主題
+
+內建主題：`claude-coral`、`catppuccin-mocha`、`nord`、`gruvbox-dark`、`tokyo-night`、`mono`、`dracula`、`lunar-pink`、`reverie` 與 `morning-haze`。主題就是指定 `VL_BG_*` 與 `VL_FG_*` 的 `.conf` 檔；wizard 會遞迴掃描 [`themes/`](./themes/) 下的 `.conf`。
+
+## 選用功能
+
+### Subagent 面板
+
+![coralline 主狀態列與套用主題的 subagent 面板列](./assets/subagent-panel.png)
+
+明確啟用或停用套用主題的 subagent 列：
+
+```bash
+bash ~/.claude/coralline/configure.sh --subagent-rows=on
+bash ~/.claude/coralline/configure.sh --subagent-rows=off
+```
+
+Bash install-only 與一般更新不會自行新增或刪除 `subagentStatusLine`；只有 wizard 選擇或上方明確指令才會改動。原生 installer 預設使用 `-SubagentRows preserve`，只有明確指定 `on` 或 `off` 才改設定。
+
+每個 task 的 model 與 context 欄位需要 Claude Code v2.1.205+。在 v2.1.211，coralline 會從 task sidecar 恢復 payload 缺少的本機 `agentType` role；沒有 sidecar 時仍會使用 payload 的 name 與 label。缺少 model、context size、token count 或 start time 時只隱藏受影響的區段。列由 panel event 觸發重繪，不是固定每秒輪詢；原生 main-session 列會保留，也不推測 per-task effort。設計與現行 fallback 行為可追溯到 [issue #45](https://github.com/Nanako0129/coralline/issues/45) 與 [PR #44](https://github.com/Nanako0129/coralline/pull/44)。
+
+| `VL_SUB_SEGMENTS` 值 | 顯示內容 |
+|---|---|
+| `name` | task identity 與 label，依狀態上色 |
+| `model` | per-task model |
+| `ctx` | context 用量條與 token 數 |
+| `elapsed` | 經過的 wall-clock 時間 |
+
+預設順序是 `name model ctx elapsed`。
+
+### 消耗率區段
+
+把 `burn` 加入 `VL_SEGMENTS`，即可顯示綁定中的 5h 或 7d 額度到達 100% 的預估時間。它預設關閉；列在清單中時會把樣本寫入 `~/.claude/coralline/burn-5h.tsv`，移除後停止寫入。`CORALLINE_BURN_WINDOW` 預設為 600 秒。動機與 estimator 契約見 [issue #17](https://github.com/Nanako0129/coralline/issues/17)。
+
+### 跨 session 額度同步（選用）
+
+設定 `VL_LIMIT_SYNC=1`，讓會重繪的 session 透過 `limit-5h.d` 與 `limit-7d.d` 共用帳號仍開放的 5h 與 7d 視窗。session 自己的有效讀數永遠贏自己的視窗；只有 store 握有嚴格較新的視窗，或 session 完全沒有讀數時，才使用仍開放的 stored window。它預設關閉、沒有 API 存取，也無法刷新完全閒置的 session。原始 redraw-only 契約見 [PR #24](https://github.com/Nanako0129/coralline/pull/24)，無讀數 fallback 見 [PR #64](https://github.com/Nanako0129/coralline/pull/64)。
+
+### Float readout（選用）
+
+設定 `VL_FLOAT=1`，每次 render 都會把純文字一行寫入 `~/.claude/coralline/float.txt`。`VL_FLOAT_SEGMENTS` 預設為 `model ctx cost`。coralline 不提供 display carrier；這個檔案就是 integration seam，repo 另附一個不受支援的 [iTerm2 範例](./example/float-display-iterm2/)。設計邊界記錄在 [issue #15](https://github.com/Nanako0129/coralline/issues/15)。
+
+## 更新、重新設定與移除
 
 ### 更新
 
-下方兩種 installer 流程用於更新 Bash 安裝。無論哪種，你的 `~/.claude/coralline.conf`
-都會被保留，舊的 `statusline.sh` 會備份在 `~/.claude/coralline/` 下（保留最近 3 份）。
-
-#### 僅 PowerShell 的更新方式
-
-重新執行 [Windows 無 Git Bash](#windows-無-git-bash)的原生一行指令，並使用相同的
-`Repo` 與 `Ref`。只有受管理檔案 byte 不同時才會個別 atomic replace，只有 managed
-settings 值不同時才會合併；變更時保留帶時間戳備份，而且永遠不碰
-`~/.claude/coralline.conf`。runtime 目錄下既有的非受管理檔案，包括 burn／limit
-history、`float.txt` 與自訂 themes，都會留在原位，不會進入 replacement transaction。
-
-#### 請 Claude 更新（推薦）
-
-把這段貼進 Claude Code：
+請 Claude 依照 upgrade playbook 更新：
 
 ```text
 Please update coralline for me:
@@ -264,312 +180,67 @@ fetch https://raw.githubusercontent.com/Nanako0129/coralline/main/UPGRADE.md
 and follow the playbook in it.
 ```
 
-Claude 會重跑 installer、讀取「new since your installed copy」報告，並主動問你要不要開啟新出現的 opt-in 功能。
-
-#### 自己更新
-
-重跑 installer —— 有新東西時它會印出一段簡短的「new since your installed copy」報告：
+或直接更新 Bash 安裝：
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash -s -- --install-only
 ```
 
-## 信任與安全
-
-「請 Claude 安裝」本質上是一份遠端文件，指示 AI 執行 `curl | bash` 並修改
-`~/.claude/settings.json`。這個形狀和 prompt-injection 攻擊一模一樣，所以你的 Claude
-如果先亮紅旗、要求檢查，那是它運作正常，不是故障。回應這種懷疑的方式是檢驗，不是信任：
-
-- **先讀會執行的東西。** 全部都在這個 repo 裡。Bash 環境使用
-  [install.sh](./install.sh)，僅有 PowerShell 的 Windows 使用
-  [install.ps1](./install.ps1)，[INSTALL.md](./INSTALL.md) 負責替 AI 判斷路徑。
-  PowerShell bootstrap 不是 `irm | iex`：它會限制下載大小、先解析暫存 installer，
-  再把它當檔案啟動。
-- **釘選版本。** `... | bash -s -- --ref v0.13.0` 安裝打過 tag 的 release 而非 `main`，
-  你審過的就是你跑的。互動式安裝本來就預設建議最新 tag。
-- **確切會寫入什麼：** Bash 流程會依前述規則寫入 runtime、經你同意的 config 與
-  Claude settings。原生 installer 只會在 `~/.claude/coralline` 寫入
-  `statusline.ps1` 與十個 themes，並更新 `settings.json` 最上層完全相符的
-  `statusLine` 值。它不建立或修改 `coralline.conf`；除非明確選擇原生 opt-in 或
-  opt-out，否則會保留 `subagentStatusLine`。既有 runtime/settings 有變更時會留下
-  同層時間戳備份。
-- **裝完之後跑的是什麼：** 每次 prompt 會執行註冊的 Bash 或 PowerShell renderer，
-  runtime 都不會發出網路請求。原生命令會引用絕對路徑的可信
-  `$PSHOME\powershell.exe` 與 renderer，不會從 workspace 搜尋 `powershell.exe`。
-- **INSTALL.md 為什麼對 AI 說話：** 人類走視覺化精靈、AI 走訪談腳本，所以 playbook 對
-  「實際執行它的讀者」說話。一份開頭就對你的 AI 下指令的文件本來就該被檢視，這正是它
-  引用的每個檔案都放在這個 repo、讓你們倆都能先讀的原因。
-
-### 移除
-
-若環境可使用 Bash，請先移除 subagent 列主題，再刪除工具：
-
-```bash
-bash ~/.claude/coralline/configure.sh --subagent-rows=off
-rm -rf ~/.claude/coralline ~/.claude/coralline.conf
-```
-
-然後把 `~/.claude/settings.json` 裡的 `statusLine` 區塊刪掉（或還原最新的
-`settings.json.bak.*`）。若略過第一個指令，也要一併刪除 `subagentStatusLine`。
-
-若是僅有 PowerShell 的原生 archive 安裝，先關閉 Claude Code 並備份設定檔：
-
-```powershell
-$settings = Join-Path $HOME '.claude\settings.json'
-Copy-Item -LiteralPath $settings -Destination "$settings.bak.$(Get-Date -Format yyyyMMddHHmmss)"
-notepad.exe $settings
-```
-
-在記事本中刪除 command 指向 `~/.claude/coralline/statusline.ps1` 的 `statusLine`
-物件。若 `subagentStatusLine` 的 command 也指向 coralline，請一併刪除，並確認存檔後
-仍是有效 JSON。最後移除已安裝的 runtime 與選用設定檔：
-
-```powershell
-Remove-Item -LiteralPath (Join-Path $HOME '.claude\coralline') -Recurse -Force
-Remove-Item -LiteralPath (Join-Path $HOME '.claude\coralline.conf') -Force -ErrorAction SilentlyContinue
-```
-
-## 設定
-
-兩種 Bash 設定方式都使用同一支 installer。人類不帶模式參數執行時會進入視覺化設定；
-Claude 則使用 `--install-only` bootstrap，接著依照 `INSTALL.md` 訪談並寫入設定。
-原生 PowerShell installer 沒有 wizard，而且永遠不寫 config；它讀取同一份
-`coralline.conf`，可沿用既有 Bash 設定或手動建立。
-
-### 設定模式
-
-| 模式 | 適合情境 |
-|---|---|
-| 預設 | 想直接使用 coralline 預設外觀 |
-| Powerlevel10k import | 已經有 `~/.p10k.zsh`，想帶入 style、時間格式與主要色彩 |
-| 視覺化 wizard | 想先預覽 theme、style、segments、折行、時鐘與字型相容性 |
-
-自己直接執行 installer、不帶模式參數時，會開啟互動式設定。除非你明確要求視覺化自訂，
-Claude 不需要操作這個人類 TUI。
+兩個預設路徑都使用可變的 `main`。先前釘選的安裝，不會讓之後未釘選的更新自動變成 immutable。要做 audited update，請從同一個已檢閱的 40 字元 SHA 抓取 `UPGRADE.md` 與 `install.sh`，並把相同 SHA 傳給 `--ref`。僅有 PowerShell 的 Windows 則以同一個選定 ref 重跑原生 bootstrap。Installer 會報告新的 opt-in，但除非取得同意，否則保留既有選擇；見 [issue #31](https://github.com/Nanako0129/coralline/issues/31) 與現行 [`UPGRADE.md`](./UPGRADE.md)。
 
 ### 重新設定
 
-兩種 Bash 安裝方式都會把 wizard 複製到 `~/.claude/coralline`，所以有 Bash 的環境可隨時
-重跑來重新調整外觀：
+有 Bash 的安裝包含視覺化 wizard：
 
 ```bash
 bash ~/.claude/coralline/configure.sh
 ```
 
-PowerShell-only 安裝不含原生 wizard。請先備份再手動編輯
-`$HOME\.claude\coralline.conf`，或沿用在有 Bash 的環境產生的設定。
+PowerShell-only 安裝沒有原生 wizard；請先備份再手動編輯 `coralline.conf`，或沿用有 Bash 的主機所建立的設定。
 
-### 測試 fork
+### 移除
 
-讓 installer 指向同一個 fork：
+Runtime 目錄可能包含 custom themes、burn／limit history、`float.txt` 與其他非受管理檔案。刪除前請先備份要保留的內容。也請先備份目前的 `~/.claude/settings.json`，並且只有在 command 仍指向 coralline 時才移除 `statusLine` 或 `subagentStatusLine`；未比較建立後的其他變更前，不要直接還原整份舊 backup。
+
+有 Bash 的系統先檢查並編輯目前 settings，再移除 runtime：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/YOU/coralline/main/install.sh | bash -s -- --repo YOU/coralline
+settings="$HOME/.claude/settings.json"
+cp "$settings" "$settings.bak.$(date +%Y%m%d%H%M%S)"
+"${EDITOR:-vi}" "$settings"
+rm -rf "$HOME/.claude/coralline"
+# Optional: remove your saved preferences too.
+rm -f "$HOME/.claude/coralline.conf"
 ```
 
-僅有 PowerShell 的 Windows，請同時修改原生 bootstrap 內的 `$repo` 與 `$ref`。
-bootstrap 會驗證兩者、在下載 `install.ps1` 前解析可變 Ref，再把得到的 commit SHA
-傳給 installer，下載固定的 runtime allowlist。
+PowerShell-only 系統：
 
-## 設定檔
-
-所有設定都在 `~/.claude/coralline.conf`（純 bash，由腳本 source 進來）：
-
-| 變數 | 預設值 | 說明 |
-|---|---|---|
-| `VL_STYLE` | `pill` | `pill`：powerline 膠囊 · `lean`：純色文字 · `classic`：文字鋪在統一深色橫條上(p10k classic) |
-| `VL_LAYOUT` | `fixed` | `fixed`：每個 `VL_SEGMENTS*` 變數固定一行 · `auto`：響應式 |
-| `VL_MAX_LINES` | `3` | 僅 `auto`——最多折成幾行（`1` = 永不折行） |
-| `VL_WRAP_MARGIN` | `4` | 僅 `auto`——右側預留的欄數，避免 segment 貼到視窗邊緣 |
-| `VL_SEGMENTS` | `dir git model ctx limit5h limit7d cost clock` | 第一行的區段與順序（`auto` 模式下為完整清單） |
-| `VL_SEGMENTS2` / `VL_SEGMENTS3` | （空） | 僅 `fixed`——可選的第二、三行 |
-| `VL_CLOCK` | `12h` | `12h` / `24h` / `off` |
-| `VL_CLOCK_SECONDS` | `1` | 時鐘是否顯示秒數 |
-| `VL_BAR_WIDTH` | `5` | 量表寬度（格數） |
-| `VL_BAR_FILL` / `VL_BAR_EMPTY` | `▰` / `▱` | 量表字符 |
-| `VL_CTX_GLYPH` | `⬡` | `ctx` 區段的字符 |
-| `VL_PROJECT_GLYPH` | `⬢` | `project` 區段的字符 |
-| `VL_PATH_DEPTH` | `4` | 路徑超過此深度即摺疊 |
-| `VL_NAME_MAX` | `0` | `project` / `git` 名稱超過此字數即以 `…` 截斷（`0` = 關閉） |
-| `VL_COST_DECIMALS` | `2` | 費用顯示的小數位數 |
-| `VL_CTX_ALWAYS_SHOW` | `0` | 設為 `1` 時，頂層為物件的 JSON 中缺少、`null` 或精確空字串的 context 值會顯示 0% 量表與零 token 數；JSON 格式錯誤或頂層非物件時不會觸發，非空 context 值仍沿用一般百分比處理 |
-| `VL_COST_ALWAYS_SHOW` | `0` | 設為 `1` 時，頂層為物件的 JSON 中缺少、`null` 或精確空字串的費用會顯示 `$0.00`；無效型別與數值仍隱藏 |
-| `VL_WARN_PCT` / `VL_HOT_PCT` | `50` / `75` | 量表變色門檻 |
-| `VL_ASCII` | `0` | 設為 `1` 停用 Nerd Font 字符 |
-| `VL_RUNTIME_PROBE` | `0` | `node` / `python`：設為 `1` 時，若無 pin 檔則改用 `PATH` 上的 `node` / `python3` 偵測（每次繪製會 fork） |
-| `VL_BG_*` / `VL_FG_*` | 依主題 | 顏色——256 色編號或 `"R,G,B"` |
-
-上述四個字符設定（`VL_BAR_FILL`、`VL_BAR_EMPTY`、`VL_CTX_GLYPH`、`VL_PROJECT_GLYPH`）
-屬於一般 Unicode，並非 Nerd Font 圖示，因此 Nerd Fonts 不會補進字型；
-若你的字型沒有這些字，替代就交給終端機自己的 fallback 決定。一旦替代字寬於一格，整列
-就會被推歪——量表擠成一團，或百分比前面的空格被吃掉。此時請改成終端機字型確實具備的字符。
-`▪` / `▫`（量表）與 `◔`（`ctx`）在 Meslo 與 JetBrainsMono Nerd Font 中都存在且剛好一格寬：
-
-```sh
-VL_BAR_FILL="▪" ; VL_BAR_EMPTY="▫" ; VL_CTX_GLYPH="◔"
+```powershell
+$settings = Join-Path $HOME '.claude\settings.json'
+Copy-Item -LiteralPath $settings -Destination "$settings.bak.$(Get-Date -Format yyyyMMddHHmmss)"
+notepad.exe $settings
+Remove-Item -LiteralPath (Join-Path $HOME '.claude\coralline') -Recurse -Force
+# Optional: remove your saved preferences too.
+Remove-Item -LiteralPath (Join-Path $HOME '.claude\coralline.conf') -Force -ErrorAction SilentlyContinue
 ```
 
-### 消耗率區段
+## 平台與效能
 
-![burn 區段在完整狀態列中的樣子，以及各種狀態](./assets/burn-segment.png)
-
-預設關閉。把 `burn` 加入 `VL_SEGMENTS` 即可顯示「到期倒數」—— 根據最近燒耗率推算，
-到達限額上限（5h 或 7d）還剩多久，例如 `↗ 5h ⇢ 1h58m`。相關鍵：`CORALLINE_BURN_WINDOW`
-（近期斜率回溯長度，預設 600s）、`VL_BURN_GLYPH`（預設 `↗`）、`VL_BG_BURN`（預設用 5h
-的背景色）。只要 `burn` 在區段清單裡，coralline 就會寫入樣本到
-`~/.claude/coralline/burn-5h.tsv`；從清單移除後便不再寫入任何檔案。
-
-ETA 會依「相對於視窗重置的急迫度」上色，當數字本身已無意義時則收斂成一個符號：
-
-| 你看到 | 代表 |
+| 平台 | 支援方式 |
 |---|---|
-| `↗ 5h ⇢ 1h58m` **紅** | 會在視窗重置*之前*就耗盡 |
-| `↗ 5h ⇢ 1h58m` **黃** | 重置與耗盡時間很接近 |
-| `↗ 5h ⇢ 1h58m` **綠** | 能從容趕在重置前，還有餘裕 |
-| **亮綠** `↗ ✓` | 照這個速度，就算從全新視窗開始也燒不完一輪——`24d15h` 這種數字純屬噪音 |
-| **暗淡** `↗ ✓` | idle：已停止消耗，手上沒有進行中的負載 |
-| **暗淡** `↗ …` | 暖機中：冷啟動還沒有樣本（刻意*不用*綠勾，免得全新安裝看起來一切健康） |
+| macOS | 內建 Bash 3.2 |
+| Linux | Bash 4+ / 5 |
+| Windows with Git Bash | Bash renderer |
+| Windows without Git Bash | 原生 Windows PowerShell 5.1 renderer |
 
-標籤會告訴你目前由哪道限額綁定 —— 取 `5h`／`7d` 中最快撞到 100% 的那一個。
-`5h` 只有在你燒得夠兇、最近視窗內出現至少兩次整數 % 跨越時才會出現；在輕度或穩定的
-步調下沒有可擬合的短期斜率，於是改由 7d 推算綁定，顯示 `↗ 7d`。
+Renderer 全程在本機執行：不呼叫網路或 API，也不使用 token。Bash 主列只用一次 `jq` 解析 payload；兩種 renderer 每次 render 最多呼叫一次 `git status --porcelain=v2 --branch`，不會為每個欄位啟動 process。可重現的量測方法見 [BENCHMARK.zh-TW.md](./BENCHMARK.zh-TW.md)，來源是 [PR #65](https://github.com/Nanako0129/coralline/pull/65)。
 
-### 跨 session 額度同步（選用）
+## 支持、致謝與授權
 
-`VL_LIMIT_SYNC=1` 幫助「卡在換窗邊界」的 session 追上已經換過窗的 session。每次 render 會把 `5h`／`7d` 的值寫進一個每台主機共用的 store（`limit-5h.d`、`limit-7d.d` 目錄），而持有「有效但較舊視窗」的 session 會跟著 store 裡較新的視窗走。預設關閉。
+如果 coralline 讓你的日常 session 更清楚，歡迎在 Patreon 支持後續維護。
 
-自己的讀數永遠贏自己的視窗。store 的角色是「自己完全沒有讀數時的來源」：payload 要等 session 收到 API 回應之後才會帶 rate limits，所以剛開、剛 resume、或閒置中的 session 原本會整個不顯示 gauge，即使帳號層級的視窗是已知的。store 裡只會有還沒關閉的視窗；而一筆讀數一旦所屬視窗關閉超過六小時（`5h`）或八天（`7d`），就不再拿來代表當前視窗。這兩個上限和驗證未來 reset 用的是同一組常數，所以同樣比視窗本身多出一段偏移餘裕。
+[![在 Patreon 支持 coralline](https://img.shields.io/badge/Support_on_Patreon-FF424D?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/cw/Nanako0129/membership)
 
-之所以需要它，是因為 Claude Code 只在某個 session 有活動時才會重畫它的狀態列，而傳進來的額度數字是該 session 最後一次看到的值，所以卡在換窗邊界的 session 會顯示舊視窗。它無法刷新一個完全沒有在重畫的 session。
+coralline 的視覺語言致敬 [Powerlevel10k](https://github.com/romkatv/powerlevel10k)、[powerline](https://github.com/powerline/powerline) 系譜與 [Nerd Fonts](https://www.nerdfonts.com/)。
 
-**你自己的讀數，永遠不會被別的 session 蓋掉。** 同步不會用別處較高的讀數取代你自己的。百分比在同一個視窗內是有可能合法下降的（官方重置額度、升級訂閱、任何伺服器端調整），而 payload 裡沒有任何欄位標記「這個值是什麼時候觀測到的」，所以過時的高值和當前的高值無法區分。
-
-store 只在兩種情況下勝出：它握有嚴格較新的視窗（也就是換窗追趕），或是你完全沒有讀數 — 那時沒有「你自己的值」可以優先，而另一個選項是對著帳號明明身處其中的視窗什麼都不畫。借來的值一定屬於當前還開著的視窗，因為一筆 entry 只有在 reset 仍在未來時才會被採納，而被它壓過的舊 entry 都會被回收。它是該視窗內任何 session 記錄過的最高值，所以在各 session 數字不一致時會偏高。
-
-> **它只在重畫時更新。** 完全沒在重畫的 session 救不了，而且「已知最新」也只到你最近活躍的那個 session 看到的值。coralline 沒有 API 存取，所以它只能縮小 session 之間的落差，沒辦法讓一個完全閒置的 bar 變即時。
-
-單 session 只用得到「回退」這一半 — 自己先前的 render 會讓 gauge 在重啟或 resume 之後仍有值可顯示；「追趕」那一半需要有第二個 session 可追。所以維持選用。
-
-### 響應式版面
-
-設定 `VL_LAYOUT="auto"` 後，視窗夠寬時整條維持單行，變窄時以貪婪法折行，
-最多折成 `VL_MAX_LINES` 行。達到行數上限後，剩餘區段會溢出在最後一行。
-`VL_WRAP_MARGIN` 會在右側預留幾欄空間，讓折行後的內容不貼到視窗邊緣——
-若你的終端機有額外 padding，可以把它調大。
-
-寬度來自 `$COLUMNS`。Claude Code v2.1.153+ 會在執行 statusline 前把 `COLUMNS`
-設成當前終端寬度，所以折行會隨視窗縮放自動反應、開箱即用。在 Claude Code 以外，
-腳本會退而用控制終端機的 `stty size`；兩者都拿不到時保持單行。
-
-```text
-wide window:    ~/dev/app  ⎇ main  ◆ Fable 5  ⬡ ▰▰▰▱▱ 62%  5h ▰▰▱▱▱ 41%  $1.23  ⊙ 14:45
-
-narrow window:  ~/dev/app  ⎇ main  ◆ Fable 5
-                ⬡ ▰▰▰▱▱ 62%  5h ▰▰▱▱▱ 41%  $1.23  ⊙ 14:45
-```
-
-偏好完全固定的版面就維持 `VL_LAYOUT="fixed"`，
-用 `VL_SEGMENTS` / `VL_SEGMENTS2` / `VL_SEGMENTS3` 釘住每一行。
-
-### Lean 風格
-
-偏好 Powerlevel10k 的 *lean* 簡潔路線——不要背景、只要純色文字？設定
-`VL_STYLE="lean"`，每個區段的 `VL_BG_*` 顏色就會變成它的文字強調色：
-
-![Lean 風格與 pill 風格對照](./assets/style-lean.png)
-
-| 變數 | 預設值 | 說明 |
-|---|---|---|
-| `VL_STYLE` | `pill` | 設為 `lean` 切換成簡潔風格 |
-| `VL_LEAN_SEP` | （空） | 區段之間的額外分隔字串，例如 `·` |
-| `VL_LEAN_FG` | （空） | 強制指定文字色；留空 = 繼承各區段的強調色 |
-| `VL_LEAN_BG` | （空） | 在整列後面鋪一層統一背景——`"R,G,B"` 或 256 色碼。想要完整的 p10k *classic* 外觀，建議直接用下方的 `VL_STYLE="classic"` preset，它會幫你接好這個 |
-| `VL_LEAN_CAP_R` | （空） | 收尾字元，用 `VL_LEAN_BG` 的顏色畫出，把橫條尾端斜切收進終端（p10k 的尾端分隔，例如 `$''`）；需搭配 `VL_LEAN_BG` |
-| `VL_LEAN_CAP_L` | （空） | 起始截角字元——`VL_LEAN_CAP_R` 在 bar 開頭的左向鏡像（例如 `$''`）；需搭配 `VL_LEAN_BG`。stock p10k *classic* 左端保持平的 |
-
-> **提示：** 本來就是 p10k 使用者？跟 AI 安裝員或視覺化 wizard 說要匯入
-> `~/.p10k.zsh`，它會在你同意後帶入風格、配色與時間格式。詳見
-> [INSTALL.md 的 AI interview](./INSTALL.md#ai-interview)。
-
-### Classic 風格
-
-想要 Powerlevel10k 原廠的 *classic* 提示列——一條統一的深色橫條、彩色文字、
-尾端一個實心截角？設定 `VL_STYLE="classic"`。這是一鍵預設：它以 `lean` 的方式
-把文字畫在深色橫條上（p10k 的 `POWERLEVEL9K_BACKGROUND`），並加上尾端的
-powerline 截角，不需要其他設定。
-
-![Classic 風格](./assets/style-classic.png)
-
-| 變數 | 預設值 | 說明 |
-|---|---|---|
-| `VL_STYLE` | `pill` | 設為 `classic` 切換成 p10k 深色橫條外觀 |
-| `VL_BG_BAR` | （空 → `238`） | 整列後面那條橫條的顏色——`"R,G,B"` 或 256 色碼。任何主題的配色都會鋪在這條橫條上；灰階配色（例如 `mono`）建議明確設定 `VL_BG_BAR` 以拉開對比 |
-
-底層上 `classic` 就是 `lean` 加上一個 `VL_LEAN_BG`（來自 `VL_BG_BAR`）與一個
-`VL_LEAN_CAP_R` 尾端截角，所以你若明確指定 `VL_LEAN_BG` 或截角仍會蓋過預設。
-匯入 p10k *classic* 設定時，會帶入你原本的橫條顏色與分隔字元。
-
-## 主題
-
-| | |
-|---|---|
-| **`claude-coral`** — 鋼藍 · 木槿紫 · Claude 珊瑚紅（預設）<br>![claude-coral 主題預覽](./assets/theme-claude-coral.png) | **`catppuccin-mocha`** — 深底粉彩<br>![catppuccin-mocha 主題預覽](./assets/theme-catppuccin-mocha.png) |
-| **`nord`** — 北極冷霜<br>![nord 主題預覽](./assets/theme-nord.png) | **`gruvbox-dark`** — 溫暖復古<br>![gruvbox-dark 主題預覽](./assets/theme-gruvbox-dark.png) |
-| **`tokyo-night`** — 深藍霓虹<br>![tokyo-night 主題預覽](./assets/theme-tokyo-night.png) | **`mono`** — 灰階極簡<br>![mono 主題預覽](./assets/theme-mono.png) |
-| **`dracula`** — 青 · 粉 · 紫，Dracula 暗炭底<br>![dracula 主題預覽](./assets/theme-dracula.png) | **`lunar-pink`** — 粉 · 青 · 黃，近黑底<br>![lunar-pink 主題預覽](./assets/theme-lunar-pink.png) |
-| **`reverie`** — 柔粉彩 · 暖深底配梅紫文字<br>![reverie 主題預覽](./assets/theme-reverie.png) | **`morning-haze`** — 霧霾藍紫 · 鼠尾草 · 砂岩，板岩深底<br>![morning-haze 主題預覽](./assets/theme-morning-haze.png) |
-
-主題就只是一個指定 `VL_BG_*` / `VL_FG_*` 的 `.conf` 檔——複製一份、改顏色、
-在 `coralline.conf` 裡改 source 你的版本即可。歡迎發 PR 貢獻新主題。
-wizard 會自動掃描 `themes/*.conf` 與 `themes/best-themes/*.conf` 這類巢狀集合，
-新增主題檔時不需要修改 `configure.sh`。
-
-> **要貢獻新主題？** 複製一份現有 `.conf`，設好所有 `VL_BG_*` / `VL_FG_*`（含
-> `VL_BG_EFFORT`；`VL_BG_BAR` 選用——只有灰階配色需要它來讓 classic 橫條可讀），
-> 保留檔尾的 `_VL_SUB_*` 區塊（面板列的候選顏色，加上 `_VL_SUB_FP` 指紋——當某份
-> config 在 source 你的主題之後又改動色盤時，靠它安全退回），
-> 把名稱加進 [`tools/render-screenshots.py`](./tools/render-screenshots.py)
-> 的 `THEMES` 清單，重跑產生 `assets/theme-<名稱>.png`，再到上方表格加一列。請**不要重產
-> `hero.png`** —— 它是固定展示最初六個主題的招牌圖、不是完整目錄。
-
-## 平台支援
-
-| 平台 | 狀態 |
-|---|---|
-| macOS | ✅ 支援（內建 bash 3.2 即可） |
-| Linux | ✅ 支援 |
-| Windows + Git Bash | ✅ 支援——有裝 Git Bash 時，Claude Code 會用它執行 statusline |
-| Windows 無 Git Bash | ✅ 原生 Windows PowerShell 5.1 支援 |
-
-> **Windows 提醒：** 原生 PowerShell renderer 不需要 Git Bash 或 `jq`。`git.exe`
-> 是選用項目，只用來啟用 `git`、`stash`、`project` segments。互動式 wizard 仍限定
-> 使用 bash；主列與套用 theme 的 `--subagent` 列都有原生版本。
-
-## 為什麼很快
-
-statusline 就是一個本地 renderer：完全不打網路、不呼叫任何 API、不消耗任何 token。
-Claude Code 只是把 session 的 JSON 從 stdin 餵給它，再顯示它印出的內容。
-
-主列每秒執行一次（`refreshInterval: 1`），subagent 列則由 panel event 觸發重繪。
-Bash renderer 以單次 `jq` 呼叫取出所有欄位，原生 PowerShell renderer 在程序內解析；
-兩者每次 render 最多呼叫一次 `git status --porcelain=v2 --branch`，都不會為每個欄位
-個別啟動子程序。
-
-這些數字是怎麼量出來的，以及過程中產生過錯誤數字的那些陷阱，都寫在
-[BENCHMARK.zh-TW.md](./BENCHMARK.zh-TW.md)。
-
-## 致敬與致謝
-
-coralline 的視覺語言——膠囊化的區段、powerline 轉場、git 的 `⇡⇣` 符號、
-隨用量變色的量表——是對 [@romkatv](https://github.com/romkatv) 的
-[Powerlevel10k](https://github.com/romkatv/powerlevel10k) 的致敬之作，
-它定義了「又快又美的 prompt」應有的樣子。也感謝開創這一切的
-[powerline](https://github.com/powerline/powerline) 系譜，以及讓膠囊外型成為可能的
-[Nerd Fonts](https://www.nerdfonts.com/)。
-
-至於名稱：珊瑚藻（coralline algae）以一層層纖薄的色彩堆出礁岩——
-而 **coral·line** 正是這個專案的本體：一條 Claude 珊瑚色的線。
-
-## 授權
-
-[MIT](./LICENSE)
+[MIT License](./LICENSE)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -151,7 +151,7 @@ bash ~/.claude/coralline/configure.sh --subagent-rows=off
 
 Bash install-only 與一般更新不會自行新增或刪除 `subagentStatusLine`；只有 wizard 選擇或上方明確指令才會改動。原生 installer 預設使用 `-SubagentRows preserve`，只有明確指定 `on` 或 `off` 才改設定。
 
-每個 task 的 model 與 context 欄位需要 Claude Code v2.1.205+。在 v2.1.211，coralline 會從 task sidecar 恢復 payload 缺少的本機 `agentType` role；沒有 sidecar 時仍會使用 payload 的 name 與 label。缺少 model、context size、token count 或 start time 時只隱藏受影響的區段。列由 panel event 觸發重繪，不是固定每秒輪詢；原生 main-session 列會保留，也不推測 per-task effort。設計與現行 fallback 行為可追溯到 [issue #45](https://github.com/Nanako0129/coralline/issues/45) 與 [PR #44](https://github.com/Nanako0129/coralline/pull/44)。
+每個 task 的 model 與 context 欄位需要 Claude Code v2.1.205+。在 v2.1.211，coralline 會從 task sidecar 恢復 payload 缺少的本機 `agentType` role；沒有 sidecar 時仍會使用 payload 的 name 與 label。缺少 model 或 start time 時只隱藏對應區段。只有 token count 缺失或無效時才會隱藏 `ctx`；沒有有效 context size 時仍顯示 glyph 與 bare token count，只省略量表與百分比。列由 panel event 觸發重繪，不是固定每秒輪詢；原生 main-session 列會保留，也不推測 per-task effort。設計與現行 fallback 行為可追溯到 [issue #45](https://github.com/Nanako0129/coralline/issues/45) 與 [PR #44](https://github.com/Nanako0129/coralline/pull/44)。
 
 | `VL_SUB_SEGMENTS` 值 | 顯示內容 |
 |---|---|

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -186,13 +186,13 @@ fetch https://raw.githubusercontent.com/Nanako0129/coralline/main/UPGRADE.md
 and follow the playbook in it.
 ```
 
-或直接更新 Bash 安裝：
+或在任何 coralline checkout 以外的目錄直接更新 Bash 安裝：
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash -s -- --install-only
 ```
 
-上方 URL 會抓取可變的 `main` playbook 或 bootstrap code。Bash installer 在非互動執行時維持 `main`。互動式 `--install-only` 會在成功解析 latest release tag 時詢問要安裝哪個 payload ref，按 Enter 預設該 release；若 release 查詢失敗，則不提示並維持 `main`。只有明確要開發版 payload 時才傳入 `--ref main`。先前釘選的安裝，不會讓之後未釘選的更新自動變成 immutable。要做 audited update，請從同一個已檢閱的 40 字元 SHA 抓取 `UPGRADE.md`，再依上方做法從中立暫存目錄執行同一 SHA 的 `install.sh`，並把相同 SHA 傳給 `--ref`。僅有 PowerShell 的 Windows 則以同一個選定 ref 重跑原生 bootstrap。Installer 會報告新的 opt-in，但除非取得同意，否則保留既有選擇；見 [issue #31](https://github.com/Nanako0129/coralline/issues/31) 與現行 [`UPGRADE.md`](./UPGRADE.md)。
+上方 URL 會抓取可變的 `main` playbook 或 bootstrap code。一般 updater 必須從 coralline checkout 外執行；在 checkout 內執行時，installer 會刻意使用該 checkout 的檔案，而不下載遠端 payload。在 checkout 外，Bash installer 會在非互動執行時維持 `main`。互動式 `--install-only` 會在成功解析 latest release tag 時詢問要安裝哪個 payload ref，按 Enter 預設該 release；若 release 查詢失敗，則不提示並維持 `main`。只有明確要開發版 payload 時才傳入 `--ref main`。先前釘選的安裝，不會讓之後未釘選的更新自動變成 immutable。要做 audited update，請從同一個已檢閱的 40 字元 SHA 抓取 `UPGRADE.md`，再依上方做法從中立暫存目錄執行同一 SHA 的 `install.sh`，並把相同 SHA 傳給 `--ref`。僅有 PowerShell 的 Windows 則以同一個選定 ref 重跑原生 bootstrap。Installer 會報告新的 opt-in，但除非取得同意，否則保留既有選擇；見 [issue #31](https://github.com/Nanako0129/coralline/issues/31) 與現行 [`UPGRADE.md`](./UPGRADE.md)。
 
 ### 重新設定
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -82,10 +82,16 @@ curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.s
 
 ```bash
 SHA=YOUR_AUDITED_40_CHARACTER_COMMIT_SHA
-curl -fsSL "https://raw.githubusercontent.com/Nanako0129/coralline/$SHA/install.sh" | bash -s -- --ref "$SHA"
+audit_dir=$(mktemp -d "${TMPDIR:-/tmp}/coralline-audit.XXXXXX") || exit 1
+(
+  set -o pipefail
+  trap 'cd / && rm -rf "$audit_dir"' EXIT
+  cd "$audit_dir" || exit 1
+  curl -fsSL "https://raw.githubusercontent.com/Nanako0129/coralline/$SHA/install.sh" | bash -s -- --ref "$SHA"
+)
 ```
 
-Bash `--install-only` 與更新不會修改 `coralline.conf`；wizard 或 AI 只會在顯示變更並取得同意後修改。Bash 會先備份 `settings.json`，再以 `jq` 做語意合併，因此會保留無關設定，但不承諾原始格式不變。原生 installer 則遵守上方更窄的 managed／unmanaged 邊界。兩種 renderer 在安裝後都不會發出網路請求。
+使用唯一暫存目錄，可避免從 stdin 執行的 Bash 把外層 coralline checkout 當成本機來源。Bash `--install-only` 與更新不會修改 `coralline.conf`；wizard 或 AI 只會在顯示變更並取得同意後修改。Bash 會先備份 `settings.json`，再以 `jq` 做語意合併，因此會保留無關設定，但不承諾原始格式不變。原生 installer 則遵守上方更窄的 managed／unmanaged 邊界。兩種 renderer 在安裝後都不會發出網路請求。
 
 ## 設定檔
 
@@ -186,7 +192,7 @@ and follow the playbook in it.
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash -s -- --install-only
 ```
 
-上方 URL 會抓取可變的 `main` playbook 或 bootstrap code。Bash installer 在非互動執行時維持 `main`。互動式 `--install-only` 會在成功解析 latest release tag 時詢問要安裝哪個 payload ref，按 Enter 預設該 release；若 release 查詢失敗，則不提示並維持 `main`。只有明確要開發版 payload 時才傳入 `--ref main`。先前釘選的安裝，不會讓之後未釘選的更新自動變成 immutable。要做 audited update，請從同一個已檢閱的 40 字元 SHA 抓取 `UPGRADE.md` 與 `install.sh`，並把相同 SHA 傳給 `--ref`。僅有 PowerShell 的 Windows 則以同一個選定 ref 重跑原生 bootstrap。Installer 會報告新的 opt-in，但除非取得同意，否則保留既有選擇；見 [issue #31](https://github.com/Nanako0129/coralline/issues/31) 與現行 [`UPGRADE.md`](./UPGRADE.md)。
+上方 URL 會抓取可變的 `main` playbook 或 bootstrap code。Bash installer 在非互動執行時維持 `main`。互動式 `--install-only` 會在成功解析 latest release tag 時詢問要安裝哪個 payload ref，按 Enter 預設該 release；若 release 查詢失敗，則不提示並維持 `main`。只有明確要開發版 payload 時才傳入 `--ref main`。先前釘選的安裝，不會讓之後未釘選的更新自動變成 immutable。要做 audited update，請從同一個已檢閱的 40 字元 SHA 抓取 `UPGRADE.md`，再依上方做法從中立暫存目錄執行同一 SHA 的 `install.sh`，並把相同 SHA 傳給 `--ref`。僅有 PowerShell 的 Windows 則以同一個選定 ref 重跑原生 bootstrap。Installer 會報告新的 opt-in，但除非取得同意，否則保留既有選擇；見 [issue #31](https://github.com/Nanako0129/coralline/issues/31) 與現行 [`UPGRADE.md`](./UPGRADE.md)。
 
 ### 重新設定
 


### PR DESCRIPTION
## Summary

- Restructure the English and Traditional Chinese READMEs into the same seven-section onboarding and reference flow.
- Replace essay-like historical and implementation detail with concise current-behavior contracts and contextual issue/PR links.
- Keep the observed default render, full segment index, platform routing, configuration defaults, optional feature boundaries, update flow, and data-aware uninstall guidance.
- Clarify mutable remote inputs, same-SHA audited install/update paths, Bash versus native preservation semantics, and explicit subagent settings behavior.
- Preserve the native PowerShell bootstrap byte-for-byte and keep both languages structurally aligned.

## Verification

- Rendered the default statusline with an isolated config and a clean temporary `main` worktree.
- Rendered both files through GitHub's GFM endpoint.
- Verified bilingual heading, code block, table identifier, image, and issue/PR URL parity.
- Verified relative links, anchors, issue/PR types, and the existing Windows backlinks.
- Ran `git diff --check`.
- Completed fresh independent verification with a `CONFIRMED` verdict and no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
