### PR TITLE
perf(state): winner-published burn estimate with follower fast path

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -1149,17 +1149,27 @@ EOF
   [ "$had_c" = 1 ] || set +C
   [ "$won" = 1 ] || return 0
   # Divergent same-second winners publish in parse-completion order, which is
-  # not claim order: a lower-pct winner finishing late must never replace the
-  # estimate of a covering higher claim whose parse includes a row ours does
-  # not. If a higher claim exists by the time we are about to rename, yield;
-  # if it appears in the residual race window instead, its own publication
+  # not claim order: a winner finishing late must never replace the estimate
+  # of a covering claim whose parse includes a row ours does not. That covers
+  # a higher pct in our own window AND any claim for a newer window (whose
+  # estimate would supersede ours for every adopter our own would satisfy).
+  # If a covering claim exists by the time we are about to rename, yield; if
+  # it appears in the residual race window instead, its own publication
   # necessarily lands after ours and corrects the file.
-  for f in "$_SB_BASE.${NOW}.${_CUR_BURN_RST}".*.tick; do
+  local cr
+  for f in "$_SB_BASE.${NOW}".*.tick; do
     [ -e "$f" ] || [ -L "$f" ] || continue
-    p=${f#"$_SB_BASE.${NOW}.${_CUR_BURN_RST}".}; p=${p%.tick}
+    p=${f#"$_SB_BASE.${NOW}".}; p=${p%.tick}
+    case "$p" in *.*) ;; *) continue ;; esac
+    cr=${p%%.*}; p=${p#*.}
+    case "$cr" in (''|*[!0-9]*) continue ;; esac
+    [ "${#cr}" -le 12 ] || continue
     case "$p" in (''|*[!0-9]*) continue ;; esac
     [ "${#p}" -le 6 ] || continue
-    if [ "$p" -gt "$_CUR_BURN_PCT" ]; then rm -f "$tmp" 2>/dev/null; return 0; fi
+    if [ "$cr" -gt "$_CUR_BURN_RST" ]; then rm -f "$tmp" 2>/dev/null; return 0; fi
+    if [ "$cr" -eq "$_CUR_BURN_RST" ] && [ "$p" -gt "$_CUR_BURN_PCT" ]; then
+      rm -f "$tmp" 2>/dev/null; return 0
+    fi
   done
   if state_paths_revalidate && state_no_symlink_path "$est" && [ "$_SNP" = "$est" ] \
      && state_path_leaf "$est" f; then
@@ -1191,8 +1201,11 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
   # An estimate for a window older than our own reading is a cache miss, not a
   # candidate: our observation alone would advance maxrst past it, so the full
   # parse must run. Without this, the 3s freshness allowance could span a 5h
-  # reset and briefly revive the closed window's ETA.
+  # reset and briefly revive the closed window's ETA. The far bound mirrors
+  # the TSV estimator's implausibility rule (reset beyond NOW + RL_MAX_5H is
+  # healed there, so it must never be adopted here either).
   [ "$rst" -ge "${_CUR_BURN_RST:-0}" ] || return 1
+  [ "$rst" -le $(( NOW + RL_MAX_5H )) ] || return 1
   case "${s:-}" in (active|idle|warming) ;; (*) return 1 ;; esac
   # Leading zeros are rejected outright (our publisher never emits them, and
   # bash arithmetic downstream would read them as octal): the (0|[1-9]...)

--- a/statusline.sh
+++ b/statusline.sh
@@ -1095,7 +1095,18 @@ burn_eta_5h() {  # → _B5_* from canonical TSV; $1=allow trim/heal mutation
 
   if [ "$write_tmp" = 1 ] && [ -f "$tmp" ] && [ ! -L "$tmp" ]; then
     if [ "$rc" -eq 0 ] && state_paths_revalidate && state_no_symlink_path "$tmp" && [ "$_SNP" = "$tmp" ]; then
-      mv -f "$tmp" "$_SB_BASE" 2>/dev/null || true
+      if mv -f "$tmp" "$_SB_BASE" 2>/dev/null; then
+        # rename(2) carries the temporary's own mtime onto the store, and that
+        # timestamp predates the replacement - it is when awk wrote the file.
+        # A replacement could therefore land looking OLDER than a concurrent
+        # reader's snapshot marker, and that reader would treat a store it
+        # never parsed as untouched. Stamping the store after the rename makes
+        # every replacement advance past any marker taken before it. The stamp
+        # is one empty line: both renderers skip a record that does not split
+        # into three fields (awk's `nf != 3` here, ConvertFrom-BurnRecord's
+        # length check in statusline.ps1), and the next rewrite drops it.
+        state_paths_revalidate && printf '\n' >> "$_SB_BASE" 2>/dev/null || true
+      fi
     elif state_paths_revalidate && state_no_symlink_path "$tmp" && [ "$_SNP" = "$tmp" ]; then
       rm -f "$tmp" 2>/dev/null || true
     fi

--- a/statusline.sh
+++ b/statusline.sh
@@ -1201,8 +1201,8 @@ EOF
   # covering claim the adopter lost to predates a row its own full parse
   # would include, and is rejected on the read side regardless of how writer
   # renames interleave.
-  if printf '%s %s %s %s %s %s %s %s\n' "$NOW" $(( NOW + ${_B5_TTR:-0} )) "$s" "$sp" "$d" "$l" \
-       "$_CUR_BURN_RST" "$_CUR_BURN_PCT" 2>/dev/null > "$tmp"; then won=1; fi
+  if printf '%s %s %s %s %s %s %s %s %s\n' "$NOW" $(( NOW + ${_B5_TTR:-0} )) "$s" "$sp" "$d" "$l" \
+       "$_CUR_BURN_RST" "$_CUR_BURN_PCT" "$CORALLINE_BURN_WINDOW" 2>/dev/null > "$tmp"; then won=1; fi
   [ "$had_c" = 1 ] || set +C
   # The redirection creates the file before printf runs, so a write that
   # fails afterwards (out of space, over quota) leaves a partial temporary
@@ -1242,7 +1242,7 @@ EOF
 }
 
 burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated estimate
-  local est="$_SB_BASE.est" LC_ALL=C pub rst s sp d l crst cpct t
+  local est="$_SB_BASE.est" LC_ALL=C pub rst s sp d l crst cpct cwin t
   # Same defaults burn_eta_5h starts from: the adopter replaces that call
   # entirely, and downstream comparisons assume every _B5_* is populated.
   _B5_STATE=warming; _B5_ETA=inf; _B5_RATE="0.0000000000"; _B5_TTR=0; _B5_RAW=""
@@ -1266,7 +1266,7 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
   # a render will ever ingest; trailing junk lands in the last field and
   # fails its digit check, so a malformed line is rejected, never truncated
   # into a plausible one.
-  read -r -n 128 pub rst s sp d l crst cpct < "$est" 2>/dev/null || :
+  read -r -n 128 pub rst s sp d l crst cpct cwin < "$est" 2>/dev/null || :
   # Every field is validated before it reaches any arithmetic context; the
   # published values bypass the awk whose internal caps normally guarantee
   # these bounds, so the reader must re-impose them itself.
@@ -1300,6 +1300,13 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
   state_epoch "${crst:-}" 12 || return 1; crst=$_SE_VALUE
   case "${cpct:-}" in (''|*[!0-9]*|0[0-9]*) return 1 ;; esac
   [ "${#cpct}" -le 6 ] && [ "$cpct" -le 100000 ] || return 1
+  # The estimate is a parse under a specific lookback, and CORALLINE_BURN_WINDOW
+  # is per-session config: sessions sharing one BURN_FILE with different
+  # lookbacks compute genuinely different answers from identical rows, and a
+  # wider window can report active where a narrower one reports warming.
+  # Adopt only a parse run under our own lookback.
+  case "${cwin:-}" in (''|*[!0-9]*|0[0-9]*) return 1 ;; esac
+  [ "${#cwin}" -le 5 ] && [ "$cwin" -eq "$CORALLINE_BURN_WINDOW" ] || return 1
   if [ "$crst" -le "${_CUR_BURN_RST:-0}" ]; then
     [ "$crst" -eq "${_CUR_BURN_RST:-0}" ] || return 1
     [ "$cpct" -ge "${_BURN_LOST_PCT:-100001}" ] || return 1

--- a/statusline.sh
+++ b/statusline.sh
@@ -1255,8 +1255,11 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
   # defined by the newest sample, so a same-window adoption substitutes our
   # own current pct for the published latest. Percentages legitimately DROP
   # within a window (upstream resets, subscription upgrades - see rl_choose
-  # above), so this is a substitution, not a max.
-  [ "$crst" -eq "${_CUR_BURN_RST:-0}" ] && l=$_CUR_BURN_PCT
+  # above), so this is a substitution, not a max - but only for a PRIOR-tick
+  # estimate: a same-tick winner's row shares our sample key, where add_obs
+  # keeps the maximum, so the published latest already includes what our own
+  # injection could contribute.
+  [ "$crst" -eq "${_CUR_BURN_RST:-0}" ] && [ "$pub" -lt "$NOW" ] && l=$_CUR_BURN_PCT
   # ttr derives locally from the published window and our own NOW, so a
   # 1-3s-old estimate cannot trip the rebind gate into warming flicker.
   t=$(( rst - NOW )); [ "$t" -lt 0 ] && t=0

--- a/statusline.sh
+++ b/statusline.sh
@@ -964,8 +964,10 @@ burn_tmp_sweep() {  # remove trim temporaries orphaned by killed renders
 # deliberate security property: _B5_ETA and _B5_TTR flow into bash arithmetic
 # downstream, so every producer must pass this same gate.
 burn_b5_line() {  # → _B5_* from one estimator line; 1 = line rejected
-  local state span delta latest ttr
-  read -r state span delta latest ttr <<EOF
+  # The trailing newest-sample epoch is provenance for the cache, not input
+  # to the estimate; it is read here only so it cannot land inside ttr.
+  local state span delta latest ttr newest
+  read -r state span delta latest ttr newest <<EOF
 $1
 EOF
   case "$state" in
@@ -1060,14 +1062,14 @@ burn_eta_5h() {  # → _B5_* from canonical TSV; $1=allow trim/heal mutation
       if (curvalid) add_obs(crst + 0, csamp + 0, cpct + 0)
       maxrst = 0
       for (i = 1; i <= n; i++) if (rs[i] > maxrst) maxrst = rs[i]
-      if (maxrst <= 0) { print "warming 0 0 0 0"; exit }
+      if (maxrst <= 0) { print "warming 0 0 0 0 0"; exit }
       m = 0
       for (i = 1; i <= n; i++) if (rs[i] == maxrst) {
         sk = sprintf("%.0f", sm[i])
         if (!(sk in sample_pct)) { order[++m] = sm[i]; sample_pct[sk] = pc[i] }
         else if (pc[i] > sample_pct[sk]) sample_pct[sk] = pc[i]
       }
-      if (m == 0) { print "warming 0 0 0 0"; exit }
+      if (m == 0) { print "warming 0 0 0 0 0"; exit }
       qsort(order, 1, m)
       sk = sprintf("%.0f", order[m]); latest = sample_pct[sk]
       ttr = maxrst - now; if (ttr < 0) ttr = 0
@@ -1085,9 +1087,9 @@ burn_eta_5h() {  # → _B5_* from canonical TSV; $1=allow trim/heal mutation
         }
       }
       if (ncross >= 2 && lc_t > fc_t && lc_p > fc_p && (lc_t - fc_t) >= minspan)
-        printf "active %.0f %.0f %.0f %.0f\n", lc_t - fc_t, lc_p - fc_p, latest, ttr
-      else if (anycross && ncross == 0) printf "idle 0 0 %.0f %.0f\n", latest, ttr
-      else printf "warming 0 0 %.0f %.0f\n", latest, ttr
+        printf "active %.0f %.0f %.0f %.0f %.0f\n", lc_t - fc_t, lc_p - fc_p, latest, ttr, order[m]
+      else if (anycross && ncross == 0) printf "idle 0 0 %.0f %.0f %.0f\n", latest, ttr, order[m]
+      else printf "warming 0 0 %.0f %.0f %.0f\n", latest, ttr, order[m]
     }
   ' "$src" 2>/dev/null); rc=$?
 
@@ -1177,7 +1179,7 @@ burn_est_publish() {  # winner only: publish "<now> <maxrst> <state> <span> <del
   [ "$fresh" = 1 ] || return 0
   [ "${_CUR_BURN_VALID:-0}" = 1 ] || return 0
   [ -n "${_B5_RAW:-}" ] || return 0
-  local est="$_SB_BASE.est" tmp="$_SB_BASE.$$.tmp" s sp d l t p f had_c=0 won=0
+  local est="$_SB_BASE.est" tmp="$_SB_BASE.$$.tmp" s sp d l t nw p f had_c=0 won=0
   state_paths_revalidate || return 0
   # The est file is a seventh state object outside state_paths_validate's
   # six-path distinctness matrix; refuse to publish over any configured
@@ -1191,9 +1193,10 @@ burn_est_publish() {  # winner only: publish "<now> <maxrst> <state> <span> <del
   state_path_leaf "$est" f || return 0
   state_no_symlink_path "$tmp" && [ "$_SNP" = "$tmp" ] || return 0
   [ ! -e "$tmp" ] && [ ! -L "$tmp" ] || return 0
-  read -r s sp d l t <<EOF
+  read -r s sp d l t nw <<EOF
 $_B5_RAW
 EOF
+  case "${nw:-}" in (''|*[!0-9]*) nw=0 ;; esac
   case $- in *C*) had_c=1 ;; esac
   set -C
   # The trailing claim identity (our reset and pct) lets an adopter require
@@ -1201,8 +1204,8 @@ EOF
   # covering claim the adopter lost to predates a row its own full parse
   # would include, and is rejected on the read side regardless of how writer
   # renames interleave.
-  if printf '%s %s %s %s %s %s %s %s %s\n' "$NOW" $(( NOW + ${_B5_TTR:-0} )) "$s" "$sp" "$d" "$l" \
-       "$_CUR_BURN_RST" "$_CUR_BURN_PCT" "$CORALLINE_BURN_WINDOW" 2>/dev/null > "$tmp"; then won=1; fi
+  if printf '%s %s %s %s %s %s %s %s %s %s\n' "$NOW" $(( NOW + ${_B5_TTR:-0} )) "$s" "$sp" "$d" "$l" \
+       "$_CUR_BURN_RST" "$_CUR_BURN_PCT" "$CORALLINE_BURN_WINDOW" "$nw" 2>/dev/null > "$tmp"; then won=1; fi
   [ "$had_c" = 1 ] || set +C
   # The redirection creates the file before printf runs, so a write that
   # fails afterwards (out of space, over quota) leaves a partial temporary
@@ -1242,7 +1245,7 @@ EOF
 }
 
 burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated estimate
-  local est="$_SB_BASE.est" LC_ALL=C pub rst s sp d l crst cpct cwin t
+  local est="$_SB_BASE.est" LC_ALL=C pub rst s sp d l crst cpct cwin cnew t
   # Same defaults burn_eta_5h starts from: the adopter replaces that call
   # entirely, and downstream comparisons assume every _B5_* is populated.
   _B5_STATE=warming; _B5_ETA=inf; _B5_RATE="0.0000000000"; _B5_TTR=0; _B5_RAW=""
@@ -1266,7 +1269,7 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
   # a render will ever ingest; trailing junk lands in the last field and
   # fails its digit check, so a malformed line is rejected, never truncated
   # into a plausible one.
-  read -r -n 128 pub rst s sp d l crst cpct cwin < "$est" 2>/dev/null || :
+  read -r -n 128 pub rst s sp d l crst cpct cwin cnew < "$est" 2>/dev/null || :
   # Every field is validated before it reaches any arithmetic context; the
   # published values bypass the awk whose internal caps normally guarantee
   # these bounds, so the reader must re-impose them itself.
@@ -1309,6 +1312,7 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
   # Adopt only a parse run under our own lookback.
   case "${cwin:-}" in (''|*[!0-9]*|0[0-9]*) return 1 ;; esac
   [ "${#cwin}" -le 5 ] && [ "$cwin" -eq "$CORALLINE_BURN_WINDOW" ] || return 1
+  state_epoch "${cnew:-}" 12 || return 1; cnew=$_SE_VALUE
   if [ "$crst" -le "${_CUR_BURN_RST:-0}" ]; then
     [ "$crst" -eq "${_CUR_BURN_RST:-0}" ] || return 1
     [ "$cpct" -ge "${_BURN_LOST_PCT:-100001}" ] || return 1
@@ -1339,6 +1343,13 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
     # would move span, delta, and possibly warming to active - none of them
     # correctable without the rows. Adopt only when our sample cannot change
     # them; then substituting latest is the entire difference.
+    #
+    # "Newest" is not an assumption either: the reader accepts samples up to
+    # now + 300 for clock skew, so a future-dated row can outrank ours and
+    # own latest, and inserting our row before it can even create a crossing
+    # against it. The publisher therefore states the newest sample it saw,
+    # and adoption falls back unless that proves ours comes after.
+    [ "$cnew" -lt "$NOW" ] || return 1
     [ $(( _CUR_BURN_PCT / 1000 )) -gt $(( l / 1000 )) ] && return 1
     l=$_CUR_BURN_PCT
   fi

--- a/statusline.sh
+++ b/statusline.sh
@@ -1178,32 +1178,30 @@ burn_est_snap() {  # → _BURN_SNAP: marker recording the pre-parse TSV state
 }
 
 burn_est_publish() {  # winner only: publish "<now> <maxrst> <state> <span> <delta> <latest>"
-  # Release the parse-time marker first and unconditionally: its only job is
-  # this comparison, and every later exit path must not leak it. No marker
-  # means the parse was never versioned, which is a refusal, not a licence.
-  local fresh=0
-  if [ -n "${_BURN_SNAP:-}" ]; then
-    [ "$_SB_BASE" -nt "$_BURN_SNAP" ] || fresh=1
-    burn_est_discard "$_BURN_SNAP"
-    _BURN_SNAP=""
-  fi
-  [ "$fresh" = 1 ] || return 0
-  [ "${_CUR_BURN_VALID:-0}" = 1 ] || return 0
-  [ -n "${_B5_RAW:-}" ] || return 0
+  # The parse-time marker is claimed for this call and released on every exit
+  # path below. No marker means the parse was never versioned, which is a
+  # refusal, not a licence.
+  local snap="${_BURN_SNAP:-}"
+  _BURN_SNAP=""
+  [ -n "$snap" ] || return 0
+  [ "${_CUR_BURN_VALID:-0}" = 1 ] || { burn_est_discard "$snap"; return 0; }
+  [ -n "${_B5_RAW:-}" ] || { burn_est_discard "$snap"; return 0; }
   local est="$_SB_BASE.est" tmp="$_SB_BASE.$$.tmp" s sp d l t nw p f had_c=0 won=0
-  state_paths_revalidate || return 0
+  state_paths_revalidate || { burn_est_discard "$snap"; return 0; }
   # The est file is a seventh state object outside state_paths_validate's
   # six-path distinctness matrix; refuse to publish over any configured
   # namespace (state_same_path is conservative: unsure means same).
   for p in "$_SB_BASE" "$_SB_ROOT" "$_SL5_BASE" "$_SL5_ROOT" "$_SL7_BASE" "$_SL7_ROOT"; do
-    if state_same_path "$est" "$p"; then return 0; fi
+    if state_same_path "$est" "$p"; then burn_est_discard "$snap"; return 0; fi
   done
   # A symlink or directory planted at the est name is not followed, not
   # deleted, and aborts the publish; same rule as the election tokens.
-  state_no_symlink_path "$est" && [ "$_SNP" = "$est" ] || return 0
-  state_path_leaf "$est" f || return 0
-  state_no_symlink_path "$tmp" && [ "$_SNP" = "$tmp" ] || return 0
-  [ ! -e "$tmp" ] && [ ! -L "$tmp" ] || return 0
+  state_no_symlink_path "$est" && [ "$_SNP" = "$est" ] \
+    || { burn_est_discard "$snap"; return 0; }
+  state_path_leaf "$est" f || { burn_est_discard "$snap"; return 0; }
+  state_no_symlink_path "$tmp" && [ "$_SNP" = "$tmp" ] \
+    || { burn_est_discard "$snap"; return 0; }
+  [ ! -e "$tmp" ] && [ ! -L "$tmp" ] || { burn_est_discard "$snap"; return 0; }
   read -r s sp d l t nw <<EOF
 $_B5_RAW
 EOF
@@ -1223,7 +1221,7 @@ EOF
   # that burn_tmp_sweep cannot retire while the same failure keeps the TSV
   # from advancing past it. Discard it here instead of accumulating one per
   # winner render.
-  [ "$won" = 1 ] || { burn_est_discard "$tmp"; return 0; }
+  [ "$won" = 1 ] || { burn_est_discard "$tmp"; burn_est_discard "$snap"; return 0; }
   # Divergent same-second winners publish in parse-completion order, which is
   # not claim order: a winner finishing late must never replace the estimate
   # of a covering claim whose parse includes a row ours does not. That covers
@@ -1242,16 +1240,28 @@ EOF
     [ "${#cr}" -le 12 ] || continue
     case "$p" in (''|*[!0-9]*) continue ;; esac
     [ "${#p}" -le 6 ] || continue
-    if [ "$cr" -gt "$_CUR_BURN_RST" ]; then burn_est_discard "$tmp"; return 0; fi
+    if [ "$cr" -gt "$_CUR_BURN_RST" ]; then
+      burn_est_discard "$tmp"; burn_est_discard "$snap"; return 0
+    fi
     if [ "$cr" -eq "$_CUR_BURN_RST" ] && [ "$p" -gt "$_CUR_BURN_PCT" ]; then
-      burn_est_discard "$tmp"; return 0
+      burn_est_discard "$tmp"; burn_est_discard "$snap"; return 0
     fi
   done
-  if state_paths_revalidate && state_no_symlink_path "$est" && [ "$_SNP" = "$est" ] \
+  # The version test belongs HERE, immediately before the rename, not before
+  # the temporary was written: a row landing in between would otherwise be
+  # missing from an estimate that nonetheless carries a newer mtime than the
+  # TSV, defeating the adopter's guard too. The marker must also still exist:
+  # it shares burn_tmp_sweep's namespace, so a concurrent writer's sweep can
+  # retire it mid-parse, and a vanished marker proves nothing about the
+  # store. Both conditions failing mean the same thing - this estimate is not
+  # provably a summary of the current TSV - so publication is abandoned.
+  if [ -f "$snap" ] && [ ! -L "$snap" ] && [ ! "$_SB_BASE" -nt "$snap" ] \
+     && state_paths_revalidate && state_no_symlink_path "$est" && [ "$_SNP" = "$est" ] \
      && state_path_leaf "$est" f; then
-    mv -f "$tmp" "$est" 2>/dev/null && return 0
+    if mv -f "$tmp" "$est" 2>/dev/null; then burn_est_discard "$snap"; return 0; fi
   fi
   burn_est_discard "$tmp"
+  burn_est_discard "$snap"
   return 0
 }
 

--- a/statusline.sh
+++ b/statusline.sh
@@ -1136,7 +1136,42 @@ burn_est_discard() {  # $1=our publish temporary; remove only through revalidate
   return 0
 }
 
+# The estimate has to describe the TSV as it stood when the parse READ it,
+# not when the publish wrote it. A straggler appending in between would
+# otherwise hand followers a summary that silently omits its row: the
+# adopter's mtime test cannot catch that, because the estimate is written
+# afterwards and is therefore legitimately newer. A zero-byte marker taken
+# before the parse records that instant, and publication is abandoned if the
+# TSV moved past it. The marker lives in the <base>.<digits>.tmp namespace
+# burn_tmp_sweep owns, so a killed render leaves nothing permanent, and it is
+# named apart from the pid-named temporaries the trim and the publish use. A
+# trim rewrite during our own parse also trips the test and costs that
+# second's publication: rare (once per BURN_SLACK appends), and the next tick
+# publishes normally.
+burn_est_snap() {  # → _BURN_SNAP: marker recording the pre-parse TSV state
+  _BURN_SNAP=""
+  local snap="$_SB_BASE.$(( $$ + 1000000 )).tmp" had_c=0
+  state_paths_revalidate || return 0
+  state_no_symlink_path "$snap" && [ "$_SNP" = "$snap" ] || return 0
+  [ ! -e "$snap" ] && [ ! -L "$snap" ] || return 0
+  case $- in *C*) had_c=1 ;; esac
+  set -C
+  : 2>/dev/null > "$snap" && _BURN_SNAP=$snap
+  [ "$had_c" = 1 ] || set +C
+  return 0
+}
+
 burn_est_publish() {  # winner only: publish "<now> <maxrst> <state> <span> <delta> <latest>"
+  # Release the parse-time marker first and unconditionally: its only job is
+  # this comparison, and every later exit path must not leak it. No marker
+  # means the parse was never versioned, which is a refusal, not a licence.
+  local fresh=0
+  if [ -n "${_BURN_SNAP:-}" ]; then
+    [ "$_SB_BASE" -nt "$_BURN_SNAP" ] || fresh=1
+    burn_est_discard "$_BURN_SNAP"
+    _BURN_SNAP=""
+  fi
+  [ "$fresh" = 1 ] || return 0
   [ "${_CUR_BURN_VALID:-0}" = 1 ] || return 0
   [ -n "${_B5_RAW:-}" ] || return 0
   local est="$_SB_BASE.est" tmp="$_SB_BASE.$$.tmp" s sp d l t p f had_c=0 won=0
@@ -1291,6 +1326,7 @@ burn_estimate() {  # → _BURN_STATE _BURN_LABEL _BURN_ETA _BURN_RATE _BURN_TTR
   # when it validates, and everything else takes the plain read-only parse.
   [ "${_STATE_MUTATE:-0}" = 1 ] && state_burn_lead && m=1
   if [ "$m" = 1 ]; then
+    burn_est_snap
     burn_eta_5h 1
     burn_est_publish
   elif [ "${_BURN_LOST:-0}" = 1 ] && [ "${_CUR_BURN_VALID:-0}" = 1 ] && burn_est_adopt; then

--- a/statusline.sh
+++ b/statusline.sh
@@ -699,7 +699,11 @@ state_burn_lead() {  # → 0 iff this render must run the burn write path
     for f in "$slot".*.tick; do
       [ -e "$f" ] || [ -L "$f" ] || continue
       p=${f#"$slot".}; p=${p%.tick}
+      # Length caps mirror state_epoch's width rule: a planted name with an
+      # oversized digit run must not reach [ -gt ] (integer overflow would
+      # leak an error line onto the render's stderr).
       case "$p" in (''|*[!0-9]*) continue ;; esac
+      [ "${#p}" -le 6 ] || continue
       [ "$p" -gt "$best" ] && best=$p
     done
     [ "$_CUR_BURN_PCT" -gt "$best" ] || return 1
@@ -748,11 +752,14 @@ state_burn_lead() {  # → 0 iff this render must run the burn write path
     n=${f#"$_SB_BASE".}; n=${n%.tick}
     e=${n%%.*}
     case "$e" in (''|*[!0-9]*) continue ;; esac
+    [ "${#e}" -le 12 ] || continue
     n=${n#*.}
     case "$n" in *.*) ;; *) continue ;; esac
     r=${n%%.*}; p=${n#*.}
     case "$r" in (''|*[!0-9]*) continue ;; esac
+    [ "${#r}" -le 12 ] || continue
     case "$p" in (''|*[!0-9]*) continue ;; esac
+    [ "${#p}" -le 6 ] || continue
     [ "$e" -le "$NOW" ] && [ "$e" -ge $(( NOW - 8 )) ] && continue
     set -- "$@" "$f"; c=$(( c + 1 ))
     [ "$c" -ge 8 ] && break

--- a/statusline.sh
+++ b/statusline.sh
@@ -1207,12 +1207,17 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
   state_path_object "$est" f || return 1
   [ -f "$est" ] && [ ! -L "$est" ] || return 1
   # Snapshot versioning: an estimate is a parse of the TSV as it stood at
-  # publish time. A straggler from a prior tick (its token still inside the
-  # sweep's grace window) may append after that publish; if the TSV has a
-  # later mtime than the estimate, the cached parse is missing rows a
-  # read-only parse would see, so fall back. Same-second mutations sit below
-  # test's mtime granularity and are corrected by the next second's publish,
-  # a strictly tighter bound than the 3s freshness allowance.
+  # publish time, so the source must still be there to be summarized. A
+  # deleted TSV (history reset) makes the mtime test below vacuous - nothing
+  # is newer than the estimate - and would let a summary outlive the file it
+  # describes, where a full parse would report warming.
+  [ -f "$_SB_BASE" ] && [ ! -L "$_SB_BASE" ] || return 1
+  # A straggler from a prior tick (its token still inside the sweep's grace
+  # window) may append after that publish; if the TSV has a later mtime than
+  # the estimate, the cached parse is missing rows a read-only parse would
+  # see, so fall back. Same-second mutations sit below test's mtime
+  # granularity and are corrected by the next second's publish, a strictly
+  # tighter bound than the 3s freshness allowance.
   [ "$_SB_BASE" -nt "$est" ] && return 1
   # -n (not -N: that is bash 4.1+) caps how much of a hostile oversized file
   # a render will ever ingest; trailing junk lands in the last field and

--- a/statusline.sh
+++ b/statusline.sh
@@ -1125,7 +1125,7 @@ burn_eta_7d() {  # → _B7_*; $1=pct_milli $2=reset epoch
 burn_est_publish() {  # winner only: publish "<now> <maxrst> <state> <span> <delta> <latest>"
   [ "${_CUR_BURN_VALID:-0}" = 1 ] || return 0
   [ -n "${_B5_RAW:-}" ] || return 0
-  local est="$_SB_BASE.est" tmp="$_SB_BASE.$$.tmp" s sp d l t p had_c=0 won=0
+  local est="$_SB_BASE.est" tmp="$_SB_BASE.$$.tmp" s sp d l t p f had_c=0 won=0
   state_paths_revalidate || return 0
   # The est file is a seventh state object outside state_paths_validate's
   # six-path distinctness matrix; refuse to publish over any configured
@@ -1148,6 +1148,19 @@ EOF
        2>/dev/null > "$tmp"; then won=1; fi
   [ "$had_c" = 1 ] || set +C
   [ "$won" = 1 ] || return 0
+  # Divergent same-second winners publish in parse-completion order, which is
+  # not claim order: a lower-pct winner finishing late must never replace the
+  # estimate of a covering higher claim whose parse includes a row ours does
+  # not. If a higher claim exists by the time we are about to rename, yield;
+  # if it appears in the residual race window instead, its own publication
+  # necessarily lands after ours and corrects the file.
+  for f in "$_SB_BASE.${NOW}.${_CUR_BURN_RST}".*.tick; do
+    [ -e "$f" ] || [ -L "$f" ] || continue
+    p=${f#"$_SB_BASE.${NOW}.${_CUR_BURN_RST}".}; p=${p%.tick}
+    case "$p" in (''|*[!0-9]*) continue ;; esac
+    [ "${#p}" -le 6 ] || continue
+    if [ "$p" -gt "$_CUR_BURN_PCT" ]; then rm -f "$tmp" 2>/dev/null; return 0; fi
+  done
   if state_paths_revalidate && state_no_symlink_path "$est" && [ "$_SNP" = "$est" ] \
      && state_path_leaf "$est" f; then
     mv -f "$tmp" "$est" 2>/dev/null && return 0

--- a/statusline.sh
+++ b/statusline.sh
@@ -1194,6 +1194,14 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
   [ "${_STATE_BURN_SAFE:-0}" = 1 ] || return 1
   state_path_object "$est" f || return 1
   [ -f "$est" ] && [ ! -L "$est" ] || return 1
+  # Snapshot versioning: an estimate is a parse of the TSV as it stood at
+  # publish time. A straggler from a prior tick (its token still inside the
+  # sweep's grace window) may append after that publish; if the TSV has a
+  # later mtime than the estimate, the cached parse is missing rows a
+  # read-only parse would see, so fall back. Same-second mutations sit below
+  # test's mtime granularity and are corrected by the next second's publish,
+  # a strictly tighter bound than the 3s freshness allowance.
+  [ "$_SB_BASE" -nt "$est" ] && return 1
   # -n (not -N: that is bash 4.1+) caps how much of a hostile oversized file
   # a render will ever ingest; trailing junk lands in the last field and
   # fails its digit check, so a malformed line is rejected, never truncated

--- a/statusline.sh
+++ b/statusline.sh
@@ -708,8 +708,10 @@ state_burn_lead() {  # → 0 iff this render must run the burn write path
     done
     # A covering claim (pct at or above ours) is the one loss reason a
     # follower may trust: it proves a winner is computing this second, so the
-    # published estimate is safe to adopt (_BURN_LOST gates burn_est_adopt).
-    [ "$_CUR_BURN_PCT" -gt "$best" ] || { _BURN_LOST=1; return 1; }
+    # published estimate is safe to adopt (_BURN_LOST gates burn_est_adopt,
+    # and _BURN_LOST_PCT records the covering pct so the adopter can require
+    # the estimate's embedded claim to be at least that complete).
+    [ "$_CUR_BURN_PCT" -gt "$best" ] || { _BURN_LOST=1; _BURN_LOST_PCT=$best; return 1; }
   else
     # No reading of our own: maintenance-only claim under the reserved
     # window/pct 0.0, so trim, healing, and the tmp sweep never starve while
@@ -733,7 +735,7 @@ state_burn_lead() {  # → 0 iff this render must run the burn write path
   if [ "$won" != 1 ]; then
     # EEXIST from a regular file: another session claimed this exact reading,
     # which also counts as a covering claim for adoption purposes.
-    if [ -f "$tok" ] && [ ! -L "$tok" ]; then _BURN_LOST=1; return 1; fi
+    if [ -f "$tok" ] && [ ! -L "$tok" ]; then _BURN_LOST=1; _BURN_LOST_PCT=$_CUR_BURN_PCT; return 1; fi
     # A non-file object raced in: lose without trusting it.
     if [ -e "$tok" ] || [ -L "$tok" ]; then return 1; fi
     # Anything else (missing parent on a fresh store, transient fs error):
@@ -1144,8 +1146,13 @@ $_B5_RAW
 EOF
   case $- in *C*) had_c=1 ;; esac
   set -C
-  if printf '%s %s %s %s %s %s\n' "$NOW" $(( NOW + ${_B5_TTR:-0} )) "$s" "$sp" "$d" "$l" \
-       2>/dev/null > "$tmp"; then won=1; fi
+  # The trailing claim identity (our reset and pct) lets an adopter require
+  # provenance ordering: an estimate whose embedded claim sits below the
+  # covering claim the adopter lost to predates a row its own full parse
+  # would include, and is rejected on the read side regardless of how writer
+  # renames interleave.
+  if printf '%s %s %s %s %s %s %s %s\n' "$NOW" $(( NOW + ${_B5_TTR:-0} )) "$s" "$sp" "$d" "$l" \
+       "$_CUR_BURN_RST" "$_CUR_BURN_PCT" 2>/dev/null > "$tmp"; then won=1; fi
   [ "$had_c" = 1 ] || set +C
   [ "$won" = 1 ] || return 0
   # Divergent same-second winners publish in parse-completion order, which is
@@ -1180,7 +1187,7 @@ EOF
 }
 
 burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated estimate
-  local est="$_SB_BASE.est" LC_ALL=C pub rst s sp d l t
+  local est="$_SB_BASE.est" LC_ALL=C pub rst s sp d l crst cpct t
   # Same defaults burn_eta_5h starts from: the adopter replaces that call
   # entirely, and downstream comparisons assume every _B5_* is populated.
   _B5_STATE=warming; _B5_ETA=inf; _B5_RATE="0.0000000000"; _B5_TTR=0; _B5_RAW=""
@@ -1191,7 +1198,7 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
   # a render will ever ingest; trailing junk lands in the last field and
   # fails its digit check, so a malformed line is rejected, never truncated
   # into a plausible one.
-  read -r -n 128 pub rst s sp d l < "$est" 2>/dev/null || :
+  read -r -n 128 pub rst s sp d l crst cpct < "$est" 2>/dev/null || :
   # Every field is validated before it reaches any arithmetic context; the
   # published values bypass the awk whose internal caps normally guarantee
   # these bounds, so the reader must re-impose them itself.
@@ -1216,6 +1223,19 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
   [ "${#d}" -le 6 ] && [ "$d" -le 100000 ] || return 1
   case "${l:-}" in (''|*[!0-9]*|0[0-9]*) return 1 ;; esac
   [ "${#l}" -le 6 ] && [ "$l" -le 100000 ] || return 1
+  # Provenance ordering: the embedded claim must be at least as complete as
+  # the covering claim we lost to. A claim for a newer window supersedes any
+  # same-window pct; within our window the claim pct must reach the covering
+  # pct, or the estimate predates a row our own full parse would include
+  # (writer renames can interleave arbitrarily, so this is the check that
+  # holds regardless of publication order).
+  state_epoch "${crst:-}" 12 || return 1; crst=$_SE_VALUE
+  case "${cpct:-}" in (''|*[!0-9]*|0[0-9]*) return 1 ;; esac
+  [ "${#cpct}" -le 6 ] && [ "$cpct" -le 100000 ] || return 1
+  if [ "$crst" -le "${_CUR_BURN_RST:-0}" ]; then
+    [ "$crst" -eq "${_CUR_BURN_RST:-0}" ] || return 1
+    [ "$cpct" -ge "${_BURN_LOST_PCT:-100001}" ] || return 1
+  fi
   # ttr derives locally from the published window and our own NOW, so a
   # 1-3s-old estimate cannot trip the rebind gate into warming flicker.
   t=$(( rst - NOW )); [ "$t" -lt 0 ] && t=0

--- a/statusline.sh
+++ b/statusline.sh
@@ -1124,6 +1124,18 @@ burn_eta_7d() {  # → _B7_*; $1=pct_milli $2=reset epoch
 # returned), so burn_tmp_sweep's <base>.<digits>.tmp rule covers orphans from
 # a killed render. Fork budget: one mv per second per store, paid by the
 # winner, replacing N-1 whole-file awk parses.
+# Unlinking is a mutation like any other: an ancestor swapped for a symlink
+# after the temporary was written would make a bare rm traverse untrusted
+# ground and delete a same-named file in the attacker's target. Every discard
+# therefore re-proves the path identity first, mirroring burn_eta_5h's guarded
+# cleanup. A temporary left behind because revalidation failed is not lost:
+# burn_tmp_sweep owns the <base>.<digits>.tmp namespace and retires it.
+burn_est_discard() {  # $1=our publish temporary; remove only through revalidated identities
+  state_paths_revalidate && state_no_symlink_path "$1" && [ "$_SNP" = "$1" ] \
+    && [ -f "$1" ] && [ ! -L "$1" ] && rm -f "$1" 2>/dev/null
+  return 0
+}
+
 burn_est_publish() {  # winner only: publish "<now> <maxrst> <state> <span> <delta> <latest>"
   [ "${_CUR_BURN_VALID:-0}" = 1 ] || return 0
   [ -n "${_B5_RAW:-}" ] || return 0
@@ -1173,16 +1185,16 @@ EOF
     [ "${#cr}" -le 12 ] || continue
     case "$p" in (''|*[!0-9]*) continue ;; esac
     [ "${#p}" -le 6 ] || continue
-    if [ "$cr" -gt "$_CUR_BURN_RST" ]; then rm -f "$tmp" 2>/dev/null; return 0; fi
+    if [ "$cr" -gt "$_CUR_BURN_RST" ]; then burn_est_discard "$tmp"; return 0; fi
     if [ "$cr" -eq "$_CUR_BURN_RST" ] && [ "$p" -gt "$_CUR_BURN_PCT" ]; then
-      rm -f "$tmp" 2>/dev/null; return 0
+      burn_est_discard "$tmp"; return 0
     fi
   done
   if state_paths_revalidate && state_no_symlink_path "$est" && [ "$_SNP" = "$est" ] \
      && state_path_leaf "$est" f; then
     mv -f "$tmp" "$est" 2>/dev/null && return 0
   fi
-  rm -f "$tmp" 2>/dev/null
+  burn_est_discard "$tmp"
   return 0
 }
 

--- a/statusline.sh
+++ b/statusline.sh
@@ -697,7 +697,10 @@ state_burn_lead() {  # → 0 iff this render must run the burn write path
     # claimed for this (second, window) at or above ours makes our row
     # redundant.
     for f in "$slot".*.tick; do
-      [ -e "$f" ] || [ -L "$f" ] || continue
+      # Only a regular non-symlink file is a claim we made: a planted symlink
+      # or directory must not stand in for a winner, or losing to it would
+      # let a follower adopt a cached estimate with no live parse behind it.
+      [ -f "$f" ] && [ ! -L "$f" ] || continue
       p=${f#"$slot".}; p=${p%.tick}
       # Length caps mirror state_epoch's width rule: a planted name with an
       # oversized digit run must not reach [ -gt ] (integer overflow would
@@ -1201,7 +1204,12 @@ EOF
   if printf '%s %s %s %s %s %s %s %s\n' "$NOW" $(( NOW + ${_B5_TTR:-0} )) "$s" "$sp" "$d" "$l" \
        "$_CUR_BURN_RST" "$_CUR_BURN_PCT" 2>/dev/null > "$tmp"; then won=1; fi
   [ "$had_c" = 1 ] || set +C
-  [ "$won" = 1 ] || return 0
+  # The redirection creates the file before printf runs, so a write that
+  # fails afterwards (out of space, over quota) leaves a partial temporary
+  # that burn_tmp_sweep cannot retire while the same failure keeps the TSV
+  # from advancing past it. Discard it here instead of accumulating one per
+  # winner render.
+  [ "$won" = 1 ] || { burn_est_discard "$tmp"; return 0; }
   # Divergent same-second winners publish in parse-completion order, which is
   # not claim order: a winner finishing late must never replace the estimate
   # of a covering claim whose parse includes a row ours does not. That covers

--- a/statusline.sh
+++ b/statusline.sh
@@ -1244,6 +1244,16 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
     [ "$crst" -eq "${_CUR_BURN_RST:-0}" ] || return 1
     [ "$cpct" -ge "${_BURN_LOST_PCT:-100001}" ] || return 1
   fi
+  # What is deliberately NOT checked: that the estimate's tick equals ours.
+  # An adopter at 1Hz cadence normally consumes the previous second's
+  # publication; that is the designed freshness allowance, and the residual
+  # it admits is only that the estimate excludes this session's own
+  # current-second observation - a documented, tested trade-off bounded by
+  # one to three observations against a 600-second slope window. Within one
+  # 5h window used_percentage is non-decreasing and every store consumer
+  # applies max-pct semantics (add_obs keeps the highest reading per
+  # sample), so a slightly older estimate can only carry the high-water
+  # reading the estimator would keep anyway, never an inflated one.
   # ttr derives locally from the published window and our own NOW, so a
   # 1-3s-old estimate cannot trip the rebind gate into warming flicker.
   t=$(( rst - NOW )); [ "$t" -lt 0 ] && t=0

--- a/statusline.sh
+++ b/statusline.sh
@@ -1319,6 +1319,14 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
   [ "${#d}" -le 3 ] && [ "$d" -le 100 ] || return 1
   case "${l:-}" in (''|*[!0-9]*|0[0-9]*) return 1 ;; esac
   [ "${#l}" -le 6 ] && [ "$l" -le 100000 ] || return 1
+  # Shape the pair to what the producer can actually emit: an active result
+  # needs two crossings at least win/10 apart, and every other state carries
+  # zeroes. A span or delta outside that is a record no parse produced.
+  if [ "$s" = active ]; then
+    [ "$sp" -ge $(( CORALLINE_BURN_WINDOW / 10 )) ] || return 1
+  else
+    [ "$sp" -eq 0 ] && [ "$d" -eq 0 ] || return 1
+  fi
   # Provenance ordering: the embedded claim must be at least as complete as
   # the covering claim we lost to. A claim for a newer window supersedes any
   # same-window pct; within our window the claim pct must reach the covering

--- a/statusline.sh
+++ b/statusline.sh
@@ -706,7 +706,10 @@ state_burn_lead() {  # → 0 iff this render must run the burn write path
       [ "${#p}" -le 6 ] || continue
       [ "$p" -gt "$best" ] && best=$p
     done
-    [ "$_CUR_BURN_PCT" -gt "$best" ] || return 1
+    # A covering claim (pct at or above ours) is the one loss reason a
+    # follower may trust: it proves a winner is computing this second, so the
+    # published estimate is safe to adopt (_BURN_LOST gates burn_est_adopt).
+    [ "$_CUR_BURN_PCT" -gt "$best" ] || { _BURN_LOST=1; return 1; }
   else
     # No reading of our own: maintenance-only claim under the reserved
     # window/pct 0.0, so trim, healing, and the tmp sweep never starve while
@@ -728,7 +731,10 @@ state_burn_lead() {  # → 0 iff this render must run the burn write path
   if : 2>/dev/null > "$tok"; then won=1; fi
   [ "$had_c" = 1 ] || set +C
   if [ "$won" != 1 ]; then
-    # EEXIST: another session already claimed this exact reading.
+    # EEXIST from a regular file: another session claimed this exact reading,
+    # which also counts as a covering claim for adoption purposes.
+    if [ -f "$tok" ] && [ ! -L "$tok" ]; then _BURN_LOST=1; return 1; fi
+    # A non-file object raced in: lose without trusting it.
     if [ -e "$tok" ] || [ -L "$tok" ]; then return 1; fi
     # Anything else (missing parent on a fresh store, transient fs error):
     # fail open so sampling never silently stops.
@@ -947,9 +953,35 @@ burn_tmp_sweep() {  # remove trim temporaries orphaned by killed renders
   return 0
 }
 
+# The single parser for one "state span delta latest ttr" estimator line.
+# burn_eta_5h feeds it the awk's stdout; burn_est_adopt feeds it a line
+# reconstructed from a published estimate. Exactly one validator existing is a
+# deliberate security property: _B5_ETA and _B5_TTR flow into bash arithmetic
+# downstream, so every producer must pass this same gate.
+burn_b5_line() {  # → _B5_* from one estimator line; 1 = line rejected
+  local state span delta latest ttr
+  read -r state span delta latest ttr <<EOF
+$1
+EOF
+  case "$state" in
+    (active)
+      case "$span$delta$latest$ttr" in (''|*[!0-9]*) return 1 ;; esac
+      [ "$span" -gt 0 ] && [ "$delta" -gt 0 ] || return 1
+      state_rate10 $(( delta * 10000000000 )) "$span"; _B5_RATE=$_RATE10
+      state_round_even $(( (100000 - latest) * span )) $(( delta * 1000 )) || return 1
+      _B5_STATE=active; _B5_ETA=$_RE; _B5_TTR=$ttr
+      ;;
+    (idle|warming)
+      case "$ttr" in (''|*[!0-9]*) ttr=0 ;; esac
+      _B5_STATE=$state; _B5_TTR=$ttr
+      ;;
+    (*) return 1 ;;
+  esac
+}
+
 burn_eta_5h() {  # → _B5_* from canonical TSV; $1=allow trim/heal mutation
-  local mutate="${1:-0}" src=/dev/null tmp="" write_tmp=0 out="" rc state span delta latest ttr
-  _B5_STATE=warming; _B5_ETA=inf; _B5_RATE="0.0000000000"; _B5_TTR=0
+  local mutate="${1:-0}" src=/dev/null tmp="" write_tmp=0 out="" rc
+  _B5_STATE=warming; _B5_ETA=inf; _B5_RATE="0.0000000000"; _B5_TTR=0; _B5_RAW=""
   if [ "${_STATE_BURN_SAFE:-0}" = 1 ] && state_path_object "$_SB_BASE" f; then src=$_SB_BASE; fi
   if [ "$mutate" = 1 ] && [ "$src" != /dev/null ]; then
     burn_tmp_sweep
@@ -1062,22 +1094,8 @@ burn_eta_5h() {  # → _B5_* from canonical TSV; $1=allow trim/heal mutation
     fi
   fi
   [ "$rc" -eq 0 ] || return 0
-  read -r state span delta latest ttr <<EOF
-$out
-EOF
-  case "$state" in
-    (active)
-      case "$span$delta$latest$ttr" in (''|*[!0-9]*) return 0 ;; esac
-      [ "$span" -gt 0 ] && [ "$delta" -gt 0 ] || return 0
-      state_rate10 $(( delta * 10000000000 )) "$span"; _B5_RATE=$_RATE10
-      state_round_even $(( (100000 - latest) * span )) $(( delta * 1000 )) || return 0
-      _B5_STATE=active; _B5_ETA=$_RE; _B5_TTR=$ttr
-      ;;
-    (idle|warming)
-      case "$ttr" in (''|*[!0-9]*) ttr=0 ;; esac
-      _B5_STATE=$state; _B5_TTR=$ttr
-      ;;
-  esac
+  burn_b5_line "$out" || return 0
+  _B5_RAW=$out
 }
 
 burn_eta_7d() {  # → _B7_*; $1=pct_milli $2=reset epoch
@@ -1091,12 +1109,100 @@ burn_eta_7d() {  # → _B7_*; $1=pct_milli $2=reset epoch
   state_round_even $(( (100000 - pct) * elapsed )) "$pct"; _B7_ETA=$_RE
 }
 
+# Cross-session estimate sharing. The election winner already paid for the
+# full TSV parse; publishing its validated result lets every same-second loser
+# skip that parse entirely (the read side is ~75ms of a 141ms state-enabled
+# render at n=16 — the dominant multi-session cost after the write election).
+# The published file is display-only derived data with the TSV as the source
+# of truth: ANY anomaly on the read side falls back to the full parse.
+# Publish is rename-only through the store's tmp discipline — never an
+# in-place write, which would follow a planted hardlink and tear reads. The
+# tmp reuses "$_SB_BASE".$$.tmp strictly AFTER burn_eta_5h's own trim tmp
+# lifecycle has ended (burn_estimate calls publish only once burn_eta_5h has
+# returned), so burn_tmp_sweep's <base>.<digits>.tmp rule covers orphans from
+# a killed render. Fork budget: one mv per second per store, paid by the
+# winner, replacing N-1 whole-file awk parses.
+burn_est_publish() {  # winner only: publish "<now> <maxrst> <state> <span> <delta> <latest>"
+  [ "${_CUR_BURN_VALID:-0}" = 1 ] || return 0
+  [ -n "${_B5_RAW:-}" ] || return 0
+  local est="$_SB_BASE.est" tmp="$_SB_BASE.$$.tmp" s sp d l t p had_c=0 won=0
+  state_paths_revalidate || return 0
+  # The est file is a seventh state object outside state_paths_validate's
+  # six-path distinctness matrix; refuse to publish over any configured
+  # namespace (state_same_path is conservative: unsure means same).
+  for p in "$_SB_BASE" "$_SB_ROOT" "$_SL5_BASE" "$_SL5_ROOT" "$_SL7_BASE" "$_SL7_ROOT"; do
+    if state_same_path "$est" "$p"; then return 0; fi
+  done
+  # A symlink or directory planted at the est name is not followed, not
+  # deleted, and aborts the publish; same rule as the election tokens.
+  state_no_symlink_path "$est" && [ "$_SNP" = "$est" ] || return 0
+  state_path_leaf "$est" f || return 0
+  state_no_symlink_path "$tmp" && [ "$_SNP" = "$tmp" ] || return 0
+  [ ! -e "$tmp" ] && [ ! -L "$tmp" ] || return 0
+  read -r s sp d l t <<EOF
+$_B5_RAW
+EOF
+  case $- in *C*) had_c=1 ;; esac
+  set -C
+  if printf '%s %s %s %s %s %s\n' "$NOW" $(( NOW + ${_B5_TTR:-0} )) "$s" "$sp" "$d" "$l" \
+       2>/dev/null > "$tmp"; then won=1; fi
+  [ "$had_c" = 1 ] || set +C
+  [ "$won" = 1 ] || return 0
+  if state_paths_revalidate && state_no_symlink_path "$est" && [ "$_SNP" = "$est" ] \
+     && state_path_leaf "$est" f; then
+    mv -f "$tmp" "$est" 2>/dev/null && return 0
+  fi
+  rm -f "$tmp" 2>/dev/null
+  return 0
+}
+
+burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated estimate
+  local est="$_SB_BASE.est" LC_ALL=C pub rst s sp d l t
+  # Same defaults burn_eta_5h starts from: the adopter replaces that call
+  # entirely, and downstream comparisons assume every _B5_* is populated.
+  _B5_STATE=warming; _B5_ETA=inf; _B5_RATE="0.0000000000"; _B5_TTR=0; _B5_RAW=""
+  [ "${_STATE_BURN_SAFE:-0}" = 1 ] || return 1
+  state_path_object "$est" f || return 1
+  [ -f "$est" ] && [ ! -L "$est" ] || return 1
+  # -n (not -N: that is bash 4.1+) caps how much of a hostile oversized file
+  # a render will ever ingest; trailing junk lands in the last field and
+  # fails its digit check, so a malformed line is rejected, never truncated
+  # into a plausible one.
+  read -r -n 128 pub rst s sp d l < "$est" 2>/dev/null || :
+  # Every field is validated before it reaches any arithmetic context; the
+  # published values bypass the awk whose internal caps normally guarantee
+  # these bounds, so the reader must re-impose them itself.
+  state_epoch "${pub:-}" 12 || return 1; pub=$_SE_VALUE
+  state_epoch "${rst:-}" 12 || return 1; rst=$_SE_VALUE
+  [ "$pub" -le "$NOW" ] && [ "$pub" -ge $(( NOW - 3 )) ] || return 1
+  case "${s:-}" in (active|idle|warming) ;; (*) return 1 ;; esac
+  case "${sp:-}" in (''|*[!0-9]*) return 1 ;; esac
+  [ "${#sp}" -le 5 ] && [ "$sp" -le 86400 ] || return 1
+  case "${d:-}" in (''|*[!0-9]*) return 1 ;; esac
+  [ "${#d}" -le 6 ] && [ "$d" -le 100000 ] || return 1
+  case "${l:-}" in (''|*[!0-9]*) return 1 ;; esac
+  [ "${#l}" -le 6 ] && [ "$l" -le 100000 ] || return 1
+  # ttr derives locally from the published window and our own NOW, so a
+  # 1-3s-old estimate cannot trip the rebind gate into warming flicker.
+  t=$(( rst - NOW )); [ "$t" -lt 0 ] && t=0
+  burn_b5_line "$s $sp $d $l $t"
+}
+
 burn_estimate() {  # → _BURN_STATE _BURN_LABEL _BURN_ETA _BURN_RATE _BURN_TTR
   local f5=0 f7=0 m=0
-  # Trim/heal mutation follows the same per-(tick, window) election as the
-  # append: only the tick leader rewrites, everyone else reads.
+  # Trim/heal mutation follows the same per-(tick, window, pct) election as
+  # the append: a claim winner runs the full parse (and publishes its result);
+  # a session that lost to a covering claim adopts the published estimate
+  # when it validates, and everything else takes the plain read-only parse.
   [ "${_STATE_MUTATE:-0}" = 1 ] && state_burn_lead && m=1
-  burn_eta_5h "$m"
+  if [ "$m" = 1 ]; then
+    burn_eta_5h 1
+    burn_est_publish
+  elif [ "${_BURN_LOST:-0}" = 1 ] && [ "${_CUR_BURN_VALID:-0}" = 1 ] && burn_est_adopt; then
+    :
+  else
+    burn_eta_5h 0
+  fi
   # The 5h projection needs the same rebinding the 7d one gets: whenever the synced
   # state is what the gauge draws, the ETA has to be projected from that same window.
   # Two ways they diverge. With no reading of our own the history can still sit on

--- a/statusline.sh
+++ b/statusline.sh
@@ -1175,12 +1175,20 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
   state_epoch "${pub:-}" 12 || return 1; pub=$_SE_VALUE
   state_epoch "${rst:-}" 12 || return 1; rst=$_SE_VALUE
   [ "$pub" -le "$NOW" ] && [ "$pub" -ge $(( NOW - 3 )) ] || return 1
+  # An estimate for a window older than our own reading is a cache miss, not a
+  # candidate: our observation alone would advance maxrst past it, so the full
+  # parse must run. Without this, the 3s freshness allowance could span a 5h
+  # reset and briefly revive the closed window's ETA.
+  [ "$rst" -ge "${_CUR_BURN_RST:-0}" ] || return 1
   case "${s:-}" in (active|idle|warming) ;; (*) return 1 ;; esac
-  case "${sp:-}" in (''|*[!0-9]*) return 1 ;; esac
+  # Leading zeros are rejected outright (our publisher never emits them, and
+  # bash arithmetic downstream would read them as octal): the (0|[1-9]...)
+  # shape mirrors state_epoch's rule.
+  case "${sp:-}" in (''|*[!0-9]*|0[0-9]*) return 1 ;; esac
   [ "${#sp}" -le 5 ] && [ "$sp" -le 86400 ] || return 1
-  case "${d:-}" in (''|*[!0-9]*) return 1 ;; esac
+  case "${d:-}" in (''|*[!0-9]*|0[0-9]*) return 1 ;; esac
   [ "${#d}" -le 6 ] && [ "$d" -le 100000 ] || return 1
-  case "${l:-}" in (''|*[!0-9]*) return 1 ;; esac
+  case "${l:-}" in (''|*[!0-9]*|0[0-9]*) return 1 ;; esac
   [ "${#l}" -le 6 ] && [ "$l" -le 100000 ] || return 1
   # ttr derives locally from the published window and our own NOW, so a
   # 1-3s-old estimate cannot trip the rebind gate into warming flicker.

--- a/statusline.sh
+++ b/statusline.sh
@@ -1244,16 +1244,19 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
     [ "$crst" -eq "${_CUR_BURN_RST:-0}" ] || return 1
     [ "$cpct" -ge "${_BURN_LOST_PCT:-100001}" ] || return 1
   fi
-  # What is deliberately NOT checked: that the estimate's tick equals ours.
-  # An adopter at 1Hz cadence normally consumes the previous second's
-  # publication; that is the designed freshness allowance, and the residual
-  # it admits is only that the estimate excludes this session's own
-  # current-second observation - a documented, tested trade-off bounded by
-  # one to three observations against a 600-second slope window. Within one
-  # 5h window used_percentage is non-decreasing and every store consumer
-  # applies max-pct semantics (add_obs keeps the highest reading per
-  # sample), so a slightly older estimate can only carry the high-water
-  # reading the estimator would keep anyway, never an inflated one.
+  # THE CONTRACT: the estimate is a cache of the full parse with a freshness
+  # bound of three seconds. Within that bound it may lag rows that landed
+  # after its publish; every guard above shrinks the lag (mtime versioning,
+  # claim provenance, window bounds) but only the next publish or the
+  # fallback parse closes it, because bash offers no atomic read of file
+  # plus summary. What the cache must NEVER do is contradict what this
+  # session itself knows: the full parse injects this session's own reading
+  # as the newest sample of its window, and the estimator's latest is
+  # defined by the newest sample, so a same-window adoption substitutes our
+  # own current pct for the published latest. Percentages legitimately DROP
+  # within a window (upstream resets, subscription upgrades - see rl_choose
+  # above), so this is a substitution, not a max.
+  [ "$crst" -eq "${_CUR_BURN_RST:-0}" ] && l=$_CUR_BURN_PCT
   # ttr derives locally from the published window and our own NOW, so a
   # 1-3s-old estimate cannot trip the rebind gate into warming flicker.
   t=$(( rst - NOW )); [ "$t" -lt 0 ] && t=0

--- a/statusline.sh
+++ b/statusline.sh
@@ -1309,8 +1309,10 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
   # Leading zeros are rejected outright (our publisher never emits them, and
   # bash arithmetic downstream would read them as octal): the (0|[1-9]...)
   # shape mirrors state_epoch's rule.
+  # Both crossings lie inside [NOW - win, NOW] in the producer, so the span
+  # cannot exceed the lookback; the clamp ceiling is not the bound here.
   case "${sp:-}" in (''|*[!0-9]*|0[0-9]*) return 1 ;; esac
-  [ "${#sp}" -le 5 ] && [ "$sp" -le 86400 ] || return 1
+  [ "${#sp}" -le 5 ] && [ "$sp" -le "$CORALLINE_BURN_WINDOW" ] || return 1
   # delta is a difference of two whole-percent values in the producer, so 100
   # is its real ceiling; the pct-milli scale does not apply to it.
   case "${d:-}" in (''|*[!0-9]*|0[0-9]*) return 1 ;; esac

--- a/statusline.sh
+++ b/statusline.sh
@@ -1318,8 +1318,11 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
   # above), so this is a substitution, not a max - but only for a PRIOR-tick
   # estimate: a same-tick winner's row shares our sample key, where add_obs
   # keeps the maximum, so the published latest already includes what our own
-  # injection could contribute.
-  [ "$crst" -eq "${_CUR_BURN_RST:-0}" ] && [ "$pub" -lt "$NOW" ] && l=$_CUR_BURN_PCT
+  # injection could contribute. The window that matters is the one the
+  # estimate DESCRIBES (rst, the parse's newest window), not the one its
+  # writer happened to claim: a writer on our window whose parse selected
+  # newer rows published numbers our reading has no part in.
+  [ "$rst" -eq "${_CUR_BURN_RST:-0}" ] && [ "$pub" -lt "$NOW" ] && l=$_CUR_BURN_PCT
   # ttr derives locally from the published window and our own NOW, so a
   # 1-3s-old estimate cannot trip the rebind gate into warming flicker.
   t=$(( rst - NOW )); [ "$t" -lt 0 ] && t=0

--- a/statusline.sh
+++ b/statusline.sh
@@ -1287,8 +1287,10 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
   # shape mirrors state_epoch's rule.
   case "${sp:-}" in (''|*[!0-9]*|0[0-9]*) return 1 ;; esac
   [ "${#sp}" -le 5 ] && [ "$sp" -le 86400 ] || return 1
+  # delta is a difference of two whole-percent values in the producer, so 100
+  # is its real ceiling; the pct-milli scale does not apply to it.
   case "${d:-}" in (''|*[!0-9]*|0[0-9]*) return 1 ;; esac
-  [ "${#d}" -le 6 ] && [ "$d" -le 100000 ] || return 1
+  [ "${#d}" -le 3 ] && [ "$d" -le 100 ] || return 1
   case "${l:-}" in (''|*[!0-9]*|0[0-9]*) return 1 ;; esac
   [ "${#l}" -le 6 ] && [ "$l" -le 100000 ] || return 1
   # Provenance ordering: the embedded claim must be at least as complete as
@@ -1329,7 +1331,17 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
   # estimate DESCRIBES (rst, the parse's newest window), not the one its
   # writer happened to claim: a writer on our window whose parse selected
   # newer rows published numbers our reading has no part in.
-  [ "$rst" -eq "${_CUR_BURN_RST:-0}" ] && [ "$pub" -lt "$NOW" ] && l=$_CUR_BURN_PCT
+  if [ "$rst" -eq "${_CUR_BURN_RST:-0}" ] && [ "$pub" -lt "$NOW" ]; then
+    # Our observation is the newest sample of this window, so the full parse
+    # would fold it into the crossing detection, not just into latest. It can
+    # only ADD a crossing by lifting the whole-percent value (the detector
+    # compares integer percents, and a crossing needs a strict rise), which
+    # would move span, delta, and possibly warming to active - none of them
+    # correctable without the rows. Adopt only when our sample cannot change
+    # them; then substituting latest is the entire difference.
+    [ $(( _CUR_BURN_PCT / 1000 )) -gt $(( l / 1000 )) ] && return 1
+    l=$_CUR_BURN_PCT
+  fi
   # ttr derives locally from the published window and our own NOW, so a
   # 1-3s-old estimate cannot trip the rebind gate into warming flicker.
   t=$(( rst - NOW )); [ "$t" -lt 0 ] && t=0

--- a/statusline.sh
+++ b/statusline.sh
@@ -1303,6 +1303,13 @@ burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated esti
   # (writer renames can interleave arbitrarily, so this is the check that
   # holds regardless of publication order).
   state_epoch "${crst:-}" 12 || return 1; crst=$_SE_VALUE
+  # Producer invariant: a writer injects its own claimed observation into the
+  # parse, so the window the estimate DESCRIBES can never precede the one its
+  # writer CLAIMED, and the claim is bounded by the same horizon. Provenance
+  # that no real publisher could have produced is a cache miss, not a licence
+  # to skip the covering-claim comparison below.
+  [ "$rst" -ge "$crst" ] || return 1
+  [ "$crst" -le $(( NOW + RL_MAX_5H )) ] || return 1
   case "${cpct:-}" in (''|*[!0-9]*|0[0-9]*) return 1 ;; esac
   [ "${#cpct}" -le 6 ] && [ "$cpct" -le 100000 ] || return 1
   # The estimate is a parse under a specific lookback, and CORALLINE_BURN_WINDOW

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -543,9 +543,9 @@ run_concurrency() {  # $1=runtime $2=workers $3=tag
   # and no orphaned publish temporaries once every render has exited.
   _CC_EST=0
   if [ -f "$root/state/burn.tsv.est" ] && [ ! -L "$root/state/burn.tsv.est" ]; then
-    _E1=""; _E2=""; _E3=""; _E4=""; _E5=""; _E6=""; _E7=""; _E8=""; _E9=""
-    read -r _E1 _E2 _E3 _E4 _E5 _E6 _E7 _E8 _E9 < "$root/state/burn.tsv.est" 2>/dev/null || :
-    case "$_E1$_E2$_E4$_E5$_E6$_E7$_E8$_E9" in (''|*[!0-9]*) ;; (*)
+    _E1=""; _E2=""; _E3=""; _E4=""; _E5=""; _E6=""; _E7=""; _E8=""; _E9=""; _E10=""
+    read -r _E1 _E2 _E3 _E4 _E5 _E6 _E7 _E8 _E9 _E10 < "$root/state/burn.tsv.est" 2>/dev/null || :
+    case "$_E1$_E2$_E4$_E5$_E6$_E7$_E8$_E9$_E10" in (''|*[!0-9]*) ;; (*)
       case "$_E3" in (active|idle|warming) _CC_EST=1 ;; esac ;; esac
   fi
   _CC_TMPS=$(ls "$root/state" 2>/dev/null | grep -c '\.tmp$')
@@ -706,7 +706,7 @@ printf '1\t6\t9\n' > "$BURN_FILE"
 # Publish: winner shape, maintenance/no-raw refusal.
 _CUR_BURN_VALID=1; _B5_RAW='warming 0 0 41200 9000'; _B5_TTR=9000
 burn_est_snap; burn_est_publish
-eq 'est publish: winner writes the claim-stamped line' "$(cat "$EST" 2>/dev/null)" '1000000 1009000 warming 0 0 41200 1015900 41200 600'
+eq 'est publish: winner writes the claim-stamped line' "$(cat "$EST" 2>/dev/null)" '1000000 1009000 warming 0 0 41200 1015900 41200 600 0'
 rm -f "$EST"
 _CUR_BURN_VALID=0
 burn_est_snap; burn_est_publish
@@ -784,42 +784,42 @@ rm -f "$CASE/burn.tsv.4243.tmp"
 # Adopt: fresh valid estimate is used without the awk (values differ from
 # anything the empty TSV could produce, so adoption is observable).
 # _BURN_LOST_PCT simulates the covering claim this session lost to.
-printf '1000000 1015900 active 300 5 50000 1015900 41200 600\n' > "$EST"
+printf '1000000 1015900 active 300 5 50000 1015900 41200 600 999000\n' > "$EST"
 _CUR_BURN_VALID=1; _BURN_LOST_PCT=41200
 true_case 'est adopt: fresh valid estimate adopted' burn_est_adopt
 eq 'est adopt: state comes from the estimate' "$_B5_STATE" active
 eq 'est adopt: ttr derives from window and local NOW' "$_B5_TTR" 15900
-printf '999996 1015900 active 300 5 50000 1015900 41200 600\n' > "$EST"
+printf '999996 1015900 active 300 5 50000 1015900 41200 600 999000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: stale estimate rejected' adopted; else ok 'est adopt: stale estimate rejected'; fi
-printf '1000002 1015900 active 300 5 50000 1015900 41200 600\n' > "$EST"
+printf '1000002 1015900 active 300 5 50000 1015900 41200 600 999000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: future-dated estimate rejected' adopted; else ok 'est adopt: future-dated estimate rejected'; fi
-printf '1000000 1015900 active 90000 5 50000 1015900 41200 600\n' > "$EST"
+printf '1000000 1015900 active 90000 5 50000 1015900 41200 600 999000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: span beyond window cap rejected' adopted; else ok 'est adopt: span beyond window cap rejected'; fi
-printf '1000000 1015900 active 300 101 50000 1015900 41200 600\n' > "$EST"
+printf '1000000 1015900 active 300 101 50000 1015900 41200 600 999000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: delta beyond the producer cap rejected' adopted; else ok 'est adopt: delta beyond the producer cap rejected'; fi
-printf '1000000 1015900 active 300 5 100001 1015900 41200 600\n' > "$EST"
+printf '1000000 1015900 active 300 5 100001 1015900 41200 600 999000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: latest beyond pct cap rejected' adopted; else ok 'est adopt: latest beyond pct cap rejected'; fi
-printf '1000000 1015900 hacked 300 5 50000 1015900 41200 600\n' > "$EST"
+printf '1000000 1015900 hacked 300 5 50000 1015900 41200 600 999000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: unknown state token rejected' adopted; else ok 'est adopt: unknown state token rejected'; fi
-printf '1000000 1015900 active 008 5 50000 1015900 41200 600\n' > "$EST"
+printf '1000000 1015900 active 008 5 50000 1015900 41200 600 999000\n' > "$EST"
 if burn_est_adopt 2> "$CASE/octal.err"; then bad 'est adopt: leading-zero span rejected' adopted; else ok 'est adopt: leading-zero span rejected'; fi
 eq 'est adopt: leading-zero rejection leaks no stderr' "$(wc -c < "$CASE/octal.err" | tr -d ' ')" 0
-printf '1000000 1009000 active 300 5 50000 1009000 41200 600\n' > "$EST"
+printf '1000000 1009000 active 300 5 50000 1009000 41200 600 999000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: older-window estimate rejected' adopted; else ok 'est adopt: older-window estimate rejected'; fi
-printf '1000000 1020000 active 300 5 50000 1020000 41200 600\n' > "$EST"
+printf '1000000 1020000 active 300 5 50000 1020000 41200 600 999000\n' > "$EST"
 true_case 'est adopt: newer-window estimate accepted' burn_est_adopt
 eq 'est adopt: newer-window ttr from published maxrst' "$_B5_TTR" 20000
-printf '1000000 1021601 active 300 5 50000 1021601 41200 600\n' > "$EST"
+printf '1000000 1021601 active 300 5 50000 1021601 41200 600 999000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: reset beyond 5h horizon rejected' adopted; else ok 'est adopt: reset beyond 5h horizon rejected'; fi
-printf '1000000 1021600 active 300 5 50000 1021600 41200 600\n' > "$EST"
+printf '1000000 1021600 active 300 5 50000 1021600 41200 600 999000\n' > "$EST"
 true_case 'est adopt: reset at the 5h horizon accepted' burn_est_adopt
 printf '1000000 1015900 active 300 5 50000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: legacy six-field line rejected' adopted; else ok 'est adopt: legacy six-field line rejected'; fi
-printf '1000000 1015900 active 300 5 50000 1015900 30000 600\n' > "$EST"
+printf '1000000 1015900 active 300 5 50000 1015900 30000 600 999000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: claim below the covering pct rejected' adopted; else ok 'est adopt: claim below the covering pct rejected'; fi
-printf '1000000 1015900 active 300 5 50000 1015900 50000 600\n' > "$EST"
+printf '1000000 1015900 active 300 5 50000 1015900 50000 600 999000\n' > "$EST"
 true_case 'est adopt: claim above the covering pct accepted' burn_est_adopt
-printf '1000000 1020000 active 300 5 50000 1020000 5000 600\n' > "$EST"
+printf '1000000 1020000 active 300 5 50000 1020000 5000 600 999000\n' > "$EST"
 true_case 'est adopt: newer-window claim supersedes any pct' burn_est_adopt
 # Prior-tick same-window adoption substitutes this session's own reading for
 # the published latest (our observation is the newest distinct sample, and
@@ -828,46 +828,52 @@ true_case 'est adopt: newer-window claim supersedes any pct' burn_est_adopt
 # reader keeps the maximum, so it already covers our injection.
 # A prior-tick sample that lifts the whole-percent value would change the
 # crossing structure, which the cached span/delta cannot be corrected for.
-printf '999999 1015900 active 300 5 30000 1015900 41200 600\n' > "$EST"
+printf '999999 1015900 active 300 5 30000 1015900 41200 600 999000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: crossing-changing sample falls back' adopted; else ok 'est adopt: crossing-changing sample falls back'; fi
-printf '999999 1015900 active 300 5 41900 1015900 41200 600\n' > "$EST"
+# A future-dated row (the reader tolerates now+300 for clock skew) can own
+# latest, so the cache must prove our sample comes after the newest one it saw.
+printf '999999 1015900 active 300 5 41900 1015900 41200 600 1000000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: sample not provably newest falls back' adopted; else ok 'est adopt: sample not provably newest falls back'; fi
+printf '999999 1015900 active 300 5 41900 1015900 41200 600 1000300\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: future-dated newest sample falls back' adopted; else ok 'est adopt: future-dated newest sample falls back'; fi
+printf '999999 1015900 active 300 5 41900 1015900 41200 600 999000\n' > "$EST"
 true_case 'est adopt: same whole percent still adopts' burn_est_adopt
 eq 'est adopt: same-percent substitution keeps our milli' "$_B5_TTR" 15900
-printf '999999 1015900 active 300 5 50000 1015900 50000 600\n' > "$EST"
+printf '999999 1015900 active 300 5 50000 1015900 50000 600 999000\n' > "$EST"
 true_case 'est adopt: prior-tick latest override adoption succeeds' burn_est_adopt
 _ADOPT_ETA=$_B5_ETA
-burn_b5_line 'active 300 5 41200 15900' || bad 'est adopt: reference line parses' failed
+burn_b5_line 'active 300 5 41200 15900 999000' || bad 'est adopt: reference line parses' failed
 eq 'est adopt: prior-tick latest is our own reading' "$_ADOPT_ETA" "$_B5_ETA"
-printf '1000000 1015900 active 300 5 50000 1015900 50000 600\n' > "$EST"
+printf '1000000 1015900 active 300 5 50000 1015900 50000 600 999000\n' > "$EST"
 true_case 'est adopt: same-tick adoption succeeds' burn_est_adopt
 _ADOPT_ETA=$_B5_ETA
-burn_b5_line 'active 300 5 50000 15900' || bad 'est adopt: same-tick reference parses' failed
+burn_b5_line 'active 300 5 50000 15900 999000' || bad 'est adopt: same-tick reference parses' failed
 eq 'est adopt: same-tick keeps the published latest' "$_ADOPT_ETA" "$_B5_ETA"
 # A writer claiming our window whose parse selected a NEWER window published
 # numbers our reading has no part in: the substitution follows the described
 # window, not the claimed one.
-printf '999999 1020000 active 300 5 50000 1015900 41200 600\n' > "$EST"
+printf '999999 1020000 active 300 5 50000 1015900 41200 600 999000\n' > "$EST"
 true_case 'est adopt: claim-ours described-newer adoption succeeds' burn_est_adopt
 _ADOPT_ETA=$_B5_ETA
-burn_b5_line 'active 300 5 50000 20000' || bad 'est adopt: described-window reference parses' failed
+burn_b5_line 'active 300 5 50000 20000 999000' || bad 'est adopt: described-window reference parses' failed
 eq 'est adopt: described-newer keeps the published latest' "$_ADOPT_ETA" "$_B5_ETA"
 
 # A TSV strictly newer than the estimate means rows landed after the publish
 # (an older-tick straggler inside the sweep grace window): the snapshot is
 # incomplete and must not be adopted.
-printf '1000000 1015900 active 300 5 50000 1015900 41200 600\n' > "$EST"
+printf '1000000 1015900 active 300 5 50000 1015900 41200 600 999000\n' > "$EST"
 touch -t 202001010000 "$EST"
 printf '1\t6\t9\n' >> "$BURN_FILE"
 if burn_est_adopt; then bad 'est adopt: TSV newer than estimate rejected' adopted; else ok 'est adopt: TSV newer than estimate rejected'; fi
 # A summary must not outlive the file it summarizes: with the TSV deleted the
 # mtime test is vacuous, so absence is checked on its own.
 cp "$BURN_FILE" "$CASE/tsv.keep"; rm -f "$BURN_FILE"
-printf '1000000 1015900 active 300 5 50000 1015900 41200 600\n' > "$EST"
+printf '1000000 1015900 active 300 5 50000 1015900 41200 600 999000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: missing source TSV rejected' adopted; else ok 'est adopt: missing source TSV rejected'; fi
 ln -s "$CASE/tsv.keep" "$BURN_FILE"
 if burn_est_adopt; then bad 'est adopt: symlinked source TSV rejected' adopted; else ok 'est adopt: symlinked source TSV rejected'; fi
 rm -f "$BURN_FILE"; cp "$CASE/tsv.keep" "$BURN_FILE"
-printf '1000000 1015900 active a[$(touch %s/pwn)] 5 50000 1015900 41200 600\n' "$CASE" > "$EST"
+printf '1000000 1015900 active a[$(touch %s/pwn)] 5 50000 1015900 41200 600 999000\n' "$CASE" > "$EST"
 if burn_est_adopt; then bad 'est adopt: arithmetic injection rejected' adopted; else ok 'est adopt: arithmetic injection rejected'; fi
 true_case 'est adopt: injection produced no side effect' test ! -e "$CASE/pwn"
 { printf '1000000 1015900 active 300 5 50000 1015900 41200 '; head -c 400 /dev/zero | tr '\0' '9'; printf '\n'; } > "$EST"
@@ -877,11 +883,11 @@ if burn_est_adopt; then bad 'est adopt: symlink est rejected' adopted; else ok '
 true_case 'est adopt: symlink est not followed' test ! -e "$CASE/esttarget"
 true_case 'est adopt: symlink est not deleted' test -L "$EST"
 rm -f "$EST"
-printf '1000000 1015900 active 300 5 50000 1015900 41200 900\n' > "$EST"
+printf '1000000 1015900 active 300 5 50000 1015900 41200 900 999000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: foreign lookback window rejected' adopted; else ok 'est adopt: foreign lookback window rejected'; fi
 printf '1000000 1015900 active 300 5 50000 1015900 41200\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: missing lookback window rejected' adopted; else ok 'est adopt: missing lookback window rejected'; fi
-printf '999998 1015900 active 300 5 50000 1015900 41200 600\n' > "$EST"
+printf '999998 1015900 active 300 5 50000 1015900 41200 600 999000\n' > "$EST"
 true_case 'est adopt: two-second-old estimate still adopts' burn_est_adopt
 eq 'est adopt: aged estimate ttr still local' "$_B5_TTR" 15900
 _CUR_BURN_VALID=0
@@ -895,7 +901,7 @@ CASE="$TMPD/est-ro"; mkdir -p "$CASE/state"
 write_config "$CASE/conf" "$CASE/state" burn 0
 _now=$(date +%s)
 make_payload "$CASE/input" 41.2 "$((_now + 9000))" '' ''
-printf '%s %s active 300 5 50000 %s 41200 600\n' "$_now" "$((_now + 9000))" "$((_now + 9000))" > "$CASE/state/burn.tsv.est"
+printf '%s %s active 300 5 50000 %s 41200 600 999000\n' "$_now" "$((_now + 9000))" "$((_now + 9000))" > "$CASE/state/burn.tsv.est"
 cp "$CASE/state/burn.tsv.est" "$CASE/est.before"
 run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 1
 printf '\033[0m B … \033[0m\n' > "$CASE/oracle"

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -689,6 +689,9 @@ _BURN_LEAD=
 CASE="$TMPD/est"; mkdir -p "$CASE"
 unit_gate "$CASE" 1000000 41.2 1015900 '' '' 0
 EST="$CASE/burn.tsv.est"
+# An estimate summarizes the TSV, so the source has to exist for any of the
+# adoption cases below to describe a real situation.
+printf '1\t6\t9\n' > "$BURN_FILE"
 
 # Publish: winner shape, maintenance/no-raw refusal.
 _CUR_BURN_VALID=1; _B5_RAW='warming 0 0 41200 9000'; _B5_TTR=9000
@@ -805,6 +808,14 @@ printf '1000000 1015900 active 300 5000 50000 1015900 41200\n' > "$EST"
 touch -t 202001010000 "$EST"
 printf '1\t6\t9\n' >> "$BURN_FILE"
 if burn_est_adopt; then bad 'est adopt: TSV newer than estimate rejected' adopted; else ok 'est adopt: TSV newer than estimate rejected'; fi
+# A summary must not outlive the file it summarizes: with the TSV deleted the
+# mtime test is vacuous, so absence is checked on its own.
+cp "$BURN_FILE" "$CASE/tsv.keep"; rm -f "$BURN_FILE"
+printf '1000000 1015900 active 300 5000 50000 1015900 41200\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: missing source TSV rejected' adopted; else ok 'est adopt: missing source TSV rejected'; fi
+ln -s "$CASE/tsv.keep" "$BURN_FILE"
+if burn_est_adopt; then bad 'est adopt: symlinked source TSV rejected' adopted; else ok 'est adopt: symlinked source TSV rejected'; fi
+rm -f "$BURN_FILE"; cp "$CASE/tsv.keep" "$BURN_FILE"
 printf '1000000 1015900 active a[$(touch %s/pwn)] 5000 50000 1015900 41200\n' "$CASE" > "$EST"
 if burn_est_adopt; then bad 'est adopt: arithmetic injection rejected' adopted; else ok 'est adopt: arithmetic injection rejected'; fi
 true_case 'est adopt: injection produced no side effect' test ! -e "$CASE/pwn"

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -810,6 +810,15 @@ printf '1000000 1015900 active 601 5 50000 1015900 41200 600 999000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: span past the configured lookback rejected' adopted; else ok 'est adopt: span past the configured lookback rejected'; fi
 printf '1000000 1015900 active 600 5 50000 1015900 41200 600 999000\n' > "$EST"
 true_case 'est adopt: span at the configured lookback accepted' burn_est_adopt
+printf '1000000 1015900 active 59 5 50000 1015900 41200 600 999000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: active span below the producer minimum rejected' adopted; else ok 'est adopt: active span below the producer minimum rejected'; fi
+printf '1000000 1015900 active 60 5 50000 1015900 41200 600 999000\n' > "$EST"
+true_case 'est adopt: active span at the producer minimum accepted' burn_est_adopt
+printf '1000000 1015900 warming 300 5 50000 1015900 41200 600 999000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: non-active with crossing fields rejected' adopted; else ok 'est adopt: non-active with crossing fields rejected'; fi
+printf '1000000 1015900 warming 0 0 50000 1015900 41200 600 999000\n' > "$EST"
+true_case 'est adopt: warming with producer zeroes accepted' burn_est_adopt
+eq 'est adopt: warming state carried through' "$_B5_STATE" warming
 printf '1000000 1015900 active 300 101 50000 1015900 41200 600 999000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: delta beyond the producer cap rejected' adopted; else ok 'est adopt: delta beyond the producer cap rejected'; fi
 printf '1000000 1015900 active 300 5 100001 1015900 41200 600 999000\n' > "$EST"

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -727,6 +727,14 @@ printf '1000000 1015900 active 300 5000 100001\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: latest beyond pct cap rejected' adopted; else ok 'est adopt: latest beyond pct cap rejected'; fi
 printf '1000000 1015900 hacked 300 5000 50000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: unknown state token rejected' adopted; else ok 'est adopt: unknown state token rejected'; fi
+printf '1000000 1015900 active 008 5000 50000\n' > "$EST"
+if burn_est_adopt 2> "$CASE/octal.err"; then bad 'est adopt: leading-zero span rejected' adopted; else ok 'est adopt: leading-zero span rejected'; fi
+eq 'est adopt: leading-zero rejection leaks no stderr' "$(wc -c < "$CASE/octal.err" | tr -d ' ')" 0
+printf '1000000 1009000 active 300 5000 50000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: older-window estimate rejected' adopted; else ok 'est adopt: older-window estimate rejected'; fi
+printf '1000000 1020000 active 300 5000 50000\n' > "$EST"
+true_case 'est adopt: newer-window estimate accepted' burn_est_adopt
+eq 'est adopt: newer-window ttr from published maxrst' "$_B5_TTR" 20000
 printf '1000000 1015900 active a[$(touch %s/pwn)] 5000 50000\n' "$CASE" > "$EST"
 if burn_est_adopt; then bad 'est adopt: arithmetic injection rejected' adopted; else ok 'est adopt: arithmetic injection rejected'; fi
 true_case 'est adopt: injection produced no side effect' test ! -e "$CASE/pwn"

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -543,9 +543,9 @@ run_concurrency() {  # $1=runtime $2=workers $3=tag
   # and no orphaned publish temporaries once every render has exited.
   _CC_EST=0
   if [ -f "$root/state/burn.tsv.est" ] && [ ! -L "$root/state/burn.tsv.est" ]; then
-    _E1=""; _E2=""; _E3=""; _E4=""; _E5=""; _E6=""; _E7=""; _E8=""
-    read -r _E1 _E2 _E3 _E4 _E5 _E6 _E7 _E8 < "$root/state/burn.tsv.est" 2>/dev/null || :
-    case "$_E1$_E2$_E4$_E5$_E6$_E7$_E8" in (''|*[!0-9]*) ;; (*)
+    _E1=""; _E2=""; _E3=""; _E4=""; _E5=""; _E6=""; _E7=""; _E8=""; _E9=""
+    read -r _E1 _E2 _E3 _E4 _E5 _E6 _E7 _E8 _E9 < "$root/state/burn.tsv.est" 2>/dev/null || :
+    case "$_E1$_E2$_E4$_E5$_E6$_E7$_E8$_E9" in (''|*[!0-9]*) ;; (*)
       case "$_E3" in (active|idle|warming) _CC_EST=1 ;; esac ;; esac
   fi
   _CC_TMPS=$(ls "$root/state" 2>/dev/null | grep -c '\.tmp$')
@@ -706,7 +706,7 @@ printf '1\t6\t9\n' > "$BURN_FILE"
 # Publish: winner shape, maintenance/no-raw refusal.
 _CUR_BURN_VALID=1; _B5_RAW='warming 0 0 41200 9000'; _B5_TTR=9000
 burn_est_snap; burn_est_publish
-eq 'est publish: winner writes the claim-stamped line' "$(cat "$EST" 2>/dev/null)" '1000000 1009000 warming 0 0 41200 1015900 41200'
+eq 'est publish: winner writes the claim-stamped line' "$(cat "$EST" 2>/dev/null)" '1000000 1009000 warming 0 0 41200 1015900 41200 600'
 rm -f "$EST"
 _CUR_BURN_VALID=0
 burn_est_snap; burn_est_publish
@@ -784,54 +784,54 @@ rm -f "$CASE/burn.tsv.4243.tmp"
 # Adopt: fresh valid estimate is used without the awk (values differ from
 # anything the empty TSV could produce, so adoption is observable).
 # _BURN_LOST_PCT simulates the covering claim this session lost to.
-printf '1000000 1015900 active 300 5000 50000 1015900 41200\n' > "$EST"
+printf '1000000 1015900 active 300 5000 50000 1015900 41200 600\n' > "$EST"
 _CUR_BURN_VALID=1; _BURN_LOST_PCT=41200
 true_case 'est adopt: fresh valid estimate adopted' burn_est_adopt
 eq 'est adopt: state comes from the estimate' "$_B5_STATE" active
 eq 'est adopt: ttr derives from window and local NOW' "$_B5_TTR" 15900
-printf '999996 1015900 active 300 5000 50000 1015900 41200\n' > "$EST"
+printf '999996 1015900 active 300 5000 50000 1015900 41200 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: stale estimate rejected' adopted; else ok 'est adopt: stale estimate rejected'; fi
-printf '1000002 1015900 active 300 5000 50000 1015900 41200\n' > "$EST"
+printf '1000002 1015900 active 300 5000 50000 1015900 41200 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: future-dated estimate rejected' adopted; else ok 'est adopt: future-dated estimate rejected'; fi
-printf '1000000 1015900 active 90000 5000 50000 1015900 41200\n' > "$EST"
+printf '1000000 1015900 active 90000 5000 50000 1015900 41200 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: span beyond window cap rejected' adopted; else ok 'est adopt: span beyond window cap rejected'; fi
-printf '1000000 1015900 active 300 200000 50000 1015900 41200\n' > "$EST"
+printf '1000000 1015900 active 300 200000 50000 1015900 41200 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: delta beyond pct cap rejected' adopted; else ok 'est adopt: delta beyond pct cap rejected'; fi
-printf '1000000 1015900 active 300 5000 100001 1015900 41200\n' > "$EST"
+printf '1000000 1015900 active 300 5000 100001 1015900 41200 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: latest beyond pct cap rejected' adopted; else ok 'est adopt: latest beyond pct cap rejected'; fi
-printf '1000000 1015900 hacked 300 5000 50000 1015900 41200\n' > "$EST"
+printf '1000000 1015900 hacked 300 5000 50000 1015900 41200 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: unknown state token rejected' adopted; else ok 'est adopt: unknown state token rejected'; fi
-printf '1000000 1015900 active 008 5000 50000 1015900 41200\n' > "$EST"
+printf '1000000 1015900 active 008 5000 50000 1015900 41200 600\n' > "$EST"
 if burn_est_adopt 2> "$CASE/octal.err"; then bad 'est adopt: leading-zero span rejected' adopted; else ok 'est adopt: leading-zero span rejected'; fi
 eq 'est adopt: leading-zero rejection leaks no stderr' "$(wc -c < "$CASE/octal.err" | tr -d ' ')" 0
-printf '1000000 1009000 active 300 5000 50000 1009000 41200\n' > "$EST"
+printf '1000000 1009000 active 300 5000 50000 1009000 41200 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: older-window estimate rejected' adopted; else ok 'est adopt: older-window estimate rejected'; fi
-printf '1000000 1020000 active 300 5000 50000 1020000 41200\n' > "$EST"
+printf '1000000 1020000 active 300 5000 50000 1020000 41200 600\n' > "$EST"
 true_case 'est adopt: newer-window estimate accepted' burn_est_adopt
 eq 'est adopt: newer-window ttr from published maxrst' "$_B5_TTR" 20000
-printf '1000000 1021601 active 300 5000 50000 1021601 41200\n' > "$EST"
+printf '1000000 1021601 active 300 5000 50000 1021601 41200 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: reset beyond 5h horizon rejected' adopted; else ok 'est adopt: reset beyond 5h horizon rejected'; fi
-printf '1000000 1021600 active 300 5000 50000 1021600 41200\n' > "$EST"
+printf '1000000 1021600 active 300 5000 50000 1021600 41200 600\n' > "$EST"
 true_case 'est adopt: reset at the 5h horizon accepted' burn_est_adopt
 printf '1000000 1015900 active 300 5000 50000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: legacy six-field line rejected' adopted; else ok 'est adopt: legacy six-field line rejected'; fi
-printf '1000000 1015900 active 300 5000 50000 1015900 30000\n' > "$EST"
+printf '1000000 1015900 active 300 5000 50000 1015900 30000 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: claim below the covering pct rejected' adopted; else ok 'est adopt: claim below the covering pct rejected'; fi
-printf '1000000 1015900 active 300 5000 50000 1015900 50000\n' > "$EST"
+printf '1000000 1015900 active 300 5000 50000 1015900 50000 600\n' > "$EST"
 true_case 'est adopt: claim above the covering pct accepted' burn_est_adopt
-printf '1000000 1020000 active 300 5000 50000 1020000 5000\n' > "$EST"
+printf '1000000 1020000 active 300 5000 50000 1020000 5000 600\n' > "$EST"
 true_case 'est adopt: newer-window claim supersedes any pct' burn_est_adopt
 # Prior-tick same-window adoption substitutes this session's own reading for
 # the published latest (our observation is the newest distinct sample, and
 # percentages legitimately drop within a window). A same-tick estimate keeps
 # the published value: the winner's row shares our sample key, where the
 # reader keeps the maximum, so it already covers our injection.
-printf '999999 1015900 active 300 5000 50000 1015900 50000\n' > "$EST"
+printf '999999 1015900 active 300 5000 50000 1015900 50000 600\n' > "$EST"
 true_case 'est adopt: prior-tick latest override adoption succeeds' burn_est_adopt
 _ADOPT_ETA=$_B5_ETA
 burn_b5_line 'active 300 5000 41200 15900' || bad 'est adopt: reference line parses' failed
 eq 'est adopt: prior-tick latest is our own reading' "$_ADOPT_ETA" "$_B5_ETA"
-printf '1000000 1015900 active 300 5000 50000 1015900 50000\n' > "$EST"
+printf '1000000 1015900 active 300 5000 50000 1015900 50000 600\n' > "$EST"
 true_case 'est adopt: same-tick adoption succeeds' burn_est_adopt
 _ADOPT_ETA=$_B5_ETA
 burn_b5_line 'active 300 5000 50000 15900' || bad 'est adopt: same-tick reference parses' failed
@@ -839,7 +839,7 @@ eq 'est adopt: same-tick keeps the published latest' "$_ADOPT_ETA" "$_B5_ETA"
 # A writer claiming our window whose parse selected a NEWER window published
 # numbers our reading has no part in: the substitution follows the described
 # window, not the claimed one.
-printf '999999 1020000 active 300 5000 50000 1015900 41200\n' > "$EST"
+printf '999999 1020000 active 300 5000 50000 1015900 41200 600\n' > "$EST"
 true_case 'est adopt: claim-ours described-newer adoption succeeds' burn_est_adopt
 _ADOPT_ETA=$_B5_ETA
 burn_b5_line 'active 300 5000 50000 20000' || bad 'est adopt: described-window reference parses' failed
@@ -848,29 +848,33 @@ eq 'est adopt: described-newer keeps the published latest' "$_ADOPT_ETA" "$_B5_E
 # A TSV strictly newer than the estimate means rows landed after the publish
 # (an older-tick straggler inside the sweep grace window): the snapshot is
 # incomplete and must not be adopted.
-printf '1000000 1015900 active 300 5000 50000 1015900 41200\n' > "$EST"
+printf '1000000 1015900 active 300 5000 50000 1015900 41200 600\n' > "$EST"
 touch -t 202001010000 "$EST"
 printf '1\t6\t9\n' >> "$BURN_FILE"
 if burn_est_adopt; then bad 'est adopt: TSV newer than estimate rejected' adopted; else ok 'est adopt: TSV newer than estimate rejected'; fi
 # A summary must not outlive the file it summarizes: with the TSV deleted the
 # mtime test is vacuous, so absence is checked on its own.
 cp "$BURN_FILE" "$CASE/tsv.keep"; rm -f "$BURN_FILE"
-printf '1000000 1015900 active 300 5000 50000 1015900 41200\n' > "$EST"
+printf '1000000 1015900 active 300 5000 50000 1015900 41200 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: missing source TSV rejected' adopted; else ok 'est adopt: missing source TSV rejected'; fi
 ln -s "$CASE/tsv.keep" "$BURN_FILE"
 if burn_est_adopt; then bad 'est adopt: symlinked source TSV rejected' adopted; else ok 'est adopt: symlinked source TSV rejected'; fi
 rm -f "$BURN_FILE"; cp "$CASE/tsv.keep" "$BURN_FILE"
-printf '1000000 1015900 active a[$(touch %s/pwn)] 5000 50000 1015900 41200\n' "$CASE" > "$EST"
+printf '1000000 1015900 active a[$(touch %s/pwn)] 5000 50000 1015900 41200 600\n' "$CASE" > "$EST"
 if burn_est_adopt; then bad 'est adopt: arithmetic injection rejected' adopted; else ok 'est adopt: arithmetic injection rejected'; fi
 true_case 'est adopt: injection produced no side effect' test ! -e "$CASE/pwn"
-{ printf '1000000 1015900 active 300 5000 50000 1015900 '; head -c 400 /dev/zero | tr '\0' '9'; printf '\n'; } > "$EST"
+{ printf '1000000 1015900 active 300 5000 50000 1015900 41200 '; head -c 400 /dev/zero | tr '\0' '9'; printf '\n'; } > "$EST"
 if burn_est_adopt; then bad 'est adopt: oversized line rejected' adopted; else ok 'est adopt: oversized line rejected'; fi
 rm -f "$EST"; ln -s "$CASE/esttarget" "$EST"
 if burn_est_adopt; then bad 'est adopt: symlink est rejected' adopted; else ok 'est adopt: symlink est rejected'; fi
 true_case 'est adopt: symlink est not followed' test ! -e "$CASE/esttarget"
 true_case 'est adopt: symlink est not deleted' test -L "$EST"
 rm -f "$EST"
-printf '999998 1015900 active 300 5000 50000 1015900 41200\n' > "$EST"
+printf '1000000 1015900 active 300 5000 50000 1015900 41200 900\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: foreign lookback window rejected' adopted; else ok 'est adopt: foreign lookback window rejected'; fi
+printf '1000000 1015900 active 300 5000 50000 1015900 41200\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: missing lookback window rejected' adopted; else ok 'est adopt: missing lookback window rejected'; fi
+printf '999998 1015900 active 300 5000 50000 1015900 41200 600\n' > "$EST"
 true_case 'est adopt: two-second-old estimate still adopts' burn_est_adopt
 eq 'est adopt: aged estimate ttr still local' "$_B5_TTR" 15900
 _CUR_BURN_VALID=0
@@ -884,7 +888,7 @@ CASE="$TMPD/est-ro"; mkdir -p "$CASE/state"
 write_config "$CASE/conf" "$CASE/state" burn 0
 _now=$(date +%s)
 make_payload "$CASE/input" 41.2 "$((_now + 9000))" '' ''
-printf '%s %s active 300 5000 50000 %s 41200\n' "$_now" "$((_now + 9000))" "$((_now + 9000))" > "$CASE/state/burn.tsv.est"
+printf '%s %s active 300 5000 50000 %s 41200 600\n' "$_now" "$((_now + 9000))" "$((_now + 9000))" > "$CASE/state/burn.tsv.est"
 cp "$CASE/state/burn.tsv.est" "$CASE/est.before"
 run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 1
 printf '\033[0m B … \033[0m\n' > "$CASE/oracle"

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -174,11 +174,15 @@ if grep -q 99999999 "$BURN_FILE"; then bad 'burn sentinel healed on mutable read
 
 BURN_TRIM=3
 run5h '1\t6\t9\n2\t6\t9\n3\t7\t9\n4\t7\t9\n5\t8\t9\n' 6 1
-eq '5h trim physical rowcount' "$(wc -l < "$BURN_FILE" | tr -d ' ')" 3
+# A rewrite ends with an empty stamp line (see the rename in burn_eta_5h),
+# which both renderers skip and the next rewrite drops: rows + 1 physical line.
+eq '5h trim physical rowcount' "$(wc -l < "$BURN_FILE" | tr -d ' ')" 4
+eq '5h trim data rowcount' "$(grep -c '	' "$BURN_FILE")" 3
+eq '5h trim ends with the replacement stamp' "$(tail -1 "$BURN_FILE")" ''
 IFS=$'\t' read -r _FIRST _ _ < "$BURN_FILE"; eq '5h trim first kept' "$_FIRST" 3
 BURN_TRIM=3
 run5h '1\t6\t9\n1\t6.100\t9\n1\t6.200\t9\n2\t7\t9\n2\t7.100\t9\n2\t7.200\t9\n' 3 1
-eq 'resize burst collapses same-second rows' "$(wc -l < "$BURN_FILE" | tr -d ' ')" 2
+eq 'resize burst collapses same-second rows' "$(grep -c '	' "$BURN_FILE")" 2
 
 CASE="$TMPD/stale-tmp"; mkdir -p "$CASE"
 unit_gate "$CASE" 6 '' '' '' '' 1
@@ -421,7 +425,7 @@ if cmp -s "$CASE/before.tar" "$CASE/after.tar"; then ok 'immutable burn.d stays 
 printf 'tmp-canary' > "$CASE/state/burn.tsv.keep.tmp"
 _i=0; while [ "$_i" -lt 8 ]; do run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out.$_i" "$CASE/err.$_i" 0; _i=$((_i + 1)); done
 eq 'unrelated temp canary preserved' "$(LC_ALL=C tr -d '\n' < "$CASE/state/burn.tsv.keep.tmp")" tmp-canary
-[ "$(wc -l < "$CASE/state/burn.tsv" | tr -d ' ')" -le 3 ] && ok 'repeated render TSV remains trimmed' || bad 'repeated render TSV remains trimmed' "rows=$(wc -l < "$CASE/state/burn.tsv")"
+[ "$(grep -c '	' "$CASE/state/burn.tsv")" -le 3 ] && ok 'repeated render TSV remains trimmed' || bad 'repeated render TSV remains trimmed' "rows=$(grep -c '	' "$CASE/state/burn.tsv")"
 
 # Malformed arithmetic/metacharacter basenames and nonempty canonical-looking
 # directories never displace the valid winner, emit stderr, or trigger side effects.
@@ -609,7 +613,7 @@ BURN_TRIM=3; BURN_SLACK=2
 run5h '1\t6\t9\n2\t6\t9\n3\t7\t9\n4\t7\t9\n' 6 1
 eq 'slack holds the rewrite below trim+slack' "$(wc -l < "$BURN_FILE" | tr -d ' ')" 4
 run5h '1\t6\t9\n2\t6\t9\n3\t7\t9\n4\t7\t9\n5\t8\t9\n6\t8\t9\n' 7 1
-eq 'past trim+slack rewrites down to trim' "$(wc -l < "$BURN_FILE" | tr -d ' ')" 3
+eq 'past trim+slack rewrites down to trim' "$(grep -c '	' "$BURN_FILE")" 3
 run5h '1\t6\t9\n2\t7\t9\n9999000\t99\t99999999\n' 6 1
 if grep -q 99999999 "$BURN_FILE"; then bad 'heal is not deferred by slack' present; else ok 'heal is not deferred by slack'; fi
 BURN_TRIM=1500; BURN_SLACK=0

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -695,41 +695,60 @@ printf '1\t6\t9\n' > "$BURN_FILE"
 
 # Publish: winner shape, maintenance/no-raw refusal.
 _CUR_BURN_VALID=1; _B5_RAW='warming 0 0 41200 9000'; _B5_TTR=9000
-burn_est_publish
+burn_est_snap; burn_est_publish
 eq 'est publish: winner writes the claim-stamped line' "$(cat "$EST" 2>/dev/null)" '1000000 1009000 warming 0 0 41200 1015900 41200'
 rm -f "$EST"
 _CUR_BURN_VALID=0
-burn_est_publish
+burn_est_snap; burn_est_publish
 true_case 'est publish: maintenance winner never publishes' test ! -e "$EST"
 _CUR_BURN_VALID=1; _B5_RAW=''
-burn_est_publish
+burn_est_snap; burn_est_publish
 true_case 'est publish: no raw line, no publish' test ! -e "$EST"
 mkdir "$EST"
 _B5_RAW='warming 0 0 41200 9000'
-burn_est_publish
+burn_est_snap; burn_est_publish
 true_case 'est publish: directory at est name aborts' test -d "$EST"
 true_case 'est publish: aborted publish leaves no tmp' test ! -e "$CASE/burn.tsv.$$.tmp"
 rmdir "$EST"
 # A covering higher claim in the same (second, window) suppresses our publish;
 # a lower one does not.
 : > "$CASE/burn.tsv.1000000.1015900.60000.tick"
-burn_est_publish
+burn_est_snap; burn_est_publish
 true_case 'est publish: higher same-second claim suppresses ours' test ! -e "$EST"
 true_case 'est publish: suppressed publish leaves no tmp' test ! -e "$CASE/burn.tsv.$$.tmp"
 rm -f "$CASE/burn.tsv.1000000.1015900.60000.tick"
 : > "$CASE/burn.tsv.1000000.1015900.30000.tick"
-burn_est_publish
+burn_est_snap; burn_est_publish
 true_case 'est publish: lower claim does not suppress' test -f "$EST"
 rm -f "$EST" "$CASE/burn.tsv.1000000.1015900.30000.tick"
 : > "$CASE/burn.tsv.1000000.1016100.20000.tick"
-burn_est_publish
+burn_est_snap; burn_est_publish
 true_case 'est publish: newer-window claim suppresses ours' test ! -e "$EST"
 true_case 'est publish: cross-window suppression leaves no tmp' test ! -e "$CASE/burn.tsv.$$.tmp"
 rm -f "$CASE/burn.tsv.1000000.1016100.20000.tick"
 : > "$CASE/burn.tsv.1000000.1009000.90000.tick"
-burn_est_publish
+burn_est_snap; burn_est_publish
 true_case 'est publish: older-window claim does not suppress' test -f "$EST"
 rm -f "$EST" "$CASE/burn.tsv.1000000.1009000.90000.tick"
+# The estimate is versioned against the TSV as the parse read it, so a row
+# landing between parse and publish abandons the publication, and an
+# unversioned publish is refused outright.
+rm -f "$EST"
+burn_est_snap
+true_case 'est snap: marker created before the parse' test -f "$_BURN_SNAP"
+_SNAPPED=$_BURN_SNAP
+sleep 1; printf '2\t7\t9\n' >> "$BURN_FILE"
+burn_est_publish
+true_case 'est publish: TSV touched during the parse abandons publication' test ! -e "$EST"
+true_case 'est publish: abandoned publication releases the marker' test ! -e "$_SNAPPED"
+_BURN_SNAP=""
+burn_est_publish
+true_case 'est publish: unversioned publish refused' test ! -e "$EST"
+burn_est_snap; burn_est_publish
+true_case 'est publish: untouched TSV publishes normally' test -f "$EST"
+true_case 'est publish: successful publication releases the marker' test ! -e "$_SNAPPED"
+rm -f "$EST"
+
 # Discarding a temporary is a mutation: it must re-prove the path identity, so
 # an unlink can never traverse an ancestor swapped for a symlink mid-render.
 : > "$CASE/burn.tsv.4242.tmp"

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -643,6 +643,13 @@ true_case 'lead sweep: non-numeric epoch kept' test -f "$CASE/burn.tsv.abc.10159
 true_case 'lead sweep: two-field name kept' test -f "$CASE/burn.tsv.999990.1015900.tick"
 true_case 'lead sweep: foreign unprefixed file untouched' test -f "$CASE/tick.999990.1015900.41200.tick"
 true_case 'lead sweep: symlink kept' test -L "$CASE/burn.tsv.999980.1015900.41200.tick"
+rm -f "$CASE"/burn.tsv.*.tick 2>/dev/null
+: > "$CASE/burn.tsv.1000000.1015900.999999999999999999999999.tick"
+: > "$CASE/burn.tsv.999990.1015900.999999999999999999999999.tick"
+_BURN_LEAD=
+state_burn_lead 2> "$CASE/overflow.err" || bad 'lead: oversized field never blocks a claim' lost
+eq 'lead: oversized digit field leaks no stderr' "$(wc -c < "$CASE/overflow.err" | tr -d ' ')" 0
+true_case 'lead sweep: stale oversized name kept, not compared' test -f "$CASE/burn.tsv.999990.1015900.999999999999999999999999.tick"
 rm -f "$CASE"/burn.tsv.*.tick "$CASE"/tick.* 2>/dev/null
 ln -s "$CASE/linktarget" "$TOK"
 _BURN_LEAD=

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -768,6 +768,15 @@ printf '1000000 1015900 active 300 5000 50000 1015900 50000\n' > "$EST"
 true_case 'est adopt: claim above the covering pct accepted' burn_est_adopt
 printf '1000000 1020000 active 300 5000 50000 1020000 5000\n' > "$EST"
 true_case 'est adopt: newer-window claim supersedes any pct' burn_est_adopt
+# Same-window adoption substitutes this session's own reading for the
+# published latest (percentages legitimately drop within a window, and the
+# full parse would inject our observation as the newest sample).
+printf '1000000 1015900 active 300 5000 50000 1015900 50000\n' > "$EST"
+true_case 'est adopt: latest override adoption succeeds' burn_est_adopt
+_ADOPT_ETA=$_B5_ETA
+burn_b5_line 'active 300 5000 41200 15900' || bad 'est adopt: reference line parses' failed
+eq 'est adopt: same-window latest is our own reading' "$_ADOPT_ETA" "$_B5_ETA"
+
 # A TSV strictly newer than the estimate means rows landed after the publish
 # (an older-tick straggler inside the sweep grace window): the snapshot is
 # incomplete and must not be adopted.

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -768,6 +768,13 @@ printf '1000000 1015900 active 300 5000 50000 1015900 50000\n' > "$EST"
 true_case 'est adopt: claim above the covering pct accepted' burn_est_adopt
 printf '1000000 1020000 active 300 5000 50000 1020000 5000\n' > "$EST"
 true_case 'est adopt: newer-window claim supersedes any pct' burn_est_adopt
+# A TSV strictly newer than the estimate means rows landed after the publish
+# (an older-tick straggler inside the sweep grace window): the snapshot is
+# incomplete and must not be adopted.
+printf '1000000 1015900 active 300 5000 50000 1015900 41200\n' > "$EST"
+touch -t 202001010000 "$EST"
+printf '1\t6\t9\n' >> "$BURN_FILE"
+if burn_est_adopt; then bad 'est adopt: TSV newer than estimate rejected' adopted; else ok 'est adopt: TSV newer than estimate rejected'; fi
 printf '1000000 1015900 active a[$(touch %s/pwn)] 5000 50000 1015900 41200\n' "$CASE" > "$EST"
 if burn_est_adopt; then bad 'est adopt: arithmetic injection rejected' adopted; else ok 'est adopt: arithmetic injection rejected'; fi
 true_case 'est adopt: injection produced no side effect' test ! -e "$CASE/pwn"

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -806,6 +806,10 @@ printf '1000002 1015900 active 300 5 50000 1015900 41200 600 999000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: future-dated estimate rejected' adopted; else ok 'est adopt: future-dated estimate rejected'; fi
 printf '1000000 1015900 active 90000 5 50000 1015900 41200 600 999000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: span beyond window cap rejected' adopted; else ok 'est adopt: span beyond window cap rejected'; fi
+printf '1000000 1015900 active 601 5 50000 1015900 41200 600 999000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: span past the configured lookback rejected' adopted; else ok 'est adopt: span past the configured lookback rejected'; fi
+printf '1000000 1015900 active 600 5 50000 1015900 41200 600 999000\n' > "$EST"
+true_case 'est adopt: span at the configured lookback accepted' burn_est_adopt
 printf '1000000 1015900 active 300 101 50000 1015900 41200 600 999000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: delta beyond the producer cap rejected' adopted; else ok 'est adopt: delta beyond the producer cap rejected'; fi
 printf '1000000 1015900 active 300 5 100001 1015900 41200 600 999000\n' > "$EST"

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -539,10 +539,21 @@ run_concurrency() {  # $1=runtime $2=workers $3=tag
   fi
   _CC_IMMUTABLE=0
   [ "$(LC_ALL=C tr -d '\n' < "$root/state/burn.d/canary")" = immutable-concurrency-canary ] && _CC_IMMUTABLE=1
+  # Winner-published estimate: present, regular, six validly-shaped fields;
+  # and no orphaned publish temporaries once every render has exited.
+  _CC_EST=0
+  if [ -f "$root/state/burn.tsv.est" ] && [ ! -L "$root/state/burn.tsv.est" ]; then
+    _E1=""; _E2=""; _E3=""; _E4=""; _E5=""; _E6=""
+    read -r _E1 _E2 _E3 _E4 _E5 _E6 < "$root/state/burn.tsv.est" 2>/dev/null || :
+    case "$_E1$_E2$_E4$_E5$_E6" in (''|*[!0-9]*) ;; (*)
+      case "$_E3" in (active|idle|warming) _CC_EST=1 ;; esac ;; esac
+  fi
+  _CC_TMPS=$(ls "$root/state" 2>/dev/null | grep -c '\.tmp$')
   [ "$_CC_RCFILES" -eq "$_CC_EXPECTED" ] && [ "$_CC_SUCCESS" -eq "$_CC_EXPECTED" ] \
     && [ "$_CC_NONEMPTY" -eq "$_CC_EXPECTED" ] && [ "$_CC_MATCH" -eq "$_CC_EXPECTED" ] \
     && [ "$_CC_STDERR_EMPTY" -eq "$_CC_EXPECTED" ] \
     && [ "$_CC_ROWS" -ge 1 ] && [ "$_CC_ROWS" -le "$_CC_EXPECTED" ] && [ "$_CC_DUPES" -eq 0 ] \
+    && [ "$_CC_EST" -eq 1 ] && [ "$_CC_TMPS" -eq 0 ] \
     && [ "$_CC_IMMUTABLE" -eq 1 ]
 }
 
@@ -562,9 +573,11 @@ for _N in 5 12 16; do
     eq "concurrency n=$_N stderr empty" "$_CC_STDERR_EMPTY" $((_N * 2))
     eq "concurrency n=$_N single writer per (second, window)" "$_CC_DUPES" 0
     ok "concurrency n=$_N TSV rows within [1, renders] ($_CC_ROWS)"
+    eq "concurrency n=$_N estimate published and well-shaped" "$_CC_EST" 1
+    eq "concurrency n=$_N no orphaned publish temporaries" "$_CC_TMPS" 0
     eq "concurrency n=$_N immutable store untouched" "$_CC_IMMUTABLE" 1
   else
-    bad "concurrency n=$_N" "expected=$_CC_EXPECTED rcfiles=$_CC_RCFILES success=$_CC_SUCCESS nonempty=$_CC_NONEMPTY match=$_CC_MATCH stderr=$_CC_STDERR_EMPTY rows=$_CC_ROWS dupes=$_CC_DUPES immutable=$_CC_IMMUTABLE"
+    bad "concurrency n=$_N" "expected=$_CC_EXPECTED rcfiles=$_CC_RCFILES success=$_CC_SUCCESS nonempty=$_CC_NONEMPTY match=$_CC_MATCH stderr=$_CC_STDERR_EMPTY rows=$_CC_ROWS dupes=$_CC_DUPES est=$_CC_EST tmps=$_CC_TMPS immutable=$_CC_IMMUTABLE"
   fi
 done
 
@@ -668,6 +681,84 @@ _BURN_LEAD=
 true_case 'lead: missing store parent fails open' state_burn_lead
 true_case 'lead: fail-open creates no token' test ! -e "$CASE/absent/burn.tsv.1000000.1015900.41200.tick"
 _BURN_LEAD=
+
+# Published-estimate fast path: the election winner publishes its validated
+# awk result; a follower that lost to a covering claim adopts it only after
+# every field survives the same validation the awk output gets, and every
+# anomaly falls back to the full parse.
+CASE="$TMPD/est"; mkdir -p "$CASE"
+unit_gate "$CASE" 1000000 41.2 1015900 '' '' 0
+EST="$CASE/burn.tsv.est"
+
+# Publish: winner shape, maintenance/no-raw refusal.
+_CUR_BURN_VALID=1; _B5_RAW='warming 0 0 41200 9000'; _B5_TTR=9000
+burn_est_publish
+eq 'est publish: winner writes the six-field line' "$(cat "$EST" 2>/dev/null)" '1000000 1009000 warming 0 0 41200'
+rm -f "$EST"
+_CUR_BURN_VALID=0
+burn_est_publish
+true_case 'est publish: maintenance winner never publishes' test ! -e "$EST"
+_CUR_BURN_VALID=1; _B5_RAW=''
+burn_est_publish
+true_case 'est publish: no raw line, no publish' test ! -e "$EST"
+mkdir "$EST"
+_B5_RAW='warming 0 0 41200 9000'
+burn_est_publish
+true_case 'est publish: directory at est name aborts' test -d "$EST"
+true_case 'est publish: aborted publish leaves no tmp' test ! -e "$CASE/burn.tsv.$$.tmp"
+rmdir "$EST"
+
+# Adopt: fresh valid estimate is used without the awk (values differ from
+# anything the empty TSV could produce, so adoption is observable).
+printf '1000000 1015900 active 300 5000 50000\n' > "$EST"
+_CUR_BURN_VALID=1
+true_case 'est adopt: fresh valid estimate adopted' burn_est_adopt
+eq 'est adopt: state comes from the estimate' "$_B5_STATE" active
+eq 'est adopt: ttr derives from window and local NOW' "$_B5_TTR" 15900
+printf '999996 1015900 active 300 5000 50000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: stale estimate rejected' adopted; else ok 'est adopt: stale estimate rejected'; fi
+printf '1000002 1015900 active 300 5000 50000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: future-dated estimate rejected' adopted; else ok 'est adopt: future-dated estimate rejected'; fi
+printf '1000000 1015900 active 90000 5000 50000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: span beyond window cap rejected' adopted; else ok 'est adopt: span beyond window cap rejected'; fi
+printf '1000000 1015900 active 300 200000 50000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: delta beyond pct cap rejected' adopted; else ok 'est adopt: delta beyond pct cap rejected'; fi
+printf '1000000 1015900 active 300 5000 100001\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: latest beyond pct cap rejected' adopted; else ok 'est adopt: latest beyond pct cap rejected'; fi
+printf '1000000 1015900 hacked 300 5000 50000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: unknown state token rejected' adopted; else ok 'est adopt: unknown state token rejected'; fi
+printf '1000000 1015900 active a[$(touch %s/pwn)] 5000 50000\n' "$CASE" > "$EST"
+if burn_est_adopt; then bad 'est adopt: arithmetic injection rejected' adopted; else ok 'est adopt: arithmetic injection rejected'; fi
+true_case 'est adopt: injection produced no side effect' test ! -e "$CASE/pwn"
+{ printf '1000000 1015900 active 300 5000 50000 '; head -c 400 /dev/zero | tr '\0' '9'; printf '\n'; } > "$EST"
+if burn_est_adopt; then bad 'est adopt: oversized line rejected' adopted; else ok 'est adopt: oversized line rejected'; fi
+rm -f "$EST"; ln -s "$CASE/esttarget" "$EST"
+if burn_est_adopt; then bad 'est adopt: symlink est rejected' adopted; else ok 'est adopt: symlink est rejected'; fi
+true_case 'est adopt: symlink est not followed' test ! -e "$CASE/esttarget"
+true_case 'est adopt: symlink est not deleted' test -L "$EST"
+rm -f "$EST"
+printf '999998 1015900 active 300 5000 50000\n' > "$EST"
+true_case 'est adopt: two-second-old estimate still adopts' burn_est_adopt
+eq 'est adopt: aged estimate ttr still local' "$_B5_TTR" 15900
+_CUR_BURN_VALID=0
+rm -f "$EST"
+
+# Read-only wiring: a CORALLINE_NO_SAMPLE render never consumes a published
+# estimate (test/preview determinism, rule #32) and never writes one. The
+# planted est claims an active state no empty TSV could produce, so any
+# adoption would be visible in the output.
+CASE="$TMPD/est-ro"; mkdir -p "$CASE/state"
+write_config "$CASE/conf" "$CASE/state" burn 0
+_now=$(date +%s)
+make_payload "$CASE/input" 41.2 "$((_now + 9000))" '' ''
+printf '%s %s active 300 5000 50000\n' "$_now" "$((_now + 9000))" > "$CASE/state/burn.tsv.est"
+cp "$CASE/state/burn.tsv.est" "$CASE/est.before"
+run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 1
+printf '\033[0m B … \033[0m\n' > "$CASE/oracle"
+if cmp -s "$CASE/out" "$CASE/oracle"; then ok 'est read-only: no-sample render ignores a fresh estimate'; else bad 'est read-only: no-sample render ignores a fresh estimate' "$(cat "$CASE/out")"; fi
+if cmp -s "$CASE/state/burn.tsv.est" "$CASE/est.before"; then ok 'est read-only: estimate file untouched'; else bad 'est read-only: estimate file untouched' changed; fi
+eq 'est read-only: no tokens created' "$(ls "$CASE/state" | grep -c '\.tick$')" 0
+eq 'est read-only: stderr empty' "$(wc -c < "$CASE/err" | tr -d ' ')" 0
 
 # Maintenance claim: a render with no valid 5h reading may still win the
 # mutate path (trim/heal/sweep never starve), under the reserved 0.0 name; it

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -707,6 +707,17 @@ burn_est_publish
 true_case 'est publish: directory at est name aborts' test -d "$EST"
 true_case 'est publish: aborted publish leaves no tmp' test ! -e "$CASE/burn.tsv.$$.tmp"
 rmdir "$EST"
+# A covering higher claim in the same (second, window) suppresses our publish;
+# a lower one does not.
+: > "$CASE/burn.tsv.1000000.1015900.60000.tick"
+burn_est_publish
+true_case 'est publish: higher same-second claim suppresses ours' test ! -e "$EST"
+true_case 'est publish: suppressed publish leaves no tmp' test ! -e "$CASE/burn.tsv.$$.tmp"
+rm -f "$CASE/burn.tsv.1000000.1015900.60000.tick"
+: > "$CASE/burn.tsv.1000000.1015900.30000.tick"
+burn_est_publish
+true_case 'est publish: lower claim does not suppress' test -f "$EST"
+rm -f "$EST" "$CASE/burn.tsv.1000000.1015900.30000.tick"
 
 # Adopt: fresh valid estimate is used without the awk (values differ from
 # anything the empty TSV could produce, so adoption is observable).

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -821,6 +821,12 @@ printf '1000000 1015900 active 300 5 50000 1015900 50000 600 999000\n' > "$EST"
 true_case 'est adopt: claim above the covering pct accepted' burn_est_adopt
 printf '1000000 1020000 active 300 5 50000 1020000 5000 600 999000\n' > "$EST"
 true_case 'est adopt: newer-window claim supersedes any pct' burn_est_adopt
+# A writer injects its own claim into its parse, so a described window before
+# the claimed one is provenance no publisher could produce.
+printf '1000000 1015900 active 300 5 50000 1020000 5000 600 999000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: claim newer than described window rejected' adopted; else ok 'est adopt: claim newer than described window rejected'; fi
+printf '1000000 1021600 active 300 5 50000 1021601 5000 600 999000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: claim beyond the 5h horizon rejected' adopted; else ok 'est adopt: claim beyond the 5h horizon rejected'; fi
 # Prior-tick same-window adoption substitutes this session's own reading for
 # the published latest (our observation is the newest distinct sample, and
 # percentages legitimately drop within a window). A same-tick estimate keeps

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -727,6 +727,20 @@ rm -f "$CASE/burn.tsv.1000000.1016100.20000.tick"
 burn_est_publish
 true_case 'est publish: older-window claim does not suppress' test -f "$EST"
 rm -f "$EST" "$CASE/burn.tsv.1000000.1009000.90000.tick"
+# Discarding a temporary is a mutation: it must re-prove the path identity, so
+# an unlink can never traverse an ancestor swapped for a symlink mid-render.
+: > "$CASE/burn.tsv.4242.tmp"
+_STATE_PATHS_OK=0
+burn_est_discard "$CASE/burn.tsv.4242.tmp"
+true_case 'est discard: revalidation failure keeps the temporary' test -f "$CASE/burn.tsv.4242.tmp"
+_STATE_PATHS_OK=1
+burn_est_discard "$CASE/burn.tsv.4242.tmp"
+true_case 'est discard: revalidated temporary removed' test ! -e "$CASE/burn.tsv.4242.tmp"
+ln -s "$CASE/discardtarget" "$CASE/burn.tsv.4243.tmp"
+burn_est_discard "$CASE/burn.tsv.4243.tmp"
+true_case 'est discard: symlink temporary never unlinked' test -L "$CASE/burn.tsv.4243.tmp"
+true_case 'est discard: symlink target never touched' test ! -e "$CASE/discardtarget"
+rm -f "$CASE/burn.tsv.4243.tmp"
 
 # Adopt: fresh valid estimate is used without the awk (values differ from
 # anything the empty TSV could produce, so adoption is observable).

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -758,6 +758,13 @@ true_case 'est publish: abandoned publication releases the marker' test ! -e "$_
 _BURN_SNAP=""
 burn_est_publish
 true_case 'est publish: unversioned publish refused' test ! -e "$EST"
+# The marker shares burn_tmp_sweep's namespace, so a concurrent writer can
+# retire it mid-parse; a vanished marker proves nothing and must not pass.
+burn_est_snap
+rm -f "$_BURN_SNAP"
+burn_est_publish
+true_case 'est publish: vanished marker refuses publication' test ! -e "$EST"
+true_case 'est publish: vanished marker leaves no temporary' test ! -e "$CASE/burn.tsv.$$.tmp"
 # The redirection creates the temporary before the write runs; a write that
 # fails afterwards must not leave it behind.
 printf() { return 1; }

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -635,6 +635,16 @@ _BURN_LEAD=
 true_case 'lead: our higher reading beats a lower claim' state_burn_lead
 true_case 'lead: divergent readings both leave tokens' test -f "$TOK"
 rm -f "$CASE"/burn.tsv.*.tick
+# Only a regular non-symlink file counts as a claim: a planted symlink or
+# directory carrying a higher percentage must not make us lose (and must not
+# mark the loss adoption-safe), because no live parse stands behind it.
+ln -s /dev/null "$CASE/burn.tsv.1000000.1015900.70000.tick"
+mkdir "$CASE/burn.tsv.1000000.1015900.80000.tick"
+_BURN_LEAD=; _BURN_LOST=0
+true_case 'lead: planted symlink claim does not win' state_burn_lead
+eq 'lead: planted objects never mark an adoptable loss' "${_BURN_LOST:-0}" 0
+rm -f "$CASE/burn.tsv.1000000.1015900.70000.tick"; rmdir "$CASE/burn.tsv.1000000.1015900.80000.tick"
+rm -f "$CASE"/burn.tsv.*.tick
 : > "$CASE/burn.tsv.1000000.1016000.41200.tick"
 _BURN_LEAD=
 true_case 'lead: same-second other-window token does not block' state_burn_lead
@@ -744,6 +754,13 @@ true_case 'est publish: abandoned publication releases the marker' test ! -e "$_
 _BURN_SNAP=""
 burn_est_publish
 true_case 'est publish: unversioned publish refused' test ! -e "$EST"
+# The redirection creates the temporary before the write runs; a write that
+# fails afterwards must not leave it behind.
+printf() { return 1; }
+burn_est_snap; burn_est_publish
+unset -f printf
+true_case 'est publish: failed write leaves no temporary' test ! -e "$CASE/burn.tsv.$$.tmp"
+true_case 'est publish: failed write publishes nothing' test ! -e "$EST"
 burn_est_snap; burn_est_publish
 true_case 'est publish: untouched TSV publishes normally' test -f "$EST"
 true_case 'est publish: successful publication releases the marker' test ! -e "$_SNAPPED"

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -836,6 +836,14 @@ true_case 'est adopt: same-tick adoption succeeds' burn_est_adopt
 _ADOPT_ETA=$_B5_ETA
 burn_b5_line 'active 300 5000 50000 15900' || bad 'est adopt: same-tick reference parses' failed
 eq 'est adopt: same-tick keeps the published latest' "$_ADOPT_ETA" "$_B5_ETA"
+# A writer claiming our window whose parse selected a NEWER window published
+# numbers our reading has no part in: the substitution follows the described
+# window, not the claimed one.
+printf '999999 1020000 active 300 5000 50000 1015900 41200\n' > "$EST"
+true_case 'est adopt: claim-ours described-newer adoption succeeds' burn_est_adopt
+_ADOPT_ETA=$_B5_ETA
+burn_b5_line 'active 300 5000 50000 20000' || bad 'est adopt: described-window reference parses' failed
+eq 'est adopt: described-newer keeps the published latest' "$_ADOPT_ETA" "$_B5_ETA"
 
 # A TSV strictly newer than the estimate means rows landed after the publish
 # (an older-tick straggler inside the sweep grace window): the snapshot is

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -784,97 +784,104 @@ rm -f "$CASE/burn.tsv.4243.tmp"
 # Adopt: fresh valid estimate is used without the awk (values differ from
 # anything the empty TSV could produce, so adoption is observable).
 # _BURN_LOST_PCT simulates the covering claim this session lost to.
-printf '1000000 1015900 active 300 5000 50000 1015900 41200 600\n' > "$EST"
+printf '1000000 1015900 active 300 5 50000 1015900 41200 600\n' > "$EST"
 _CUR_BURN_VALID=1; _BURN_LOST_PCT=41200
 true_case 'est adopt: fresh valid estimate adopted' burn_est_adopt
 eq 'est adopt: state comes from the estimate' "$_B5_STATE" active
 eq 'est adopt: ttr derives from window and local NOW' "$_B5_TTR" 15900
-printf '999996 1015900 active 300 5000 50000 1015900 41200 600\n' > "$EST"
+printf '999996 1015900 active 300 5 50000 1015900 41200 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: stale estimate rejected' adopted; else ok 'est adopt: stale estimate rejected'; fi
-printf '1000002 1015900 active 300 5000 50000 1015900 41200 600\n' > "$EST"
+printf '1000002 1015900 active 300 5 50000 1015900 41200 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: future-dated estimate rejected' adopted; else ok 'est adopt: future-dated estimate rejected'; fi
-printf '1000000 1015900 active 90000 5000 50000 1015900 41200 600\n' > "$EST"
+printf '1000000 1015900 active 90000 5 50000 1015900 41200 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: span beyond window cap rejected' adopted; else ok 'est adopt: span beyond window cap rejected'; fi
-printf '1000000 1015900 active 300 200000 50000 1015900 41200 600\n' > "$EST"
-if burn_est_adopt; then bad 'est adopt: delta beyond pct cap rejected' adopted; else ok 'est adopt: delta beyond pct cap rejected'; fi
-printf '1000000 1015900 active 300 5000 100001 1015900 41200 600\n' > "$EST"
+printf '1000000 1015900 active 300 101 50000 1015900 41200 600\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: delta beyond the producer cap rejected' adopted; else ok 'est adopt: delta beyond the producer cap rejected'; fi
+printf '1000000 1015900 active 300 5 100001 1015900 41200 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: latest beyond pct cap rejected' adopted; else ok 'est adopt: latest beyond pct cap rejected'; fi
-printf '1000000 1015900 hacked 300 5000 50000 1015900 41200 600\n' > "$EST"
+printf '1000000 1015900 hacked 300 5 50000 1015900 41200 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: unknown state token rejected' adopted; else ok 'est adopt: unknown state token rejected'; fi
-printf '1000000 1015900 active 008 5000 50000 1015900 41200 600\n' > "$EST"
+printf '1000000 1015900 active 008 5 50000 1015900 41200 600\n' > "$EST"
 if burn_est_adopt 2> "$CASE/octal.err"; then bad 'est adopt: leading-zero span rejected' adopted; else ok 'est adopt: leading-zero span rejected'; fi
 eq 'est adopt: leading-zero rejection leaks no stderr' "$(wc -c < "$CASE/octal.err" | tr -d ' ')" 0
-printf '1000000 1009000 active 300 5000 50000 1009000 41200 600\n' > "$EST"
+printf '1000000 1009000 active 300 5 50000 1009000 41200 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: older-window estimate rejected' adopted; else ok 'est adopt: older-window estimate rejected'; fi
-printf '1000000 1020000 active 300 5000 50000 1020000 41200 600\n' > "$EST"
+printf '1000000 1020000 active 300 5 50000 1020000 41200 600\n' > "$EST"
 true_case 'est adopt: newer-window estimate accepted' burn_est_adopt
 eq 'est adopt: newer-window ttr from published maxrst' "$_B5_TTR" 20000
-printf '1000000 1021601 active 300 5000 50000 1021601 41200 600\n' > "$EST"
+printf '1000000 1021601 active 300 5 50000 1021601 41200 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: reset beyond 5h horizon rejected' adopted; else ok 'est adopt: reset beyond 5h horizon rejected'; fi
-printf '1000000 1021600 active 300 5000 50000 1021600 41200 600\n' > "$EST"
+printf '1000000 1021600 active 300 5 50000 1021600 41200 600\n' > "$EST"
 true_case 'est adopt: reset at the 5h horizon accepted' burn_est_adopt
-printf '1000000 1015900 active 300 5000 50000\n' > "$EST"
+printf '1000000 1015900 active 300 5 50000\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: legacy six-field line rejected' adopted; else ok 'est adopt: legacy six-field line rejected'; fi
-printf '1000000 1015900 active 300 5000 50000 1015900 30000 600\n' > "$EST"
+printf '1000000 1015900 active 300 5 50000 1015900 30000 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: claim below the covering pct rejected' adopted; else ok 'est adopt: claim below the covering pct rejected'; fi
-printf '1000000 1015900 active 300 5000 50000 1015900 50000 600\n' > "$EST"
+printf '1000000 1015900 active 300 5 50000 1015900 50000 600\n' > "$EST"
 true_case 'est adopt: claim above the covering pct accepted' burn_est_adopt
-printf '1000000 1020000 active 300 5000 50000 1020000 5000 600\n' > "$EST"
+printf '1000000 1020000 active 300 5 50000 1020000 5000 600\n' > "$EST"
 true_case 'est adopt: newer-window claim supersedes any pct' burn_est_adopt
 # Prior-tick same-window adoption substitutes this session's own reading for
 # the published latest (our observation is the newest distinct sample, and
 # percentages legitimately drop within a window). A same-tick estimate keeps
 # the published value: the winner's row shares our sample key, where the
 # reader keeps the maximum, so it already covers our injection.
-printf '999999 1015900 active 300 5000 50000 1015900 50000 600\n' > "$EST"
+# A prior-tick sample that lifts the whole-percent value would change the
+# crossing structure, which the cached span/delta cannot be corrected for.
+printf '999999 1015900 active 300 5 30000 1015900 41200 600\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: crossing-changing sample falls back' adopted; else ok 'est adopt: crossing-changing sample falls back'; fi
+printf '999999 1015900 active 300 5 41900 1015900 41200 600\n' > "$EST"
+true_case 'est adopt: same whole percent still adopts' burn_est_adopt
+eq 'est adopt: same-percent substitution keeps our milli' "$_B5_TTR" 15900
+printf '999999 1015900 active 300 5 50000 1015900 50000 600\n' > "$EST"
 true_case 'est adopt: prior-tick latest override adoption succeeds' burn_est_adopt
 _ADOPT_ETA=$_B5_ETA
-burn_b5_line 'active 300 5000 41200 15900' || bad 'est adopt: reference line parses' failed
+burn_b5_line 'active 300 5 41200 15900' || bad 'est adopt: reference line parses' failed
 eq 'est adopt: prior-tick latest is our own reading' "$_ADOPT_ETA" "$_B5_ETA"
-printf '1000000 1015900 active 300 5000 50000 1015900 50000 600\n' > "$EST"
+printf '1000000 1015900 active 300 5 50000 1015900 50000 600\n' > "$EST"
 true_case 'est adopt: same-tick adoption succeeds' burn_est_adopt
 _ADOPT_ETA=$_B5_ETA
-burn_b5_line 'active 300 5000 50000 15900' || bad 'est adopt: same-tick reference parses' failed
+burn_b5_line 'active 300 5 50000 15900' || bad 'est adopt: same-tick reference parses' failed
 eq 'est adopt: same-tick keeps the published latest' "$_ADOPT_ETA" "$_B5_ETA"
 # A writer claiming our window whose parse selected a NEWER window published
 # numbers our reading has no part in: the substitution follows the described
 # window, not the claimed one.
-printf '999999 1020000 active 300 5000 50000 1015900 41200 600\n' > "$EST"
+printf '999999 1020000 active 300 5 50000 1015900 41200 600\n' > "$EST"
 true_case 'est adopt: claim-ours described-newer adoption succeeds' burn_est_adopt
 _ADOPT_ETA=$_B5_ETA
-burn_b5_line 'active 300 5000 50000 20000' || bad 'est adopt: described-window reference parses' failed
+burn_b5_line 'active 300 5 50000 20000' || bad 'est adopt: described-window reference parses' failed
 eq 'est adopt: described-newer keeps the published latest' "$_ADOPT_ETA" "$_B5_ETA"
 
 # A TSV strictly newer than the estimate means rows landed after the publish
 # (an older-tick straggler inside the sweep grace window): the snapshot is
 # incomplete and must not be adopted.
-printf '1000000 1015900 active 300 5000 50000 1015900 41200 600\n' > "$EST"
+printf '1000000 1015900 active 300 5 50000 1015900 41200 600\n' > "$EST"
 touch -t 202001010000 "$EST"
 printf '1\t6\t9\n' >> "$BURN_FILE"
 if burn_est_adopt; then bad 'est adopt: TSV newer than estimate rejected' adopted; else ok 'est adopt: TSV newer than estimate rejected'; fi
 # A summary must not outlive the file it summarizes: with the TSV deleted the
 # mtime test is vacuous, so absence is checked on its own.
 cp "$BURN_FILE" "$CASE/tsv.keep"; rm -f "$BURN_FILE"
-printf '1000000 1015900 active 300 5000 50000 1015900 41200 600\n' > "$EST"
+printf '1000000 1015900 active 300 5 50000 1015900 41200 600\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: missing source TSV rejected' adopted; else ok 'est adopt: missing source TSV rejected'; fi
 ln -s "$CASE/tsv.keep" "$BURN_FILE"
 if burn_est_adopt; then bad 'est adopt: symlinked source TSV rejected' adopted; else ok 'est adopt: symlinked source TSV rejected'; fi
 rm -f "$BURN_FILE"; cp "$CASE/tsv.keep" "$BURN_FILE"
-printf '1000000 1015900 active a[$(touch %s/pwn)] 5000 50000 1015900 41200 600\n' "$CASE" > "$EST"
+printf '1000000 1015900 active a[$(touch %s/pwn)] 5 50000 1015900 41200 600\n' "$CASE" > "$EST"
 if burn_est_adopt; then bad 'est adopt: arithmetic injection rejected' adopted; else ok 'est adopt: arithmetic injection rejected'; fi
 true_case 'est adopt: injection produced no side effect' test ! -e "$CASE/pwn"
-{ printf '1000000 1015900 active 300 5000 50000 1015900 41200 '; head -c 400 /dev/zero | tr '\0' '9'; printf '\n'; } > "$EST"
+{ printf '1000000 1015900 active 300 5 50000 1015900 41200 '; head -c 400 /dev/zero | tr '\0' '9'; printf '\n'; } > "$EST"
 if burn_est_adopt; then bad 'est adopt: oversized line rejected' adopted; else ok 'est adopt: oversized line rejected'; fi
 rm -f "$EST"; ln -s "$CASE/esttarget" "$EST"
 if burn_est_adopt; then bad 'est adopt: symlink est rejected' adopted; else ok 'est adopt: symlink est rejected'; fi
 true_case 'est adopt: symlink est not followed' test ! -e "$CASE/esttarget"
 true_case 'est adopt: symlink est not deleted' test -L "$EST"
 rm -f "$EST"
-printf '1000000 1015900 active 300 5000 50000 1015900 41200 900\n' > "$EST"
+printf '1000000 1015900 active 300 5 50000 1015900 41200 900\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: foreign lookback window rejected' adopted; else ok 'est adopt: foreign lookback window rejected'; fi
-printf '1000000 1015900 active 300 5000 50000 1015900 41200\n' > "$EST"
+printf '1000000 1015900 active 300 5 50000 1015900 41200\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: missing lookback window rejected' adopted; else ok 'est adopt: missing lookback window rejected'; fi
-printf '999998 1015900 active 300 5000 50000 1015900 41200 600\n' > "$EST"
+printf '999998 1015900 active 300 5 50000 1015900 41200 600\n' > "$EST"
 true_case 'est adopt: two-second-old estimate still adopts' burn_est_adopt
 eq 'est adopt: aged estimate ttr still local' "$_B5_TTR" 15900
 _CUR_BURN_VALID=0
@@ -888,7 +895,7 @@ CASE="$TMPD/est-ro"; mkdir -p "$CASE/state"
 write_config "$CASE/conf" "$CASE/state" burn 0
 _now=$(date +%s)
 make_payload "$CASE/input" 41.2 "$((_now + 9000))" '' ''
-printf '%s %s active 300 5000 50000 %s 41200 600\n' "$_now" "$((_now + 9000))" "$((_now + 9000))" > "$CASE/state/burn.tsv.est"
+printf '%s %s active 300 5 50000 %s 41200 600\n' "$_now" "$((_now + 9000))" "$((_now + 9000))" > "$CASE/state/burn.tsv.est"
 cp "$CASE/state/burn.tsv.est" "$CASE/est.before"
 run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 1
 printf '\033[0m B … \033[0m\n' > "$CASE/oracle"

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -543,9 +543,9 @@ run_concurrency() {  # $1=runtime $2=workers $3=tag
   # and no orphaned publish temporaries once every render has exited.
   _CC_EST=0
   if [ -f "$root/state/burn.tsv.est" ] && [ ! -L "$root/state/burn.tsv.est" ]; then
-    _E1=""; _E2=""; _E3=""; _E4=""; _E5=""; _E6=""
-    read -r _E1 _E2 _E3 _E4 _E5 _E6 < "$root/state/burn.tsv.est" 2>/dev/null || :
-    case "$_E1$_E2$_E4$_E5$_E6" in (''|*[!0-9]*) ;; (*)
+    _E1=""; _E2=""; _E3=""; _E4=""; _E5=""; _E6=""; _E7=""; _E8=""
+    read -r _E1 _E2 _E3 _E4 _E5 _E6 _E7 _E8 < "$root/state/burn.tsv.est" 2>/dev/null || :
+    case "$_E1$_E2$_E4$_E5$_E6$_E7$_E8" in (''|*[!0-9]*) ;; (*)
       case "$_E3" in (active|idle|warming) _CC_EST=1 ;; esac ;; esac
   fi
   _CC_TMPS=$(ls "$root/state" 2>/dev/null | grep -c '\.tmp$')
@@ -693,7 +693,7 @@ EST="$CASE/burn.tsv.est"
 # Publish: winner shape, maintenance/no-raw refusal.
 _CUR_BURN_VALID=1; _B5_RAW='warming 0 0 41200 9000'; _B5_TTR=9000
 burn_est_publish
-eq 'est publish: winner writes the six-field line' "$(cat "$EST" 2>/dev/null)" '1000000 1009000 warming 0 0 41200'
+eq 'est publish: winner writes the claim-stamped line' "$(cat "$EST" 2>/dev/null)" '1000000 1009000 warming 0 0 41200 1015900 41200'
 rm -f "$EST"
 _CUR_BURN_VALID=0
 burn_est_publish
@@ -730,46 +730,55 @@ rm -f "$EST" "$CASE/burn.tsv.1000000.1009000.90000.tick"
 
 # Adopt: fresh valid estimate is used without the awk (values differ from
 # anything the empty TSV could produce, so adoption is observable).
-printf '1000000 1015900 active 300 5000 50000\n' > "$EST"
-_CUR_BURN_VALID=1
+# _BURN_LOST_PCT simulates the covering claim this session lost to.
+printf '1000000 1015900 active 300 5000 50000 1015900 41200\n' > "$EST"
+_CUR_BURN_VALID=1; _BURN_LOST_PCT=41200
 true_case 'est adopt: fresh valid estimate adopted' burn_est_adopt
 eq 'est adopt: state comes from the estimate' "$_B5_STATE" active
 eq 'est adopt: ttr derives from window and local NOW' "$_B5_TTR" 15900
-printf '999996 1015900 active 300 5000 50000\n' > "$EST"
+printf '999996 1015900 active 300 5000 50000 1015900 41200\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: stale estimate rejected' adopted; else ok 'est adopt: stale estimate rejected'; fi
-printf '1000002 1015900 active 300 5000 50000\n' > "$EST"
+printf '1000002 1015900 active 300 5000 50000 1015900 41200\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: future-dated estimate rejected' adopted; else ok 'est adopt: future-dated estimate rejected'; fi
-printf '1000000 1015900 active 90000 5000 50000\n' > "$EST"
+printf '1000000 1015900 active 90000 5000 50000 1015900 41200\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: span beyond window cap rejected' adopted; else ok 'est adopt: span beyond window cap rejected'; fi
-printf '1000000 1015900 active 300 200000 50000\n' > "$EST"
+printf '1000000 1015900 active 300 200000 50000 1015900 41200\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: delta beyond pct cap rejected' adopted; else ok 'est adopt: delta beyond pct cap rejected'; fi
-printf '1000000 1015900 active 300 5000 100001\n' > "$EST"
+printf '1000000 1015900 active 300 5000 100001 1015900 41200\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: latest beyond pct cap rejected' adopted; else ok 'est adopt: latest beyond pct cap rejected'; fi
-printf '1000000 1015900 hacked 300 5000 50000\n' > "$EST"
+printf '1000000 1015900 hacked 300 5000 50000 1015900 41200\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: unknown state token rejected' adopted; else ok 'est adopt: unknown state token rejected'; fi
-printf '1000000 1015900 active 008 5000 50000\n' > "$EST"
+printf '1000000 1015900 active 008 5000 50000 1015900 41200\n' > "$EST"
 if burn_est_adopt 2> "$CASE/octal.err"; then bad 'est adopt: leading-zero span rejected' adopted; else ok 'est adopt: leading-zero span rejected'; fi
 eq 'est adopt: leading-zero rejection leaks no stderr' "$(wc -c < "$CASE/octal.err" | tr -d ' ')" 0
-printf '1000000 1009000 active 300 5000 50000\n' > "$EST"
+printf '1000000 1009000 active 300 5000 50000 1009000 41200\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: older-window estimate rejected' adopted; else ok 'est adopt: older-window estimate rejected'; fi
-printf '1000000 1020000 active 300 5000 50000\n' > "$EST"
+printf '1000000 1020000 active 300 5000 50000 1020000 41200\n' > "$EST"
 true_case 'est adopt: newer-window estimate accepted' burn_est_adopt
 eq 'est adopt: newer-window ttr from published maxrst' "$_B5_TTR" 20000
-printf '1000000 1021601 active 300 5000 50000\n' > "$EST"
+printf '1000000 1021601 active 300 5000 50000 1021601 41200\n' > "$EST"
 if burn_est_adopt; then bad 'est adopt: reset beyond 5h horizon rejected' adopted; else ok 'est adopt: reset beyond 5h horizon rejected'; fi
-printf '1000000 1021600 active 300 5000 50000\n' > "$EST"
+printf '1000000 1021600 active 300 5000 50000 1021600 41200\n' > "$EST"
 true_case 'est adopt: reset at the 5h horizon accepted' burn_est_adopt
-printf '1000000 1015900 active a[$(touch %s/pwn)] 5000 50000\n' "$CASE" > "$EST"
+printf '1000000 1015900 active 300 5000 50000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: legacy six-field line rejected' adopted; else ok 'est adopt: legacy six-field line rejected'; fi
+printf '1000000 1015900 active 300 5000 50000 1015900 30000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: claim below the covering pct rejected' adopted; else ok 'est adopt: claim below the covering pct rejected'; fi
+printf '1000000 1015900 active 300 5000 50000 1015900 50000\n' > "$EST"
+true_case 'est adopt: claim above the covering pct accepted' burn_est_adopt
+printf '1000000 1020000 active 300 5000 50000 1020000 5000\n' > "$EST"
+true_case 'est adopt: newer-window claim supersedes any pct' burn_est_adopt
+printf '1000000 1015900 active a[$(touch %s/pwn)] 5000 50000 1015900 41200\n' "$CASE" > "$EST"
 if burn_est_adopt; then bad 'est adopt: arithmetic injection rejected' adopted; else ok 'est adopt: arithmetic injection rejected'; fi
 true_case 'est adopt: injection produced no side effect' test ! -e "$CASE/pwn"
-{ printf '1000000 1015900 active 300 5000 50000 '; head -c 400 /dev/zero | tr '\0' '9'; printf '\n'; } > "$EST"
+{ printf '1000000 1015900 active 300 5000 50000 1015900 '; head -c 400 /dev/zero | tr '\0' '9'; printf '\n'; } > "$EST"
 if burn_est_adopt; then bad 'est adopt: oversized line rejected' adopted; else ok 'est adopt: oversized line rejected'; fi
 rm -f "$EST"; ln -s "$CASE/esttarget" "$EST"
 if burn_est_adopt; then bad 'est adopt: symlink est rejected' adopted; else ok 'est adopt: symlink est rejected'; fi
 true_case 'est adopt: symlink est not followed' test ! -e "$CASE/esttarget"
 true_case 'est adopt: symlink est not deleted' test -L "$EST"
 rm -f "$EST"
-printf '999998 1015900 active 300 5000 50000\n' > "$EST"
+printf '999998 1015900 active 300 5000 50000 1015900 41200\n' > "$EST"
 true_case 'est adopt: two-second-old estimate still adopts' burn_est_adopt
 eq 'est adopt: aged estimate ttr still local' "$_B5_TTR" 15900
 _CUR_BURN_VALID=0
@@ -783,7 +792,7 @@ CASE="$TMPD/est-ro"; mkdir -p "$CASE/state"
 write_config "$CASE/conf" "$CASE/state" burn 0
 _now=$(date +%s)
 make_payload "$CASE/input" 41.2 "$((_now + 9000))" '' ''
-printf '%s %s active 300 5000 50000\n' "$_now" "$((_now + 9000))" > "$CASE/state/burn.tsv.est"
+printf '%s %s active 300 5000 50000 %s 41200\n' "$_now" "$((_now + 9000))" "$((_now + 9000))" > "$CASE/state/burn.tsv.est"
 cp "$CASE/state/burn.tsv.est" "$CASE/est.before"
 run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 1
 printf '\033[0m B … \033[0m\n' > "$CASE/oracle"

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -718,6 +718,15 @@ rm -f "$CASE/burn.tsv.1000000.1015900.60000.tick"
 burn_est_publish
 true_case 'est publish: lower claim does not suppress' test -f "$EST"
 rm -f "$EST" "$CASE/burn.tsv.1000000.1015900.30000.tick"
+: > "$CASE/burn.tsv.1000000.1016100.20000.tick"
+burn_est_publish
+true_case 'est publish: newer-window claim suppresses ours' test ! -e "$EST"
+true_case 'est publish: cross-window suppression leaves no tmp' test ! -e "$CASE/burn.tsv.$$.tmp"
+rm -f "$CASE/burn.tsv.1000000.1016100.20000.tick"
+: > "$CASE/burn.tsv.1000000.1009000.90000.tick"
+burn_est_publish
+true_case 'est publish: older-window claim does not suppress' test -f "$EST"
+rm -f "$EST" "$CASE/burn.tsv.1000000.1009000.90000.tick"
 
 # Adopt: fresh valid estimate is used without the awk (values differ from
 # anything the empty TSV could produce, so adoption is observable).
@@ -746,6 +755,10 @@ if burn_est_adopt; then bad 'est adopt: older-window estimate rejected' adopted;
 printf '1000000 1020000 active 300 5000 50000\n' > "$EST"
 true_case 'est adopt: newer-window estimate accepted' burn_est_adopt
 eq 'est adopt: newer-window ttr from published maxrst' "$_B5_TTR" 20000
+printf '1000000 1021601 active 300 5000 50000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: reset beyond 5h horizon rejected' adopted; else ok 'est adopt: reset beyond 5h horizon rejected'; fi
+printf '1000000 1021600 active 300 5000 50000\n' > "$EST"
+true_case 'est adopt: reset at the 5h horizon accepted' burn_est_adopt
 printf '1000000 1015900 active a[$(touch %s/pwn)] 5000 50000\n' "$CASE" > "$EST"
 if burn_est_adopt; then bad 'est adopt: arithmetic injection rejected' adopted; else ok 'est adopt: arithmetic injection rejected'; fi
 true_case 'est adopt: injection produced no side effect' test ! -e "$CASE/pwn"

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -768,14 +768,21 @@ printf '1000000 1015900 active 300 5000 50000 1015900 50000\n' > "$EST"
 true_case 'est adopt: claim above the covering pct accepted' burn_est_adopt
 printf '1000000 1020000 active 300 5000 50000 1020000 5000\n' > "$EST"
 true_case 'est adopt: newer-window claim supersedes any pct' burn_est_adopt
-# Same-window adoption substitutes this session's own reading for the
-# published latest (percentages legitimately drop within a window, and the
-# full parse would inject our observation as the newest sample).
-printf '1000000 1015900 active 300 5000 50000 1015900 50000\n' > "$EST"
-true_case 'est adopt: latest override adoption succeeds' burn_est_adopt
+# Prior-tick same-window adoption substitutes this session's own reading for
+# the published latest (our observation is the newest distinct sample, and
+# percentages legitimately drop within a window). A same-tick estimate keeps
+# the published value: the winner's row shares our sample key, where the
+# reader keeps the maximum, so it already covers our injection.
+printf '999999 1015900 active 300 5000 50000 1015900 50000\n' > "$EST"
+true_case 'est adopt: prior-tick latest override adoption succeeds' burn_est_adopt
 _ADOPT_ETA=$_B5_ETA
 burn_b5_line 'active 300 5000 41200 15900' || bad 'est adopt: reference line parses' failed
-eq 'est adopt: same-window latest is our own reading' "$_ADOPT_ETA" "$_B5_ETA"
+eq 'est adopt: prior-tick latest is our own reading' "$_ADOPT_ETA" "$_B5_ETA"
+printf '1000000 1015900 active 300 5000 50000 1015900 50000\n' > "$EST"
+true_case 'est adopt: same-tick adoption succeeds' burn_est_adopt
+_ADOPT_ETA=$_B5_ETA
+burn_b5_line 'active 300 5000 50000 15900' || bad 'est adopt: same-tick reference parses' failed
+eq 'est adopt: same-tick keeps the published latest' "$_ADOPT_ETA" "$_B5_ETA"
 
 # A TSV strictly newer than the estimate means rows landed after the publish
 # (an older-tick straggler inside the sweep grace window): the snapshot is


### PR DESCRIPTION
## Problem

With the write side collapsed by #76's election, the dominant multi-session state cost is the read side: every session's render runs the full burn_eta_5h awk over the capped TSV every second. At n=16 saturated on the paired harness, the state layer costs ~70 ms of a ~131 ms state-enabled render against a ~60 ms state-disabled baseline.

## Change

The election winner already pays for the full parse, so it now publishes its validated result to `"$_SB_BASE".est` and every same-second loser adopts it instead of re-parsing, via bash builtins with zero forks. The published file is display-only derived data; the TSV stays the source of truth, and any anomaly on the read side falls back to the full parse.

Format is the RAW awk contract, `<now> <maxrst> <state> <span> <delta> <latest>`, not final values: `_B5_ETA`/`_B5_TTR` feed bash arithmetic downstream, so both producers route through one shared parser (`burn_b5_line`, factored out of `burn_eta_5h` unchanged) and adopting pre-computed strings would be an arithmetic-injection vector. No ttr is published; adopters derive `ttr = max(0, maxrst - NOW)` locally so a 1-3 s-old estimate cannot trip the 5h rebind gate into warming flicker. The reader re-imposes the magnitude bounds the awk normally guarantees (state whitelist, span <= 86400, delta/latest <= 100000, epochs via `state_epoch`, length checks before every numeric comparison), ingests at most 128 bytes via `read -r -n` (bash 3.2-safe), and requires a fresh (`pub within [NOW-3, NOW]`) regular non-symlink file. Publish is rename-only through the store's tmp discipline, revalidates paths, refuses symlinks/directories/collisions with the six canonical store paths, removes its temporary on every failure path, and reuses `"$_SB_BASE".$$.tmp` strictly after the trim temporary's lifecycle so `burn_tmp_sweep` covers orphans. Adoption requires having lost the election to a covering claim (`_BURN_LOST`, set exactly on the two token-exists loss branches) with a valid reading; maintenance winners never publish; `CORALLINE_NO_SAMPLE` renders neither write nor consume the estimate. The first commit also caps election-token digit-field lengths before integer comparison (a planted oversized field could previously leak an "integer expression expected" line to stderr).

This design went through a pre-implementation security review; all findings (arithmetic-injection representation, magnitude bounds, read length cap, symlink/directory refusal, ttr clock skew, maxrst-vs-writer-window, tmp lifecycle/orphan coverage, store-path distinctness, maintenance-winner exclusion) are folded in as described above.

## Measured effect

Paired A/B (5 alternating rounds, lead rotation, load 7-31, capped 1600-row fixture, n=16): median candidate/main CPU ratio 0.756 (per-round 0.726-0.781), p50 wall 423.5 ms to 324.6 ms (-23.4%); state-disabled arm within noise (median +1.9%, default path byte-identical). The plan targeted >=30%; the shortfall is understood and accepted: the remaining state cost is limit-store publishing (deliberately not elected - any session may hold a newer window that must always reach the store), election/adoption overhead, and ~15% of renders legitimately falling back when they race ahead of the winner's publish (instrumented: 1 win / 16 adopt / 3 fall per 20 concurrent renders). Chained with #76, n=16 render CPU goes 155 ms to ~99 ms (~-35%) versus the pre-election baseline.

## Verification

test/test-burn.sh grows to 311 cases, ALL PASS on macOS /bin/bash 3.2.57 and Homebrew bash 5.3.15. New coverage: publish shape and refusals (maintenance winner, no raw line, directory at est name with no tmp orphan), adoption of fresh and 2 s-old estimates with locally derived ttr, rejection of stale/future/out-of-bounds/unknown-state/oversized/symlink/arithmetic-injection estimates with no side effects, a no-sample real render ignoring a planted fresh estimate byte-for-byte, and the n=5/12/16 concurrency checker now asserting a well-shaped published estimate with zero orphaned temporaries alongside the existing single-writer contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNLnF1e3vJUEsNWfXjCL7E