### PR TITLE
perf(state): batch trim rewrites and elect one burn writer per second

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -656,33 +656,50 @@ state_gate() {  # canonicalize one render's values and state namespaces
   _STATE_READY=1
 }
 
-# Per-(second, window) leader election for the burn write path. N concurrent
-# sessions on one account share one current 5h window and would otherwise each
-# append a near-identical row every second, keeping the file permanently past
-# BURN_TRIM so that every render pays a whole-file rewrite; measured at n=16
-# that write path alone is ~600ms CPU/s aggregate. One writer per (tick, reset)
-# collapses that to a single append without losing history: the reader already
-# dedups same-(reset, sample) rows to one observation (add_obs), and a session
-# holding a DIFFERENT window claims a different token, so per-window coverage
-# is exactly what every-session writes produce. Limit-store publishing
-# (rl_sample) is deliberately NOT elected: those entries are idempotent bounded
-# mkdirs with no rewrite cost, and any session may hold a newer window that
-# must be able to reach the store.
+# Per-(second, window, pct) burn-write election. N concurrent sessions on one
+# account share one current 5h window and would otherwise each append a
+# near-identical row every second, keeping the file permanently past BURN_TRIM
+# so that every render pays a whole-file rewrite; measured at n=16 that write
+# path alone is ~600ms CPU/s aggregate. The reader keeps only the MAX pct per
+# (reset, sample) row (add_obs), so a reading at or below a pct already
+# claimed for this (second, window) is exactly the row dedup would discard: a
+# session appends only when it carries new information. Same-pct sessions (the
+# storm case) collapse to one writer; a session with a HIGHER reading — e.g.
+# the one actively burning while another idles on a stale snapshot — always
+# still lands, and a session on a DIFFERENT window claims a different token,
+# so the persisted series is exactly what every-session writes produce.
+# Limit-store publishing (rl_sample) is deliberately NOT elected: those
+# entries are idempotent bounded mkdirs with no rewrite cost, and any session
+# may hold a newer window that must be able to reach the store.
+# Tokens live beside the burn file and carry its name as prefix
+# (<burnfile>.<epoch>.<reset>.<pctmilli>.tick), mirroring burn_tmp_sweep's
+# provenance rule: in a shared parent directory only files that name THIS
+# store are ever considered ours, so the sweep cannot touch foreign files.
 # The claim is a noclobber `:` redirect (O_CREAT|O_EXCL, no fork). Losing, and
 # every guard failure around the claim, leaves the store untouched; only a
 # claim that fails while the token is genuinely absent (e.g. parent not yet
 # created) fails OPEN to today's every-session-writes behavior, because the
 # mutations downstream re-run their own TOCTOU guards and a fresh store must
 # keep sampling from its first render.
-state_burn_lead() {  # → 0 iff this render owns burn mutation for its (tick, window)
+state_burn_lead() {  # → 0 iff this render's burn reading must be persisted
   case "${_BURN_LEAD:-}" in 1) return 0 ;; 0) return 1 ;; esac
   _BURN_LEAD=0
   [ "${_STATE_BURN_SAFE:-0}" = 1 ] && [ "${_CUR_BURN_VALID:-0}" = 1 ] || return 1
-  local tok="${_SB_BASE%/*}/tick.${NOW}.${_CUR_BURN_RST}" had_c=0 won=0 f n e c=0
+  local slot="$_SB_BASE.${NOW}.${_CUR_BURN_RST}" tok had_c=0 won=0 f n e r p c=0 best=-1
+  tok="$slot.${_CUR_BURN_PCT}.tick"
   # Same discipline as every store mutation: revalidate immediately before
   # touching the path. If revalidation cannot pass, fail open without creating
   # or deleting anything here.
   if ! state_paths_revalidate; then _BURN_LEAD=1; return 0; fi
