### PR TITLE
fix(state): key the default store base on CLAUDE_CONFIG_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Add `burn` to `VL_SEGMENTS` to show the projected time until the binding 5h or 7
 
 ### Cross-session limit sync (optional)
 
-Set `VL_LIMIT_SYNC=1` to let sessions that redraw share the account's open 5h and 7d windows through `limit-5h.d` and `limit-7d.d`. A session's valid reading always wins its own window; the store wins for a strictly newer window or when the session has no reading, using only a still-open stored window. It is off by default, has no API access, and cannot refresh an idle session. See the original redraw-only contract in [PR #24](https://github.com/Nanako0129/coralline/pull/24) and the no-reading fallback in [PR #64](https://github.com/Nanako0129/coralline/pull/64).
+Set `VL_LIMIT_SYNC=1` to let sessions that redraw share the account's open 5h and 7d windows through `limit-5h.d` and `limit-7d.d`. A session's valid reading always wins its own window; the store wins for a strictly newer window or when the session has no reading, using only a still-open stored window. It is off by default, has no API access, and cannot refresh an idle session. The store lives under `~/.claude/coralline`, or under `$CLAUDE_CONFIG_DIR/coralline` when that variable is set, as do the burn samples and the float file, so two Claude config directories keep separate state instead of overwriting each other's windows. See the original redraw-only contract in [PR #24](https://github.com/Nanako0129/coralline/pull/24) and the no-reading fallback in [PR #64](https://github.com/Nanako0129/coralline/pull/64).
 
 ### Float readout (optional)
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -168,7 +168,7 @@ Bash install-only 與一般更新不會自行新增或刪除 `subagentStatusLine
 
 ### 跨 session 額度同步（選用）
 
-設定 `VL_LIMIT_SYNC=1`，讓會重繪的 session 透過 `limit-5h.d` 與 `limit-7d.d` 共用帳號仍開放的 5h 與 7d 視窗。session 自己的有效讀數永遠贏自己的視窗；只有 store 握有嚴格較新的視窗，或 session 完全沒有讀數時，才使用仍開放的 stored window。它預設關閉、沒有 API 存取，也無法刷新完全閒置的 session。原始 redraw-only 契約見 [PR #24](https://github.com/Nanako0129/coralline/pull/24)，無讀數 fallback 見 [PR #64](https://github.com/Nanako0129/coralline/pull/64)。
+設定 `VL_LIMIT_SYNC=1`，讓會重繪的 session 透過 `limit-5h.d` 與 `limit-7d.d` 共用帳號仍開放的 5h 與 7d 視窗。session 自己的有效讀數永遠贏自己的視窗；只有 store 握有嚴格較新的視窗，或 session 完全沒有讀數時，才使用仍開放的 stored window。它預設關閉、沒有 API 存取，也無法刷新完全閒置的 session。store 位於 `~/.claude/coralline`；若有設定 `CLAUDE_CONFIG_DIR`，則改為 `$CLAUDE_CONFIG_DIR/coralline`，burn 樣本與 float 檔案同理，因此兩個 Claude 設定目錄各自保有獨立狀態，不會互相覆蓋視窗。原始 redraw-only 契約見 [PR #24](https://github.com/Nanako0129/coralline/pull/24)，無讀數 fallback 見 [PR #64](https://github.com/Nanako0129/coralline/pull/64)。
 
 ### Float readout（選用）
 

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -64,18 +64,24 @@ $HomeDir = [string]$HOME
 if ([string]::IsNullOrEmpty($HomeDir)) { $HomeDir = [Environment]::GetFolderPath('UserProfile') }
 $ScriptDir = [System.IO.Path]::GetDirectoryName($MyInvocation.MyCommand.Path)
 $ScriptPath = [string]$MyInvocation.MyCommand.Path
-$DefaultFloatFile = [System.IO.Path]::Combine($HomeDir, '.claude\coralline\float.txt')
+# Base for every cross-session store below. Follows CLAUDE_CONFIG_DIR so two
+# Claude config directories keep separate burn/limit state instead of
+# overwriting each other; unset, it is the historical %USERPROFILE%\.claude.
+$CoralineDir = [string]$env:CLAUDE_CONFIG_DIR
+if ([string]::IsNullOrEmpty($CoralineDir)) { $CoralineDir = [System.IO.Path]::Combine($HomeDir, '.claude') }
+$CoralineDir = [System.IO.Path]::Combine($CoralineDir, 'coralline')
+$DefaultFloatFile = [System.IO.Path]::Combine($CoralineDir, 'float.txt')
 $DefaultBurnFile = [string]$env:CORALLINE_BURN_FILE
 if ([string]::IsNullOrEmpty($DefaultBurnFile)) {
-    $DefaultBurnFile = [System.IO.Path]::Combine($HomeDir, '.claude\coralline\burn-5h.tsv')
+    $DefaultBurnFile = [System.IO.Path]::Combine($CoralineDir, 'burn-5h.tsv')
 }
 $DefaultRl5File = [string]$env:CORALLINE_RL5H_FILE
 if ([string]::IsNullOrEmpty($DefaultRl5File)) {
-    $DefaultRl5File = [System.IO.Path]::Combine($HomeDir, '.claude\coralline\limit-5h.tsv')
+    $DefaultRl5File = [System.IO.Path]::Combine($CoralineDir, 'limit-5h.tsv')
 }
 $DefaultRl7File = [string]$env:CORALLINE_RL7D_FILE
 if ([string]::IsNullOrEmpty($DefaultRl7File)) {
-    $DefaultRl7File = [System.IO.Path]::Combine($HomeDir, '.claude\coralline\limit-7d.tsv')
+    $DefaultRl7File = [System.IO.Path]::Combine($CoralineDir, 'limit-7d.tsv')
 }
 
 $Defaults = [ordered]@{

--- a/statusline.sh
+++ b/statusline.sh
@@ -65,7 +65,11 @@ VL_ASCII=0                      # 1 = no Nerd Font glyphs (plain colored blocks)
 VL_FLOAT=0                      # 1 = also write a plain-text readout to VL_FLOAT_FILE (bring your own carrier)
 VL_FLOAT_SEGMENTS="model ctx cost"  # segments rendered into the float line (plain text: keep color-driven limit warnings inline)
 VL_FLOAT_SEP="  ·  "            # separator between float segments (plain text, no color)
-VL_FLOAT_FILE="$HOME/.claude/coralline/float.txt"
+# Base for every cross-session store below. Follows CLAUDE_CONFIG_DIR so two
+# Claude config dirs keep separate burn/limit state instead of overwriting each
+# other; unset (the common case) it is the historical $HOME/.claude/coralline.
+CORALLINE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/coralline"
+VL_FLOAT_FILE="$CORALLINE_DIR/float.txt"
 VL_NOCOLOR=0                    # internal: fg()/bg() emit nothing when 1 (plain-text path)
 
 # ── Subagent panel rows (--subagent mode) ────────────────────────────────────
@@ -96,7 +100,7 @@ unset VL_BG_SUB_NAME VL_FG_SUB_TEXT VL_FG_SUB_OK VL_FG_SUB_HOT VL_FG_SUB_DIM \
 CORALLINE_BURN_WINDOW=600       # recent-slope lookback for 5h, seconds
 VL_BURN_GLYPH="↗"               # plain-Unicode, arrow family (kept in VL_ASCII)
 VL_BG_BURN=""                   # empty → inherits VL_BG_5H at the use site
-BURN_FILE="${CORALLINE_BURN_FILE:-$HOME/.claude/coralline/burn-5h.tsv}"
+BURN_FILE="${CORALLINE_BURN_FILE:-$CORALLINE_DIR/burn-5h.tsv}"
 BURN_TRIM=1500                  # internal: max rows kept in the sample file
 
 # Cross-session limit sync (opt-in). Claude Code only re-renders a session's
@@ -112,8 +116,8 @@ BURN_TRIM=1500                  # internal: max rows kept in the sample file
 # all (that is a Claude Code limit).
 # The store is a directory-set (see rl_sample/rl_latest), race-free by design.
 VL_LIMIT_SYNC=0
-RL5H_FILE="${CORALLINE_RL5H_FILE:-$HOME/.claude/coralline/limit-5h.tsv}"
-RL7D_FILE="${CORALLINE_RL7D_FILE:-$HOME/.claude/coralline/limit-7d.tsv}"
+RL5H_FILE="${CORALLINE_RL5H_FILE:-$CORALLINE_DIR/limit-5h.tsv}"
+RL7D_FILE="${CORALLINE_RL7D_FILE:-$CORALLINE_DIR/limit-7d.tsv}"
 # Per-window ceilings for the sentinel guard (#32): a reset further out than its
 # window can possibly be is corrupt (e.g. sample-input.json's 2030 value) and must
 # never become the high-water. Kept per window because a stale 5h value a couple of

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -771,6 +771,35 @@ _STATE_RL5_VALID=1; _STATE_RL5_PCT=7000; _STATE_RL5_RST=1016900
 seg_limit5h
 case "${SEG_TXT[0]}" in (*'5h '*' 7% '*) ok 'roll-over catch-up still renders the newer window' ;; (*) bad 'roll-over catch-up still renders the newer window' "${SEG_TXT[0]}" ;; esac
 
+# Default store base follows CLAUDE_CONFIG_DIR (two Claude config dirs must not
+# share one 5h/7d store). Asserted on where a real render puts the files, with no
+# CORALLINE_*_FILE override in play, so a relocated default cannot pass by text.
+default_store_case() {  # $1=case dir $2=CLAUDE_CONFIG_DIR value ("" = unset)
+  local case_dir="$1" cfg_dir="$2" now
+  rm -rf "$case_dir"; mkdir -p "$case_dir/home"
+  printf '%s\n' 'VL_SEGMENTS="limit5h limit7d"' VL_CLOCK=off VL_STYLE=lean \
+    VL_NOCOLOR=1 VL_LIMIT_SYNC=1 > "$case_dir/conf"
+  now=$(date +%s)
+  make_payload "$case_dir/input" 41.2 "$((now + 15930))" 30 "$((now + 345630))"
+  if [ -n "$cfg_dir" ]; then
+    HOME="$case_dir/home" CLAUDE_CONFIG_DIR="$cfg_dir" CORALLINE_CONFIG="$case_dir/conf" \
+      CORALLINE_NO_SAMPLE=0 "$BASH_BIN" "$SCRIPT" < "$case_dir/input" > "$case_dir/out" 2> "$case_dir/err"
+  else
+    HOME="$case_dir/home" CORALLINE_CONFIG="$case_dir/conf" \
+      CORALLINE_NO_SAMPLE=0 "$BASH_BIN" "$SCRIPT" < "$case_dir/input" > "$case_dir/out" 2> "$case_dir/err"
+  fi
+}
+
+CASE="$TMPD/store-base"
+default_store_case "$CASE/redirected" "$CASE/redirected/alt"
+true_case 'CLAUDE_CONFIG_DIR redirects the default store' test -e "$CASE/redirected/alt/coralline/limit-5h.d"
+true_case 'redirected store leaves the HOME store untouched' test ! -e "$CASE/redirected/home/.claude/coralline"
+eq 'redirected render stderr empty' "$(file_bytes "$CASE/redirected/err")" 0
+
+default_store_case "$CASE/plain" ""
+true_case 'unset CLAUDE_CONFIG_DIR keeps the historical HOME store' test -e "$CASE/plain/home/.claude/coralline/limit-5h.d"
+eq 'plain render stderr empty' "$(file_bytes "$CASE/plain/err")" 0
+
 printf 'SUMMARY pass=%s fail=%s\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1
 printf 'ALL PASS\n'

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -785,8 +785,11 @@ default_store_case() {  # $1=case dir $2=CLAUDE_CONFIG_DIR value ("" = unset)
     HOME="$case_dir/home" CLAUDE_CONFIG_DIR="$cfg_dir" CORALLINE_CONFIG="$case_dir/conf" \
       CORALLINE_NO_SAMPLE=0 "$BASH_BIN" "$SCRIPT" < "$case_dir/input" > "$case_dir/out" 2> "$case_dir/err"
   else
-    HOME="$case_dir/home" CORALLINE_CONFIG="$case_dir/conf" \
-      CORALLINE_NO_SAMPLE=0 "$BASH_BIN" "$SCRIPT" < "$case_dir/input" > "$case_dir/out" 2> "$case_dir/err"
+    # Unset, not merely unassigned: a developer who exports CLAUDE_CONFIG_DIR
+    # (the very configuration this fix targets) would otherwise leak it in.
+    ( unset CLAUDE_CONFIG_DIR
+      HOME="$case_dir/home" CORALLINE_CONFIG="$case_dir/conf" \
+        CORALLINE_NO_SAMPLE=0 "$BASH_BIN" "$SCRIPT" < "$case_dir/input" > "$case_dir/out" 2> "$case_dir/err" )
   fi
 }
 

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -1799,6 +1799,30 @@ fi
     Check-Run 'WIN-02 PowerShell reads Bash state' $psRead
     Check-Exact 'WIN-02 PowerShell reader matches Bash fixed-pill output' $psRead $bashWrite
 
+    # Default store base follows CLAUDE_CONFIG_DIR (two Claude config directories
+    # must not share one 5h/7d store). No BURN_FILE/RL*_FILE override is set, so
+    # the assertion is on where the renderer's own defaults put the files.
+    $baseConfig = New-Config 'win02-store-base' @(('VL_SEGMENTS=' + (Quote-FromConfigure 'limit5h limit7d')),'VL_CLOCK=off','VL_LIMIT_SYNC=1')
+    $baseRoot = Join-Path $stateRoot 'store-base'
+    foreach ($case in @('redirected','plain')) {
+        $caseRoot = Join-Path $baseRoot $case
+        $caseHome = Join-Path $caseRoot 'home'
+        [void][IO.Directory]::CreateDirectory($caseHome)
+        $baseEnv = @{ CORALLINE_NO_SAMPLE=$null; CORALLINE_TEST_NOW=[string]$fixedNow
+                      HOME=(Forward-Path $caseHome); USERPROFILE=$caseHome }
+        if ($case -eq 'redirected') { $baseEnv.CLAUDE_CONFIG_DIR = Join-Path $caseRoot 'alt' }
+        else { $baseEnv.CLAUDE_CONFIG_DIR = $null }
+        $baseRun = Invoke-Statusline (Json $statePayload) $baseConfig $baseEnv '' 10000
+        Check-Run "WIN-02 PowerShell default store base $case" $baseRun
+        $homeStore = Join-Path $caseHome '.claude\coralline\limit-5h.d'
+        if ($case -eq 'redirected') {
+            Check 'WIN-02 CLAUDE_CONFIG_DIR redirects the default store' ([IO.Directory]::Exists((Join-Path $caseRoot 'alt\coralline\limit-5h.d')))
+            Check 'WIN-02 redirected store leaves the HOME store untouched' (-not [IO.Directory]::Exists((Join-Path $caseHome '.claude\coralline')))
+        } else {
+            Check 'WIN-02 unset CLAUDE_CONFIG_DIR keeps the historical HOME store' ([IO.Directory]::Exists($homeStore))
+        }
+    }
+
     # C:\, C:/, and /c/ spellings must resolve to the same physical store.
     $identityRoot = Join-Path $stateRoot 'identity'
     [void][IO.Directory]::CreateDirectory($identityRoot)


### PR DESCRIPTION
Closes #73.

Two Claude Code config directories on one host shared a single set of cross-session state files, so a session running under one directory read and overwrote the other's 5h/7d windows and burn samples. The four default paths in `statusline.sh` were written against a literal `$HOME/.claude`, and nothing short of setting `CORALLINE_RL5H_FILE`, `CORALLINE_RL7D_FILE` and `CORALLINE_BURN_FILE` by hand in one of the two `coralline.conf` files could separate them.

`statusline.sh` now derives one base, `CORALLINE_DIR`, from `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/coralline`, and `VL_FLOAT_FILE`, `BURN_FILE`, `RL5H_FILE` and `RL7D_FILE` hang off it. The `CORALLINE_*_FILE` overrides keep precedence. With `CLAUDE_CONFIG_DIR` unset, every path resolves to what it was before and the rendered line is byte-identical against the previous revision on `test/sample-input.json`. The three `mkdir` sites derive their directory from the file path itself, so none needed a change.

`VL_CONF` (`$HOME/.claude/coralline.conf`) deliberately does not follow `CLAUDE_CONFIG_DIR`. Relocating it would strand the existing config of anyone who already exports that variable, and leaving it shared gives the useful split: one palette and segment configuration, separate per-directory limit and burn state. `configure.sh`'s `TARGET_DIR`, `CONFIG_FILE` and `SETTINGS_FILE` are unchanged for the same reason.

### Test

`test/test-burn.sh` gains a `default_store_case` helper that runs the real statusline with `HOME` pointed at a sandbox and no `CORALLINE_*_FILE` override in play, then asserts where the store actually landed: with `CLAUDE_CONFIG_DIR` set, `limit-5h.d` appears beneath it and the sandbox `$HOME/.claude/coralline` is never created; with it unset, the historical `$HOME` location is still used. Asserting on the observed filesystem result rather than on the source text means the guard survives a rename or a move of the assignment. Both cases also assert an empty stderr, since a config that fails to source would otherwise pass silently.

Verified with the full `test/*.sh` suite (`test-burn.sh` at 239 pass, 0 fail) and a byte-identical diff of the default render against HEAD.

### Native renderer

`statusline.ps1` gets the same treatment: `$CoralineDir` comes from `$env:CLAUDE_CONFIG_DIR`, falling back to `$HomeDir\.claude`, and the float file plus all three state defaults hang off it. With the variable unset the paths are unchanged, so both renderers still resolve to one physical store for the cross-runtime WIN-02 differential tests. `test/test-statusline-ps1.ps1` gains a matching WIN-02 case.

Verified on native x64 Windows with PowerShell 5.1: 3127 pass, 0 fail, 0 blocked. Mutation-checked by restoring the pre-fix `statusline.ps1` there, which fails exactly the two redirect assertions (3125 pass, 2 fail) while the historical-HOME case still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