+  # Lose only to a claim that already covers this reading: the highest pct
+  # claimed for this (second, window) at or above ours makes our row redundant.
+  for f in "$slot".*.tick; do
+    [ -e "$f" ] || [ -L "$f" ] || continue
+    p=${f#"$slot".}; p=${p%.tick}
+    case "$p" in (''|*[!0-9]*) continue ;; esac
+    [ "$p" -gt "$best" ] && best=$p
+  done
+  [ "$_CUR_BURN_PCT" -gt "$best" ] || return 1
   # A pre-existing symlink (or other oddity) planted at the token name is not
   # followed and not deleted; this render just loses the tick.
   state_no_symlink_path "$tok" && [ "$_SNP" = "$tok" ] || return 1
@@ -691,33 +708,35 @@ state_burn_lead() {  # → 0 iff this render owns burn mutation for its (tick, w
   if : 2>/dev/null > "$tok"; then won=1; fi
   [ "$had_c" = 1 ] || set +C
   if [ "$won" != 1 ]; then
-    # EEXIST: another session already owns this (tick, window).
+    # EEXIST: another session already claimed this exact reading.
     if [ -e "$tok" ] || [ -L "$tok" ]; then return 1; fi
     # Anything else (missing parent on a fresh store, transient fs error):
     # fail open so sampling never silently stops.
     _BURN_LEAD=1; return 0
   fi
   _BURN_LEAD=1
-  # Leader duty: clear other seconds' tokens. A token is swept only once it is
+  # Winner duty: clear other seconds' tokens. A token is swept only once it is
   # at least 8s in the past: a render's NOW is fixed at startup, so a straggler
   # still finishing second T must find T's token intact while the second-T+1
-  # leader runs, or it would reclaim T and double-write (observed in the n=16
+  # winner runs, or it would reclaim T and double-write (observed in the n=16
   # concurrency regression; 8s outlives any render that is not already
   # pathological). Future-dated tokens (backwards clock step) drain
-  # immediately. Same-NOW tokens of other windows are live and stay. Only plain
-  # non-symlink files with a strictly numeric epoch.window name shape are ever
-  # deleted, and the identities are revalidated again before the batched rm
-  # (mirrors burn_tmp_sweep's cap-and-batch pattern).
+  # immediately. Same-NOW tokens stay. Only plain non-symlink files prefixed
+  # by this store's own name with a strictly numeric epoch.window.pct shape
+  # are ever deleted, and the identities are revalidated again before the
+  # batched rm (mirrors burn_tmp_sweep's cap-and-batch pattern).
   state_paths_revalidate || return 0
   set --
-  for f in "${_SB_BASE%/*}"/tick.*; do
+  for f in "$_SB_BASE".*.tick; do
     [ -f "$f" ] && [ ! -L "$f" ] || continue
-    n=${f##*/}; n=${n#tick.}
-    case "$n" in *.*) ;; *) continue ;; esac
+    n=${f#"$_SB_BASE".}; n=${n%.tick}
     e=${n%%.*}
     case "$e" in (''|*[!0-9]*) continue ;; esac
     n=${n#*.}
-    case "$n" in (''|*[!0-9]*) continue ;; esac
+    case "$n" in *.*) ;; *) continue ;; esac
+    r=${n%%.*}; p=${n#*.}
+    case "$r" in (''|*[!0-9]*) continue ;; esac
+    case "$p" in (''|*[!0-9]*) continue ;; esac
     [ "$e" -le "$NOW" ] && [ "$e" -ge $(( NOW - 8 )) ] && continue
     set -- "$@" "$f"; c=$(( c + 1 ))
     [ "$c" -ge 8 ] && break

--- a/statusline.sh
+++ b/statusline.sh
@@ -102,6 +102,11 @@ VL_BURN_GLYPH="↗"               # plain-Unicode, arrow family (kept in VL_ASCI
 VL_BG_BURN=""                   # empty → inherits VL_BG_5H at the use site
 BURN_FILE="${CORALLINE_BURN_FILE:-$CORALLINE_DIR/burn-5h.tsv}"
 BURN_TRIM=1500                  # internal: max rows kept in the sample file
+BURN_SLACK=500                  # internal: rows past BURN_TRIM tolerated before a trim rewrite.
+                                # Batches the steady-state trim: at the cap, appends land for
+                                # ~BURN_SLACK seconds before one render rewrites, instead of every
+                                # render rewriting every second. 1500+1000(max)+appends stays far
+                                # below the reader's 4096-physical-row bail-out.
 
 # Cross-session limit sync (opt-in). Claude Code only re-renders a session's
 # statusline on activity, and the rate-limit % in each render's JSON is that
@@ -608,6 +613,9 @@ state_gate() {  # canonicalize one render's values and state namespaces
   case "$BURN_TRIM" in (''|*[!0-9]*) BURN_TRIM=1500 ;; esac
   [ "${#BURN_TRIM}" -le 4 ] && [ "$BURN_TRIM" -ge 1 ] 2>/dev/null \
     && [ "$BURN_TRIM" -le 3000 ] 2>/dev/null || BURN_TRIM=1500
+  case "$BURN_SLACK" in (''|*[!0-9]*) BURN_SLACK=500 ;; esac
+  [ "${#BURN_SLACK}" -le 4 ] && [ "$BURN_SLACK" -ge 0 ] 2>/dev/null \
+    && [ "$BURN_SLACK" -le 1000 ] 2>/dev/null || BURN_SLACK=500
 
   _CUR5_VALID=0; _CUR7_VALID=0; _CUR_BURN_VALID=0
   _CUR5_PCT=0; _CUR5_CANON=""; _CUR5_TSV=""; _CUR5_RST=0
@@ -648,11 +656,82 @@ state_gate() {  # canonicalize one render's values and state namespaces
   _STATE_READY=1
 }
 
+# Per-(second, window) leader election for the burn write path. N concurrent
+# sessions on one account share one current 5h window and would otherwise each
+# append a near-identical row every second, keeping the file permanently past
+# BURN_TRIM so that every render pays a whole-file rewrite; measured at n=16
+# that write path alone is ~600ms CPU/s aggregate. One writer per (tick, reset)
+# collapses that to a single append without losing history: the reader already
+# dedups same-(reset, sample) rows to one observation (add_obs), and a session
+# holding a DIFFERENT window claims a different token, so per-window coverage
+# is exactly what every-session writes produce. Limit-store publishing
+# (rl_sample) is deliberately NOT elected: those entries are idempotent bounded
+# mkdirs with no rewrite cost, and any session may hold a newer window that
+# must be able to reach the store.
+# The claim is a noclobber `:` redirect (O_CREAT|O_EXCL, no fork). Losing, and
+# every guard failure around the claim, leaves the store untouched; only a
+# claim that fails while the token is genuinely absent (e.g. parent not yet
+# created) fails OPEN to today's every-session-writes behavior, because the
+# mutations downstream re-run their own TOCTOU guards and a fresh store must
+# keep sampling from its first render.
+state_burn_lead() {  # → 0 iff this render owns burn mutation for its (tick, window)
+  case "${_BURN_LEAD:-}" in 1) return 0 ;; 0) return 1 ;; esac
+  _BURN_LEAD=0
+  [ "${_STATE_BURN_SAFE:-0}" = 1 ] && [ "${_CUR_BURN_VALID:-0}" = 1 ] || return 1
+  local tok="${_SB_BASE%/*}/tick.${NOW}.${_CUR_BURN_RST}" had_c=0 won=0 f n e c=0
+  # Same discipline as every store mutation: revalidate immediately before
+  # touching the path. If revalidation cannot pass, fail open without creating
+  # or deleting anything here.
+  if ! state_paths_revalidate; then _BURN_LEAD=1; return 0; fi
+  # A pre-existing symlink (or other oddity) planted at the token name is not
+  # followed and not deleted; this render just loses the tick.
+  state_no_symlink_path "$tok" && [ "$_SNP" = "$tok" ] || return 1
+  case $- in *C*) had_c=1 ;; esac
+  set -C
+  if : 2>/dev/null > "$tok"; then won=1; fi
+  [ "$had_c" = 1 ] || set +C
+  if [ "$won" != 1 ]; then
+    # EEXIST: another session already owns this (tick, window).
+    if [ -e "$tok" ] || [ -L "$tok" ]; then return 1; fi
+    # Anything else (missing parent on a fresh store, transient fs error):
+    # fail open so sampling never silently stops.
+    _BURN_LEAD=1; return 0
+  fi
+  _BURN_LEAD=1
+  # Leader duty: clear other seconds' tokens. A token is swept only once it is
+  # at least 8s in the past: a render's NOW is fixed at startup, so a straggler
+  # still finishing second T must find T's token intact while the second-T+1
+  # leader runs, or it would reclaim T and double-write (observed in the n=16
+  # concurrency regression; 8s outlives any render that is not already
+  # pathological). Future-dated tokens (backwards clock step) drain
+  # immediately. Same-NOW tokens of other windows are live and stay. Only plain
+  # non-symlink files with a strictly numeric epoch.window name shape are ever
+  # deleted, and the identities are revalidated again before the batched rm
+  # (mirrors burn_tmp_sweep's cap-and-batch pattern).
+  state_paths_revalidate || return 0
+  set --
+  for f in "${_SB_BASE%/*}"/tick.*; do
+    [ -f "$f" ] && [ ! -L "$f" ] || continue
+    n=${f##*/}; n=${n#tick.}
+    case "$n" in *.*) ;; *) continue ;; esac
+    e=${n%%.*}
+    case "$e" in (''|*[!0-9]*) continue ;; esac
+    n=${n#*.}
+    case "$n" in (''|*[!0-9]*) continue ;; esac
+    [ "$e" -le "$NOW" ] && [ "$e" -ge $(( NOW - 8 )) ] && continue
+    set -- "$@" "$f"; c=$(( c + 1 ))
+    [ "$c" -ge 8 ] && break
+  done
+  [ "$c" -gt 0 ] && rm -f "$@" 2>/dev/null
+  return 0
+}
+
 burn_sample() {  # append one canonical validated 5h row; $1=sample $2=pct $3=reset
   local parent
   _BURN_APPENDED=0
   [ "${_STATE_MUTATE:-0}" = 1 ] && [ "${_STATE_BURN_SAFE:-0}" = 1 ] \
     && [ "${_CUR_BURN_VALID:-0}" = 1 ] || return 0
+  state_burn_lead || return 0
   [ "$1" = "$_CUR_BURN_SAMP" ] && [ "$2" = "$_CUR_BURN_TSV" ] && [ "$3" = "$_CUR_BURN_RST" ] || return 0
   parent="${_SB_BASE%/*}"; [ -n "$parent" ] || parent=/
   if [ ! -d "$parent" ]; then
@@ -837,7 +916,8 @@ burn_eta_5h() {  # → _B5_* from canonical TSV; $1=allow trim/heal mutation
        && [ ! -e "$tmp" ] && [ ! -L "$tmp" ]; then write_tmp=1; fi
   fi
   out=$(LC_ALL=C awk -F '\t' -v now="$NOW" -v win="$CORALLINE_BURN_WINDOW" \
-    -v trim="$BURN_TRIM" -v maxahead="$RL_MAX_5H" -v mutate="$write_tmp" -v tmp="$tmp" \
+    -v trim="$BURN_TRIM" -v slack="$BURN_SLACK" \
+    -v maxahead="$RL_MAX_5H" -v mutate="$write_tmp" -v tmp="$tmp" \
     -v curvalid="${_CUR_BURN_VALID:-0}" -v csamp="${_CUR_BURN_SAMP:-0}" \
     -v cpct="${_CUR_BURN_PCT:-0}" -v crst="${_CUR_BURN_RST:-0}" '
     function epoch(raw, value) {
@@ -892,7 +972,7 @@ burn_eta_5h() {  # → _B5_* from canonical TSV; $1=allow trim/heal mutation
     }
     END {
       if (incomplete) { print "incomplete"; exit }
-      if (mutate && (physical > trim || heal)) {
+      if (mutate && (physical > trim + slack || heal)) {
         lo = n - trim + 1; if (lo < 1) lo = 1
         printf "%s", "" > tmp
         for (i = lo; i <= n; i++) printf "%.0f\t%s\t%.0f\n", sm[i], canon(pc[i]), rs[i] >> tmp
@@ -970,8 +1050,11 @@ burn_eta_7d() {  # → _B7_*; $1=pct_milli $2=reset epoch
 }
 
 burn_estimate() {  # → _BURN_STATE _BURN_LABEL _BURN_ETA _BURN_RATE _BURN_TTR
-  local f5=0 f7=0
-  burn_eta_5h "${_STATE_MUTATE:-0}"
+  local f5=0 f7=0 m=0
+  # Trim/heal mutation follows the same per-(tick, window) election as the
+  # append: only the tick leader rewrites, everyone else reads.
+  [ "${_STATE_MUTATE:-0}" = 1 ] && state_burn_lead && m=1
+  burn_eta_5h "$m"
   # The 5h projection needs the same rebinding the 7d one gets: whenever the synced
   # state is what the gauge draws, the ETA has to be projected from that same window.
   # Two ways they diverge. With no reading of our own the history can still sit on

--- a/statusline.sh
+++ b/statusline.sh
@@ -681,25 +681,41 @@ state_gate() {  # canonicalize one render's values and state namespaces
 # created) fails OPEN to today's every-session-writes behavior, because the
 # mutations downstream re-run their own TOCTOU guards and a fresh store must
 # keep sampling from its first render.
-state_burn_lead() {  # → 0 iff this render's burn reading must be persisted
+state_burn_lead() {  # → 0 iff this render must run the burn write path
   case "${_BURN_LEAD:-}" in 1) return 0 ;; 0) return 1 ;; esac
   _BURN_LEAD=0
-  [ "${_STATE_BURN_SAFE:-0}" = 1 ] && [ "${_CUR_BURN_VALID:-0}" = 1 ] || return 1
-  local slot="$_SB_BASE.${NOW}.${_CUR_BURN_RST}" tok had_c=0 won=0 f n e r p c=0 best=-1
-  tok="$slot.${_CUR_BURN_PCT}.tick"
+  [ "${_STATE_BURN_SAFE:-0}" = 1 ] || return 1
+  local slot tok had_c=0 won=0 f n e r p c=0 best=-1
   # Same discipline as every store mutation: revalidate immediately before
   # touching the path. If revalidation cannot pass, fail open without creating
   # or deleting anything here.
   if ! state_paths_revalidate; then _BURN_LEAD=1; return 0; fi
-  # Lose only to a claim that already covers this reading: the highest pct
-  # claimed for this (second, window) at or above ours makes our row redundant.
-  for f in "$slot".*.tick; do
-    [ -e "$f" ] || [ -L "$f" ] || continue
-    p=${f#"$slot".}; p=${p%.tick}
-    case "$p" in (''|*[!0-9]*) continue ;; esac
-    [ "$p" -gt "$best" ] && best=$p
-  done
-  [ "$_CUR_BURN_PCT" -gt "$best" ] || return 1
+  if [ "${_CUR_BURN_VALID:-0}" = 1 ]; then
+    slot="$_SB_BASE.${NOW}.${_CUR_BURN_RST}"
+    tok="$slot.${_CUR_BURN_PCT}.tick"
+    # Lose only to a claim that already covers this reading: the highest pct
+    # claimed for this (second, window) at or above ours makes our row
+    # redundant.
+    for f in "$slot".*.tick; do
+      [ -e "$f" ] || [ -L "$f" ] || continue
+      p=${f#"$slot".}; p=${p%.tick}
+      case "$p" in (''|*[!0-9]*) continue ;; esac
+      [ "$p" -gt "$best" ] && best=$p
+    done
+    [ "$_CUR_BURN_PCT" -gt "$best" ] || return 1
+  else
+    # No reading of our own: maintenance-only claim under the reserved
+    # window/pct 0.0, so trim, healing, and the tmp sweep never starve while
+    # every rendering session happens to lack a current 5h payload. Any
+    # same-second claimant (any window) makes maintenance redundant — a real
+    # claimant runs the same mutate path — and burn_sample's own gate keeps a
+    # maintenance winner from ever appending a row.
+    for f in "$_SB_BASE.${NOW}".*.tick; do
+      [ -e "$f" ] || [ -L "$f" ] || continue
+      return 1
+    done
+    tok="$_SB_BASE.${NOW}.0.0.tick"
+  fi
   # A pre-existing symlink (or other oddity) planted at the token name is not
   # followed and not deleted; this render just loses the tick.
   state_no_symlink_path "$tok" && [ "$_SNP" = "$tok" ] || return 1

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -49,6 +49,7 @@ RL_MAX_5H=21600
 RL_MAX_7D=691200
 CORALLINE_BURN_WINDOW=600
 BURN_TRIM=1500
+BURN_SLACK=0
 VL_LIMIT_SYNC=0
 CORALLINE_NO_SAMPLE=0
 BASH_BIN=${BASH:-bash}
@@ -115,7 +116,7 @@ unit_gate() {  # $1=root $2=now $3=5h pct $4=5h reset $5=7d pct $6=7d reset $7=r
   NOW="$2"; fh_pct="$3"; fh_rst="$4"; wd_pct="$5"; wd_rst="$6"; CORALLINE_NO_SAMPLE="$7"
   BURN_FILE="$root/burn.tsv"; RL5H_FILE="$root/limit5.tsv"; RL7D_FILE="$root/limit7.tsv"
   _STATE_BURN_GATE=1; _STATE_RL5_GATE=1; _STATE_RL7_GATE=1
-  VL_LIMIT_SYNC=1; CORALLINE_BURN_WINDOW=600; BURN_TRIM=1500
+  VL_LIMIT_SYNC=1; CORALLINE_BURN_WINDOW=600; BURN_TRIM=1500; BURN_SLACK=0
   state_gate
 }
 
@@ -128,10 +129,10 @@ eq 'burn sample canonical TSV row' "$_ROW" $'1000000\t41.200\t1015900'
 eq 'burn sample appended once' "$_BURN_APPENDED" 1
 
 run5h() {  # $1=fixture $2=now $3=mutate
-  local root="$TMPD/run5h" trim="$BURN_TRIM"
+  local root="$TMPD/run5h" trim="$BURN_TRIM" slack="$BURN_SLACK"
   rm -rf "$root"; mkdir -p "$root"
   unit_gate "$root" "$2" '' '' '' '' 1
-  BURN_TRIM=$trim
+  BURN_TRIM=$trim; BURN_SLACK=$slack
   printf '%b' "$1" > "$BURN_FILE"
   _CUR_BURN_VALID=0
   burn_eta_5h "$3"
@@ -409,6 +410,9 @@ else ok 'symlink limit fixture unavailable'; fi
 # Existing immutable burn.d and unrelated temp canaries are never touched.
 CASE="$TMPD/coexist"; mkdir -p "$CASE/state/burn.d"; printf 'immutable' > "$CASE/state/burn.d/canary"
 write_config "$CASE/conf" "$CASE/state" burn 0 3
+# Slack would let the file sit above trim between rewrites; pin it off so the
+# repeated-render bound below stays exact.
+printf 'BURN_SLACK=0\n' >> "$CASE/conf"
 make_payload "$CASE/input" 41.2 "$_r5" 30 "$_r7"
 snapshot_tree "$CASE/state/burn.d" "$CASE/before.tar"
 run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 0
@@ -524,12 +528,21 @@ run_concurrency() {  # $1=runtime $2=workers $3=tag
       [ ! -s "$path.err" ] && _CC_STDERR_EMPTY=$(( _CC_STDERR_EMPTY + 1 ))
     done
   done
-  if [ -f "$root/state/burn.tsv" ]; then _CC_ROWS=$(wc -l < "$root/state/burn.tsv" | tr -d ' '); else _CC_ROWS=0; fi
+  # Single-writer contract: the per-(second, window) election means N renders
+  # in the same second persist ONE row, so the row count equals the number of
+  # distinct (sample, reset) pairs -- never the render count -- and duplicates
+  # are the failure signature of a broken election.
+  _CC_ROWS=0; _CC_DUPES=0
+  if [ -f "$root/state/burn.tsv" ]; then
+    _CC_ROWS=$(wc -l < "$root/state/burn.tsv" | tr -d ' ')
+    _CC_DUPES=$(LC_ALL=C awk -F '\t' '{k=$1 FS $3} seen[k]++ {d++} END{print d+0}' "$root/state/burn.tsv")
+  fi
   _CC_IMMUTABLE=0
   [ "$(LC_ALL=C tr -d '\n' < "$root/state/burn.d/canary")" = immutable-concurrency-canary ] && _CC_IMMUTABLE=1
   [ "$_CC_RCFILES" -eq "$_CC_EXPECTED" ] && [ "$_CC_SUCCESS" -eq "$_CC_EXPECTED" ] \
     && [ "$_CC_NONEMPTY" -eq "$_CC_EXPECTED" ] && [ "$_CC_MATCH" -eq "$_CC_EXPECTED" ] \
-    && [ "$_CC_STDERR_EMPTY" -eq "$_CC_EXPECTED" ] && [ "$_CC_ROWS" -eq "$_CC_EXPECTED" ] \
+    && [ "$_CC_STDERR_EMPTY" -eq "$_CC_EXPECTED" ] \
+    && [ "$_CC_ROWS" -ge 1 ] && [ "$_CC_ROWS" -le "$_CC_EXPECTED" ] && [ "$_CC_DUPES" -eq 0 ] \
     && [ "$_CC_IMMUTABLE" -eq 1 ]
 }
 
@@ -547,10 +560,11 @@ for _N in 5 12 16; do
     eq "concurrency n=$_N successes" "$_CC_SUCCESS" $((_N * 2))
     eq "concurrency n=$_N exact outputs" "$_CC_MATCH" $((_N * 2))
     eq "concurrency n=$_N stderr empty" "$_CC_STDERR_EMPTY" $((_N * 2))
-    eq "concurrency n=$_N TSV rows" "$_CC_ROWS" $((_N * 2))
+    eq "concurrency n=$_N single writer per (second, window)" "$_CC_DUPES" 0
+    ok "concurrency n=$_N TSV rows within [1, renders] ($_CC_ROWS)"
     eq "concurrency n=$_N immutable store untouched" "$_CC_IMMUTABLE" 1
   else
-    bad "concurrency n=$_N" "expected=$_CC_EXPECTED rcfiles=$_CC_RCFILES success=$_CC_SUCCESS nonempty=$_CC_NONEMPTY match=$_CC_MATCH stderr=$_CC_STDERR_EMPTY rows=$_CC_ROWS immutable=$_CC_IMMUTABLE"
+    bad "concurrency n=$_N" "expected=$_CC_EXPECTED rcfiles=$_CC_RCFILES success=$_CC_SUCCESS nonempty=$_CC_NONEMPTY match=$_CC_MATCH stderr=$_CC_STDERR_EMPTY rows=$_CC_ROWS dupes=$_CC_DUPES immutable=$_CC_IMMUTABLE"
   fi
 done
 
@@ -573,6 +587,109 @@ true_case 'sweep keeps a non-temporary suffix' test -f "$_SB_BASE.333.bak"
 true_case 'sweep keeps a symlink' test -L "$_SB_BASE.444.tmp"
 true_case 'sweep keeps a temporary newer than the store' test -f "$_SB_BASE.555.tmp"
 true_case 'sweep leaves the store intact' test -s "$_SB_BASE"
+
+# Trim hysteresis: at the cap, appends accumulate for BURN_SLACK rows before one
+# render pays the rewrite; healing is never deferred by slack.
+CASE="$TMPD/slack"; mkdir -p "$CASE"
+unit_gate "$CASE" 6 '' '' '' '' 1
+BURN_TRIM=3; BURN_SLACK=2
+run5h '1\t6\t9\n2\t6\t9\n3\t7\t9\n4\t7\t9\n' 6 1
+eq 'slack holds the rewrite below trim+slack' "$(wc -l < "$BURN_FILE" | tr -d ' ')" 4
+run5h '1\t6\t9\n2\t6\t9\n3\t7\t9\n4\t7\t9\n5\t8\t9\n6\t8\t9\n' 7 1
+eq 'past trim+slack rewrites down to trim' "$(wc -l < "$BURN_FILE" | tr -d ' ')" 3
+run5h '1\t6\t9\n2\t7\t9\n9999000\t99\t99999999\n' 6 1
+if grep -q 99999999 "$BURN_FILE"; then bad 'heal is not deferred by slack' present; else ok 'heal is not deferred by slack'; fi
+BURN_TRIM=1500; BURN_SLACK=0
+
+# Per-(second, window) burn-write election. The token is the only coordination
+# point and every touch around it re-runs the store's TOCTOU guards.
+CASE="$TMPD/lead"; mkdir -p "$CASE"
+unit_gate "$CASE" 1000000 41.2 1015900 '' '' 0
+_BURN_LEAD=
+true_case 'lead: first claim wins' state_burn_lead
+true_case 'lead: winning claim leaves a token' test -f "$CASE/tick.1000000.1015900"
+_BURN_LEAD=
+if state_burn_lead; then bad 'lead: planted same-window token loses' won; else ok 'lead: planted same-window token loses'; fi
+rm -f "$CASE/tick.1000000.1015900"
+: > "$CASE/tick.1000000.1016000"
+_BURN_LEAD=
+true_case 'lead: same-second other-window token does not block' state_burn_lead
+true_case 'lead: other-window token kept by the sweep' test -f "$CASE/tick.1000000.1016000"
+rm -f "$CASE"/tick.*
+: > "$CASE/tick.999990.1015900"
+: > "$CASE/tick.999999.1015900"
+: > "$CASE/tick.1000002.1015900"
+: > "$CASE/tick.abc.1015900"
+: > "$CASE/tick.999997"
+ln -s /dev/null "$CASE/tick.999980.1015900"
+_BURN_LEAD=
+state_burn_lead || bad 'lead: sweep round claim' lost
+true_case 'lead sweep: stale token removed' test ! -e "$CASE/tick.999990.1015900"
+true_case 'lead sweep: recent-past token kept for stragglers' test -f "$CASE/tick.999999.1015900"
+true_case 'lead sweep: future token removed' test ! -e "$CASE/tick.1000002.1015900"
+true_case 'lead sweep: non-numeric epoch kept' test -f "$CASE/tick.abc.1015900"
+true_case 'lead sweep: single-field name kept' test -f "$CASE/tick.999997"
+true_case 'lead sweep: symlink kept' test -L "$CASE/tick.999980.1015900"
+rm -f "$CASE"/tick.* 2>/dev/null; rm -f "$CASE/tick.abc.1015900" "$CASE/tick.999997"
+ln -s "$CASE/linktarget" "$CASE/tick.1000000.1015900"
+_BURN_LEAD=
+if state_burn_lead; then bad 'lead: symlink at the token name loses' won; else ok 'lead: symlink at the token name loses'; fi
+true_case 'lead: symlink token never followed' test ! -e "$CASE/linktarget"
+true_case 'lead: symlink token never deleted' test -L "$CASE/tick.1000000.1015900"
+rm -f "$CASE/tick.1000000.1015900"
+_STATE_PATHS_OK=0
+_BURN_LEAD=
+true_case 'lead: revalidation failure fails open' state_burn_lead
+true_case 'lead: fail-open touches nothing' test ! -e "$CASE/tick.1000000.1015900"
+_STATE_PATHS_OK=1
+CASE="$TMPD/lead-fresh"
+unit_gate "$CASE/absent" 1000000 41.2 1015900 '' '' 0
+_BURN_LEAD=
+true_case 'lead: missing store parent fails open' state_burn_lead
+true_case 'lead: fail-open creates no token' test ! -e "$CASE/absent/tick.1000000.1015900"
+_BURN_LEAD=
+
+# Two-window coverage under election: a session holding a different (newer) 5h
+# window than the tick winner must still persist its rows and reach the limit
+# store, and the newer window's history must be enough for an active estimate.
+# The store starts absent, so the first render also proves the fail-open path
+# creates a working store from nothing.
+CASE="$TMPD/twowin"; mkdir -p "$CASE"
+_now=$(date +%s); _rA=$((_now + 9000)); _rB=$((_now + 12000))
+write_config "$CASE/conf" "$CASE/state" 'burn limit5h' 1
+_i=0
+while [ "$_i" -lt 3 ]; do
+  make_payload "$CASE/inA" "3$_i.5" "$_rA" '' ''
+  make_payload "$CASE/inB" "4$_i.5" "$_rB" '' ''
+  CORALLINE_CONFIG="$CASE/conf" CORALLINE_NO_SAMPLE=0 "$BASH_BIN" "$SCRIPT" < "$CASE/inA" > /dev/null 2> "$CASE/errA.$_i" &
+  _pidA=$!
+  CORALLINE_CONFIG="$CASE/conf" CORALLINE_NO_SAMPLE=0 "$BASH_BIN" "$SCRIPT" < "$CASE/inB" > /dev/null 2> "$CASE/errB.$_i" &
+  _pidB=$!
+  wait "$_pidA" "$_pidB" 2>/dev/null
+  _i=$((_i + 1))
+  sleep 1
+done
+_rowsA=$(awk -F '\t' -v r="$_rA" '$3 == r' "$CASE/state/burn.tsv" 2>/dev/null | wc -l | tr -d ' ')
+_rowsB=$(awk -F '\t' -v r="$_rB" '$3 == r' "$CASE/state/burn.tsv" 2>/dev/null | wc -l | tr -d ' ')
+true_case 'two-window: older-window rows persisted' test "$_rowsA" -ge 2
+true_case 'two-window: newer-window rows persisted' test "$_rowsB" -ge 2
+# Once the newer reset lands, rl_choose makes every session render (and thus
+# republish) that window, so the store legitimately converges on B's entries;
+# the non-suppression proof is that entries exist at all and include B's reset.
+entry_count "$CASE/state/limit5.d"; _ENTRIES=$_COUNT
+true_case 'two-window: limit store received entries' test "$_ENTRIES" -ge 1
+_LIM_B=0; for _e in "$CASE/state/limit5.d/${_rB}"_*; do [ -e "$_e" ] && _LIM_B=1; done
+eq 'two-window: newer reset reached the limit store' "$_LIM_B" 1
+# The newer window's persisted rows must feed an active estimate rather than
+# stranding that session on permanent warming. The estimator needs crossings
+# spanning >= win/10 seconds, which a 3s render loop cannot produce, so the
+# read fixture adds two backdated in-window rows for the same reset; the LAST
+# crossing still comes from a row the elected renders persisted above.
+CASE2="$TMPD/twowin-read"; mkdir -p "$CASE2"
+{ printf '%s\t38.000\t%s\n' "$((_now - 300))" "$_rB"; printf '%s\t39.000\t%s\n' "$((_now - 240))" "$_rB"; cat "$CASE/state/burn.tsv"; } > "$CASE2/burn.tsv"
+unit_gate "$CASE2" $((_now + 5)) 49.5 "$_rB" '' '' 1
+burn_eta_5h 0
+eq 'two-window: newer window estimates active' "$_B5_STATE" active
 
 # Binding and renderer regressions after state/storage tests. Stubs isolate the
 # already-tested estimators from the presentation logic.

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -662,6 +662,27 @@ true_case 'lead: missing store parent fails open' state_burn_lead
 true_case 'lead: fail-open creates no token' test ! -e "$CASE/absent/burn.tsv.1000000.1015900.41200.tick"
 _BURN_LEAD=
 
+# Maintenance claim: a render with no valid 5h reading may still win the
+# mutate path (trim/heal/sweep never starve), under the reserved 0.0 name; it
+# loses to any same-second claimant, and a real claimant ignores it.
+CASE="$TMPD/lead-maint"; mkdir -p "$CASE"
+unit_gate "$CASE" 1000000 '' '' '' '' 0
+_BURN_LEAD=
+true_case 'maint: reading-less render claims maintenance' state_burn_lead
+true_case 'maint: reserved token created' test -f "$CASE/burn.tsv.1000000.0.0.tick"
+rm -f "$CASE"/burn.tsv.*.tick
+: > "$CASE/burn.tsv.1000000.1015900.41200.tick"
+_BURN_LEAD=
+if state_burn_lead; then bad 'maint: loses to a same-second claimant' won; else ok 'maint: loses to a same-second claimant'; fi
+rm -f "$CASE"/burn.tsv.*.tick
+: > "$CASE/burn.tsv.1000000.0.0.tick"
+unit_gate "$CASE" 1000000 41.2 1015900 '' '' 0
+_BURN_LEAD=
+true_case 'maint: real claimant ignores the maintenance token' state_burn_lead
+true_case 'maint: real claim landed beside it' test -f "$CASE/burn.tsv.1000000.1015900.41200.tick"
+rm -f "$CASE"/burn.tsv.*.tick
+_BURN_LEAD=
+
 # Two-window coverage under election: a session holding a different (newer) 5h
 # window than the tick winner must still persist its rows and reach the limit
 # store, and the newer window's history must be enough for an active estimate.

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -601,52 +601,65 @@ run5h '1\t6\t9\n2\t7\t9\n9999000\t99\t99999999\n' 6 1
 if grep -q 99999999 "$BURN_FILE"; then bad 'heal is not deferred by slack' present; else ok 'heal is not deferred by slack'; fi
 BURN_TRIM=1500; BURN_SLACK=0
 
-# Per-(second, window) burn-write election. The token is the only coordination
-# point and every touch around it re-runs the store's TOCTOU guards.
+# Per-(second, window, pct) burn-write election. Tokens carry the store's own
+# file name as prefix (provenance: a shared directory never gets foreign files
+# deleted) and every touch around the claim re-runs the store's TOCTOU guards.
 CASE="$TMPD/lead"; mkdir -p "$CASE"
 unit_gate "$CASE" 1000000 41.2 1015900 '' '' 0
+TOK="$CASE/burn.tsv.1000000.1015900.41200.tick"
 _BURN_LEAD=
 true_case 'lead: first claim wins' state_burn_lead
-true_case 'lead: winning claim leaves a token' test -f "$CASE/tick.1000000.1015900"
+true_case 'lead: winning claim leaves a token' test -f "$TOK"
 _BURN_LEAD=
-if state_burn_lead; then bad 'lead: planted same-window token loses' won; else ok 'lead: planted same-window token loses'; fi
-rm -f "$CASE/tick.1000000.1015900"
-: > "$CASE/tick.1000000.1016000"
+if state_burn_lead; then bad 'lead: same-pct token loses' won; else ok 'lead: same-pct token loses'; fi
+rm -f "$TOK"
+: > "$CASE/burn.tsv.1000000.1015900.50000.tick"
+_BURN_LEAD=
+if state_burn_lead; then bad 'lead: higher-pct claim wins over ours' won; else ok 'lead: higher-pct claim wins over ours'; fi
+rm -f "$CASE/burn.tsv.1000000.1015900.50000.tick"
+: > "$CASE/burn.tsv.1000000.1015900.30000.tick"
+_BURN_LEAD=
+true_case 'lead: our higher reading beats a lower claim' state_burn_lead
+true_case 'lead: divergent readings both leave tokens' test -f "$TOK"
+rm -f "$CASE"/burn.tsv.*.tick
+: > "$CASE/burn.tsv.1000000.1016000.41200.tick"
 _BURN_LEAD=
 true_case 'lead: same-second other-window token does not block' state_burn_lead
-true_case 'lead: other-window token kept by the sweep' test -f "$CASE/tick.1000000.1016000"
-rm -f "$CASE"/tick.*
-: > "$CASE/tick.999990.1015900"
-: > "$CASE/tick.999999.1015900"
-: > "$CASE/tick.1000002.1015900"
-: > "$CASE/tick.abc.1015900"
-: > "$CASE/tick.999997"
-ln -s /dev/null "$CASE/tick.999980.1015900"
+true_case 'lead: other-window token kept by the sweep' test -f "$CASE/burn.tsv.1000000.1016000.41200.tick"
+rm -f "$CASE"/burn.tsv.*.tick
+: > "$CASE/burn.tsv.999990.1015900.41200.tick"
+: > "$CASE/burn.tsv.999999.1015900.41200.tick"
+: > "$CASE/burn.tsv.1000002.1015900.41200.tick"
+: > "$CASE/burn.tsv.abc.1015900.41200.tick"
+: > "$CASE/burn.tsv.999990.1015900.tick"
+: > "$CASE/tick.999990.1015900.41200.tick"
+ln -s /dev/null "$CASE/burn.tsv.999980.1015900.41200.tick"
 _BURN_LEAD=
 state_burn_lead || bad 'lead: sweep round claim' lost
-true_case 'lead sweep: stale token removed' test ! -e "$CASE/tick.999990.1015900"
-true_case 'lead sweep: recent-past token kept for stragglers' test -f "$CASE/tick.999999.1015900"
-true_case 'lead sweep: future token removed' test ! -e "$CASE/tick.1000002.1015900"
-true_case 'lead sweep: non-numeric epoch kept' test -f "$CASE/tick.abc.1015900"
-true_case 'lead sweep: single-field name kept' test -f "$CASE/tick.999997"
-true_case 'lead sweep: symlink kept' test -L "$CASE/tick.999980.1015900"
-rm -f "$CASE"/tick.* 2>/dev/null; rm -f "$CASE/tick.abc.1015900" "$CASE/tick.999997"
-ln -s "$CASE/linktarget" "$CASE/tick.1000000.1015900"
+true_case 'lead sweep: stale token removed' test ! -e "$CASE/burn.tsv.999990.1015900.41200.tick"
+true_case 'lead sweep: recent-past token kept for stragglers' test -f "$CASE/burn.tsv.999999.1015900.41200.tick"
+true_case 'lead sweep: future token removed' test ! -e "$CASE/burn.tsv.1000002.1015900.41200.tick"
+true_case 'lead sweep: non-numeric epoch kept' test -f "$CASE/burn.tsv.abc.1015900.41200.tick"
+true_case 'lead sweep: two-field name kept' test -f "$CASE/burn.tsv.999990.1015900.tick"
+true_case 'lead sweep: foreign unprefixed file untouched' test -f "$CASE/tick.999990.1015900.41200.tick"
+true_case 'lead sweep: symlink kept' test -L "$CASE/burn.tsv.999980.1015900.41200.tick"
+rm -f "$CASE"/burn.tsv.*.tick "$CASE"/tick.* 2>/dev/null
+ln -s "$CASE/linktarget" "$TOK"
 _BURN_LEAD=
 if state_burn_lead; then bad 'lead: symlink at the token name loses' won; else ok 'lead: symlink at the token name loses'; fi
 true_case 'lead: symlink token never followed' test ! -e "$CASE/linktarget"
-true_case 'lead: symlink token never deleted' test -L "$CASE/tick.1000000.1015900"
-rm -f "$CASE/tick.1000000.1015900"
+true_case 'lead: symlink token never deleted' test -L "$TOK"
+rm -f "$TOK"
 _STATE_PATHS_OK=0
 _BURN_LEAD=
 true_case 'lead: revalidation failure fails open' state_burn_lead
-true_case 'lead: fail-open touches nothing' test ! -e "$CASE/tick.1000000.1015900"
+true_case 'lead: fail-open touches nothing' test ! -e "$TOK"
 _STATE_PATHS_OK=1
 CASE="$TMPD/lead-fresh"
 unit_gate "$CASE/absent" 1000000 41.2 1015900 '' '' 0
 _BURN_LEAD=
 true_case 'lead: missing store parent fails open' state_burn_lead
-true_case 'lead: fail-open creates no token' test ! -e "$CASE/absent/tick.1000000.1015900"
+true_case 'lead: fail-open creates no token' test ! -e "$CASE/absent/burn.tsv.1000000.1015900.41200.tick"
 _BURN_LEAD=
 
 # Two-window coverage under election: a session holding a different (newer) 5h


### PR DESCRIPTION
## Problem

With N concurrent sessions and the burn/limit-sync features enabled, the burn store becomes the dominant statusline cost at steady state. Once `burn-5h.tsv` reaches `BURN_TRIM` (1500 rows), any append pushes the physical row count past the trim trigger, so every render of every session rewrites the whole 1500-row file once per second, all racing on the same path, and N sessions keep the file permanently over the cap. Paired N-scaling benchmarks measured the steady-state mutating path at 78 ms CPU/render at n=1 rising to 138 ms at n=16, with the write side alone about 600 ms CPU/s aggregate at n=16.

## Change

Two mechanisms, both confined to the Bash renderer's burn write path; schema, config surface, limit-store semantics, and the default render path are unchanged.

**Trim hysteresis.** New internal `BURN_SLACK` (500, clamped in `state_gate` like `BURN_TRIM`, ceiling 1000) lets appends accumulate past `BURN_TRIM` before one render pays the rewrite, so a capped store is rewritten once per ~500 appended rows instead of on every render. Healing is never deferred by slack. The 3000+1000 worst case stays far below the reader's 4096-physical-row bail-out.

**Per-(second, window) leader election.** `state_burn_lead()` claims an empty token file `tick.<epoch>.<reset>` beside the TSV with a noclobber `:` redirect (O_CREAT|O_EXCL, zero forks); only the winner appends and runs the trim path that second. The reader's `add_obs` already collapses same-(reset, sample) rows to one observation, so one writer per second yields an identical post-dedup series, and a session holding a different 5h window claims a different token and still persists its own rows. `rl_sample` is deliberately not elected: limit entries are idempotent bounded mkdirs with no rewrite cost, and any session may hold a newer window that must always reach the store.

Safety follows the store's existing discipline: `state_paths_revalidate` runs immediately before the token create and again before the sweep; a symlink planted at the token name is neither followed nor deleted and simply loses the tick; a claim failing with the token absent (fresh store, missing parent) fails open to the historical every-session-writes behavior so sampling never silently stops. The leader sweeps only regular non-symlink files matching `tick.<digits>.<digits>`, capped at 8 per render, and only outside an 8-second grace window so a straggler still finishing second T finds T's token intact (without the grace window, the n=16 concurrency test caught reclaim-and-double-write). Leftover tokens are inert empty files older versions ignore; rollback is a single revert.

## Verification

- `test/test-burn.sh`: 268 cases, ALL PASS on macOS `/bin/bash` 3.2.57 and Homebrew bash 5.3.15. The real-render concurrency checker's contract changes from rows == renders to the single-writer contract (rows within [1, renders], zero duplicate (sample, reset) pairs); stubbing the election to always-win fails those cases with dupes=9/23/31 at n=5/12/16, so the contract detects a broken election.
- New cases: slack hysteresis (hold below trim+slack, rewrite past it, heal never deferred), election win/lose/symlink/fail-open, sweep grace-window behavior, and a two-window run proving a session on a different reset still persists rows, reaches the limit store, and estimates active.
- Default path (no burn, no limit sync) renders byte-identically to main, stdout and stderr.
- Paired A/B benchmark (5 alternating rounds, lead rotation, control-arm noise floor) on a capped 1600-row fixture at n=16: median candidate/main CPU ratio 0.904, p50 wall down 19.8% (945 ms to 758 ms), state-disabled arm unchanged within noise (-1.9%). An in-situ check across 96 concurrent renders showed exactly one token and one appended row per second, and the seeded file was never rewritten below the slack threshold.

The original plan targeted a >=20% CPU cut; measured is ~10% CPU plus ~20% p50 wall. The shortfall is understood: the remaining cost is dominated by every session's full 1500-row read/parse each second, which this PR's leader mechanism is the foundation for fixing (a follow-up will have the leader publish the computed estimate so followers skip the full parse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNLnF1e3vJUEsNWfXjCL7E