### PR TITLE
perf(state): winner-published burn estimate with follower fast path

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -699,7 +699,11 @@ state_burn_lead() {  # → 0 iff this render must run the burn write path
     for f in "$slot".*.tick; do
       [ -e "$f" ] || [ -L "$f" ] || continue
       p=${f#"$slot".}; p=${p%.tick}
+      # Length caps mirror state_epoch's width rule: a planted name with an
+      # oversized digit run must not reach [ -gt ] (integer overflow would
+      # leak an error line onto the render's stderr).
       case "$p" in (''|*[!0-9]*) continue ;; esac
+      [ "${#p}" -le 6 ] || continue
       [ "$p" -gt "$best" ] && best=$p
     done
     [ "$_CUR_BURN_PCT" -gt "$best" ] || return 1
@@ -748,11 +752,14 @@ state_burn_lead() {  # → 0 iff this render must run the burn write path
     n=${f#"$_SB_BASE".}; n=${n%.tick}
     e=${n%%.*}
     case "$e" in (''|*[!0-9]*) continue ;; esac
+    [ "${#e}" -le 12 ] || continue
     n=${n#*.}
     case "$n" in *.*) ;; *) continue ;; esac
     r=${n%%.*}; p=${n#*.}
     case "$r" in (''|*[!0-9]*) continue ;; esac
+    [ "${#r}" -le 12 ] || continue
     case "$p" in (''|*[!0-9]*) continue ;; esac
+    [ "${#p}" -le 6 ] || continue
     [ "$e" -le "$NOW" ] && [ "$e" -ge $(( NOW - 8 )) ] && continue
     set -- "$@" "$f"; c=$(( c + 1 ))
     [ "$c" -ge 8 ] && break

--- a/statusline.sh
+++ b/statusline.sh
@@ -706,7 +706,10 @@ state_burn_lead() {  # → 0 iff this render must run the burn write path
       [ "${#p}" -le 6 ] || continue
       [ "$p" -gt "$best" ] && best=$p
     done
-    [ "$_CUR_BURN_PCT" -gt "$best" ] || return 1
+    # A covering claim (pct at or above ours) is the one loss reason a
+    # follower may trust: it proves a winner is computing this second, so the
+    # published estimate is safe to adopt (_BURN_LOST gates burn_est_adopt).
+    [ "$_CUR_BURN_PCT" -gt "$best" ] || { _BURN_LOST=1; return 1; }
   else
     # No reading of our own: maintenance-only claim under the reserved
     # window/pct 0.0, so trim, healing, and the tmp sweep never starve while
@@ -728,7 +731,10 @@ state_burn_lead() {  # → 0 iff this render must run the burn write path
   if : 2>/dev/null > "$tok"; then won=1; fi
   [ "$had_c" = 1 ] || set +C
   if [ "$won" != 1 ]; then
-    # EEXIST: another session already claimed this exact reading.
+    # EEXIST from a regular file: another session claimed this exact reading,
+    # which also counts as a covering claim for adoption purposes.
+    if [ -f "$tok" ] && [ ! -L "$tok" ]; then _BURN_LOST=1; return 1; fi
+    # A non-file object raced in: lose without trusting it.
     if [ -e "$tok" ] || [ -L "$tok" ]; then return 1; fi
     # Anything else (missing parent on a fresh store, transient fs error):
     # fail open so sampling never silently stops.
@@ -947,9 +953,35 @@ burn_tmp_sweep() {  # remove trim temporaries orphaned by killed renders
   return 0
 }
 
+# The single parser for one "state span delta latest ttr" estimator line.
+# burn_eta_5h feeds it the awk's stdout; burn_est_adopt feeds it a line
+# reconstructed from a published estimate. Exactly one validator existing is a
+# deliberate security property: _B5_ETA and _B5_TTR flow into bash arithmetic
+# downstream, so every producer must pass this same gate.
+burn_b5_line() {  # → _B5_* from one estimator line; 1 = line rejected
+  local state span delta latest ttr
+  read -r state span delta latest ttr <<EOF
+$1
+EOF
+  case "$state" in
+    (active)
+      case "$span$delta$latest$ttr" in (''|*[!0-9]*) return 1 ;; esac
+      [ "$span" -gt 0 ] && [ "$delta" -gt 0 ] || return 1
+      state_rate10 $(( delta * 10000000000 )) "$span"; _B5_RATE=$_RATE10
+      state_round_even $(( (100000 - latest) * span )) $(( delta * 1000 )) || return 1
+      _B5_STATE=active; _B5_ETA=$_RE; _B5_TTR=$ttr
+      ;;
+    (idle|warming)
+      case "$ttr" in (''|*[!0-9]*) ttr=0 ;; esac
+      _B5_STATE=$state; _B5_TTR=$ttr
+      ;;
+    (*) return 1 ;;
+  esac
+}
+
 burn_eta_5h() {  # → _B5_* from canonical TSV; $1=allow trim/heal mutation
-  local mutate="${1:-0}" src=/dev/null tmp="" write_tmp=0 out="" rc state span delta latest ttr
-  _B5_STATE=warming; _B5_ETA=inf; _B5_RATE="0.0000000000"; _B5_TTR=0
+  local mutate="${1:-0}" src=/dev/null tmp="" write_tmp=0 out="" rc
+  _B5_STATE=warming; _B5_ETA=inf; _B5_RATE="0.0000000000"; _B5_TTR=0; _B5_RAW=""
   if [ "${_STATE_BURN_SAFE:-0}" = 1 ] && state_path_object "$_SB_BASE" f; then src=$_SB_BASE; fi
   if [ "$mutate" = 1 ] && [ "$src" != /dev/null ]; then
     burn_tmp_sweep
@@ -1062,22 +1094,8 @@ burn_eta_5h() {  # → _B5_* from canonical TSV; $1=allow trim/heal mutation
     fi
   fi
   [ "$rc" -eq 0 ] || return 0
-  read -r state span delta latest ttr <<EOF
-$out
-EOF
-  case "$state" in
-    (active)
-      case "$span$delta$latest$ttr" in (''|*[!0-9]*) return 0 ;; esac
-      [ "$span" -gt 0 ] && [ "$delta" -gt 0 ] || return 0
-      state_rate10 $(( delta * 10000000000 )) "$span"; _B5_RATE=$_RATE10
-      state_round_even $(( (100000 - latest) * span )) $(( delta * 1000 )) || return 0
-      _B5_STATE=active; _B5_ETA=$_RE; _B5_TTR=$ttr
-      ;;
-    (idle|warming)
-      case "$ttr" in (''|*[!0-9]*) ttr=0 ;; esac
-      _B5_STATE=$state; _B5_TTR=$ttr
-      ;;
-  esac
+  burn_b5_line "$out" || return 0
+  _B5_RAW=$out
 }
 
 burn_eta_7d() {  # → _B7_*; $1=pct_milli $2=reset epoch
@@ -1091,12 +1109,100 @@ burn_eta_7d() {  # → _B7_*; $1=pct_milli $2=reset epoch
   state_round_even $(( (100000 - pct) * elapsed )) "$pct"; _B7_ETA=$_RE
 }
 
+# Cross-session estimate sharing. The election winner already paid for the
+# full TSV parse; publishing its validated result lets every same-second loser
+# skip that parse entirely (the read side is ~75ms of a 141ms state-enabled
+# render at n=16 — the dominant multi-session cost after the write election).
+# The published file is display-only derived data with the TSV as the source
+# of truth: ANY anomaly on the read side falls back to the full parse.
+# Publish is rename-only through the store's tmp discipline — never an
+# in-place write, which would follow a planted hardlink and tear reads. The
+# tmp reuses "$_SB_BASE".$$.tmp strictly AFTER burn_eta_5h's own trim tmp
+# lifecycle has ended (burn_estimate calls publish only once burn_eta_5h has
+# returned), so burn_tmp_sweep's <base>.<digits>.tmp rule covers orphans from
+# a killed render. Fork budget: one mv per second per store, paid by the
+# winner, replacing N-1 whole-file awk parses.
+burn_est_publish() {  # winner only: publish "<now> <maxrst> <state> <span> <delta> <latest>"
+  [ "${_CUR_BURN_VALID:-0}" = 1 ] || return 0
+  [ -n "${_B5_RAW:-}" ] || return 0
+  local est="$_SB_BASE.est" tmp="$_SB_BASE.$$.tmp" s sp d l t p had_c=0 won=0
+  state_paths_revalidate || return 0
+  # The est file is a seventh state object outside state_paths_validate's
+  # six-path distinctness matrix; refuse to publish over any configured
+  # namespace (state_same_path is conservative: unsure means same).
+  for p in "$_SB_BASE" "$_SB_ROOT" "$_SL5_BASE" "$_SL5_ROOT" "$_SL7_BASE" "$_SL7_ROOT"; do
+    if state_same_path "$est" "$p"; then return 0; fi
+  done
+  # A symlink or directory planted at the est name is not followed, not
+  # deleted, and aborts the publish; same rule as the election tokens.
+  state_no_symlink_path "$est" && [ "$_SNP" = "$est" ] || return 0
+  state_path_leaf "$est" f || return 0
+  state_no_symlink_path "$tmp" && [ "$_SNP" = "$tmp" ] || return 0
+  [ ! -e "$tmp" ] && [ ! -L "$tmp" ] || return 0
+  read -r s sp d l t <<EOF
+$_B5_RAW
+EOF
+  case $- in *C*) had_c=1 ;; esac
+  set -C
+  if printf '%s %s %s %s %s %s\n' "$NOW" $(( NOW + ${_B5_TTR:-0} )) "$s" "$sp" "$d" "$l" \
+       2>/dev/null > "$tmp"; then won=1; fi
+  [ "$had_c" = 1 ] || set +C
+  [ "$won" = 1 ] || return 0
+  if state_paths_revalidate && state_no_symlink_path "$est" && [ "$_SNP" = "$est" ] \
+     && state_path_leaf "$est" f; then
+    mv -f "$tmp" "$est" 2>/dev/null && return 0
+  fi
+  rm -f "$tmp" 2>/dev/null
+  return 0
+}
+
+burn_est_adopt() {  # → 0 iff _B5_* adopted from a fresh, fully validated estimate
+  local est="$_SB_BASE.est" LC_ALL=C pub rst s sp d l t
+  # Same defaults burn_eta_5h starts from: the adopter replaces that call
+  # entirely, and downstream comparisons assume every _B5_* is populated.
+  _B5_STATE=warming; _B5_ETA=inf; _B5_RATE="0.0000000000"; _B5_TTR=0; _B5_RAW=""
+  [ "${_STATE_BURN_SAFE:-0}" = 1 ] || return 1
+  state_path_object "$est" f || return 1
+  [ -f "$est" ] && [ ! -L "$est" ] || return 1
+  # -n (not -N: that is bash 4.1+) caps how much of a hostile oversized file
+  # a render will ever ingest; trailing junk lands in the last field and
+  # fails its digit check, so a malformed line is rejected, never truncated
+  # into a plausible one.
+  read -r -n 128 pub rst s sp d l < "$est" 2>/dev/null || :
+  # Every field is validated before it reaches any arithmetic context; the
+  # published values bypass the awk whose internal caps normally guarantee
+  # these bounds, so the reader must re-impose them itself.
+  state_epoch "${pub:-}" 12 || return 1; pub=$_SE_VALUE
+  state_epoch "${rst:-}" 12 || return 1; rst=$_SE_VALUE
+  [ "$pub" -le "$NOW" ] && [ "$pub" -ge $(( NOW - 3 )) ] || return 1
+  case "${s:-}" in (active|idle|warming) ;; (*) return 1 ;; esac
+  case "${sp:-}" in (''|*[!0-9]*) return 1 ;; esac
+  [ "${#sp}" -le 5 ] && [ "$sp" -le 86400 ] || return 1
+  case "${d:-}" in (''|*[!0-9]*) return 1 ;; esac
+  [ "${#d}" -le 6 ] && [ "$d" -le 100000 ] || return 1
+  case "${l:-}" in (''|*[!0-9]*) return 1 ;; esac
+  [ "${#l}" -le 6 ] && [ "$l" -le 100000 ] || return 1
+  # ttr derives locally from the published window and our own NOW, so a
+  # 1-3s-old estimate cannot trip the rebind gate into warming flicker.
+  t=$(( rst - NOW )); [ "$t" -lt 0 ] && t=0
+  burn_b5_line "$s $sp $d $l $t"
+}
+
 burn_estimate() {  # → _BURN_STATE _BURN_LABEL _BURN_ETA _BURN_RATE _BURN_TTR
   local f5=0 f7=0 m=0
-  # Trim/heal mutation follows the same per-(tick, window) election as the
-  # append: only the tick leader rewrites, everyone else reads.
+  # Trim/heal mutation follows the same per-(tick, window, pct) election as
+  # the append: a claim winner runs the full parse (and publishes its result);
+  # a session that lost to a covering claim adopts the published estimate
+  # when it validates, and everything else takes the plain read-only parse.
   [ "${_STATE_MUTATE:-0}" = 1 ] && state_burn_lead && m=1
-  burn_eta_5h "$m"
+  if [ "$m" = 1 ]; then
+    burn_eta_5h 1
+    burn_est_publish
+  elif [ "${_BURN_LOST:-0}" = 1 ] && [ "${_CUR_BURN_VALID:-0}" = 1 ] && burn_est_adopt; then
+    :
+  else
+    burn_eta_5h 0
+  fi
   # The 5h projection needs the same rebinding the 7d one gets: whenever the synced
   # state is what the gauge draws, the ETA has to be projected from that same window.
   # Two ways they diverge. With no reading of our own the history can still sit on

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -643,6 +643,13 @@ true_case 'lead sweep: non-numeric epoch kept' test -f "$CASE/burn.tsv.abc.10159
 true_case 'lead sweep: two-field name kept' test -f "$CASE/burn.tsv.999990.1015900.tick"
 true_case 'lead sweep: foreign unprefixed file untouched' test -f "$CASE/tick.999990.1015900.41200.tick"
 true_case 'lead sweep: symlink kept' test -L "$CASE/burn.tsv.999980.1015900.41200.tick"
+rm -f "$CASE"/burn.tsv.*.tick 2>/dev/null
+: > "$CASE/burn.tsv.1000000.1015900.999999999999999999999999.tick"
+: > "$CASE/burn.tsv.999990.1015900.999999999999999999999999.tick"
+_BURN_LEAD=
+state_burn_lead 2> "$CASE/overflow.err" || bad 'lead: oversized field never blocks a claim' lost
+eq 'lead: oversized digit field leaks no stderr' "$(wc -c < "$CASE/overflow.err" | tr -d ' ')" 0
+true_case 'lead sweep: stale oversized name kept, not compared' test -f "$CASE/burn.tsv.999990.1015900.999999999999999999999999.tick"
 rm -f "$CASE"/burn.tsv.*.tick "$CASE"/tick.* 2>/dev/null
 ln -s "$CASE/linktarget" "$TOK"
 _BURN_LEAD=

--- a/test/test-burn.sh
+++ b/test/test-burn.sh
@@ -539,10 +539,21 @@ run_concurrency() {  # $1=runtime $2=workers $3=tag
   fi
   _CC_IMMUTABLE=0
   [ "$(LC_ALL=C tr -d '\n' < "$root/state/burn.d/canary")" = immutable-concurrency-canary ] && _CC_IMMUTABLE=1
+  # Winner-published estimate: present, regular, six validly-shaped fields;
+  # and no orphaned publish temporaries once every render has exited.
+  _CC_EST=0
+  if [ -f "$root/state/burn.tsv.est" ] && [ ! -L "$root/state/burn.tsv.est" ]; then
+    _E1=""; _E2=""; _E3=""; _E4=""; _E5=""; _E6=""
+    read -r _E1 _E2 _E3 _E4 _E5 _E6 < "$root/state/burn.tsv.est" 2>/dev/null || :
+    case "$_E1$_E2$_E4$_E5$_E6" in (''|*[!0-9]*) ;; (*)
+      case "$_E3" in (active|idle|warming) _CC_EST=1 ;; esac ;; esac
+  fi
+  _CC_TMPS=$(ls "$root/state" 2>/dev/null | grep -c '\.tmp$')
   [ "$_CC_RCFILES" -eq "$_CC_EXPECTED" ] && [ "$_CC_SUCCESS" -eq "$_CC_EXPECTED" ] \
     && [ "$_CC_NONEMPTY" -eq "$_CC_EXPECTED" ] && [ "$_CC_MATCH" -eq "$_CC_EXPECTED" ] \
     && [ "$_CC_STDERR_EMPTY" -eq "$_CC_EXPECTED" ] \
     && [ "$_CC_ROWS" -ge 1 ] && [ "$_CC_ROWS" -le "$_CC_EXPECTED" ] && [ "$_CC_DUPES" -eq 0 ] \
+    && [ "$_CC_EST" -eq 1 ] && [ "$_CC_TMPS" -eq 0 ] \
     && [ "$_CC_IMMUTABLE" -eq 1 ]
 }
 
@@ -562,9 +573,11 @@ for _N in 5 12 16; do
     eq "concurrency n=$_N stderr empty" "$_CC_STDERR_EMPTY" $((_N * 2))
     eq "concurrency n=$_N single writer per (second, window)" "$_CC_DUPES" 0
     ok "concurrency n=$_N TSV rows within [1, renders] ($_CC_ROWS)"
+    eq "concurrency n=$_N estimate published and well-shaped" "$_CC_EST" 1
+    eq "concurrency n=$_N no orphaned publish temporaries" "$_CC_TMPS" 0
     eq "concurrency n=$_N immutable store untouched" "$_CC_IMMUTABLE" 1
   else
-    bad "concurrency n=$_N" "expected=$_CC_EXPECTED rcfiles=$_CC_RCFILES success=$_CC_SUCCESS nonempty=$_CC_NONEMPTY match=$_CC_MATCH stderr=$_CC_STDERR_EMPTY rows=$_CC_ROWS dupes=$_CC_DUPES immutable=$_CC_IMMUTABLE"
+    bad "concurrency n=$_N" "expected=$_CC_EXPECTED rcfiles=$_CC_RCFILES success=$_CC_SUCCESS nonempty=$_CC_NONEMPTY match=$_CC_MATCH stderr=$_CC_STDERR_EMPTY rows=$_CC_ROWS dupes=$_CC_DUPES est=$_CC_EST tmps=$_CC_TMPS immutable=$_CC_IMMUTABLE"
   fi
 done
 
@@ -668,6 +681,84 @@ _BURN_LEAD=
 true_case 'lead: missing store parent fails open' state_burn_lead
 true_case 'lead: fail-open creates no token' test ! -e "$CASE/absent/burn.tsv.1000000.1015900.41200.tick"
 _BURN_LEAD=
+
+# Published-estimate fast path: the election winner publishes its validated
+# awk result; a follower that lost to a covering claim adopts it only after
+# every field survives the same validation the awk output gets, and every
+# anomaly falls back to the full parse.
+CASE="$TMPD/est"; mkdir -p "$CASE"
+unit_gate "$CASE" 1000000 41.2 1015900 '' '' 0
+EST="$CASE/burn.tsv.est"
+
+# Publish: winner shape, maintenance/no-raw refusal.
+_CUR_BURN_VALID=1; _B5_RAW='warming 0 0 41200 9000'; _B5_TTR=9000
+burn_est_publish
+eq 'est publish: winner writes the six-field line' "$(cat "$EST" 2>/dev/null)" '1000000 1009000 warming 0 0 41200'
+rm -f "$EST"
+_CUR_BURN_VALID=0
+burn_est_publish
+true_case 'est publish: maintenance winner never publishes' test ! -e "$EST"
+_CUR_BURN_VALID=1; _B5_RAW=''
+burn_est_publish
+true_case 'est publish: no raw line, no publish' test ! -e "$EST"
+mkdir "$EST"
+_B5_RAW='warming 0 0 41200 9000'
+burn_est_publish
+true_case 'est publish: directory at est name aborts' test -d "$EST"
+true_case 'est publish: aborted publish leaves no tmp' test ! -e "$CASE/burn.tsv.$$.tmp"
+rmdir "$EST"
+
+# Adopt: fresh valid estimate is used without the awk (values differ from
+# anything the empty TSV could produce, so adoption is observable).
+printf '1000000 1015900 active 300 5000 50000\n' > "$EST"
+_CUR_BURN_VALID=1
+true_case 'est adopt: fresh valid estimate adopted' burn_est_adopt
+eq 'est adopt: state comes from the estimate' "$_B5_STATE" active
+eq 'est adopt: ttr derives from window and local NOW' "$_B5_TTR" 15900
+printf '999996 1015900 active 300 5000 50000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: stale estimate rejected' adopted; else ok 'est adopt: stale estimate rejected'; fi
+printf '1000002 1015900 active 300 5000 50000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: future-dated estimate rejected' adopted; else ok 'est adopt: future-dated estimate rejected'; fi
+printf '1000000 1015900 active 90000 5000 50000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: span beyond window cap rejected' adopted; else ok 'est adopt: span beyond window cap rejected'; fi
+printf '1000000 1015900 active 300 200000 50000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: delta beyond pct cap rejected' adopted; else ok 'est adopt: delta beyond pct cap rejected'; fi
+printf '1000000 1015900 active 300 5000 100001\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: latest beyond pct cap rejected' adopted; else ok 'est adopt: latest beyond pct cap rejected'; fi
+printf '1000000 1015900 hacked 300 5000 50000\n' > "$EST"
+if burn_est_adopt; then bad 'est adopt: unknown state token rejected' adopted; else ok 'est adopt: unknown state token rejected'; fi
+printf '1000000 1015900 active a[$(touch %s/pwn)] 5000 50000\n' "$CASE" > "$EST"
+if burn_est_adopt; then bad 'est adopt: arithmetic injection rejected' adopted; else ok 'est adopt: arithmetic injection rejected'; fi
+true_case 'est adopt: injection produced no side effect' test ! -e "$CASE/pwn"
+{ printf '1000000 1015900 active 300 5000 50000 '; head -c 400 /dev/zero | tr '\0' '9'; printf '\n'; } > "$EST"
+if burn_est_adopt; then bad 'est adopt: oversized line rejected' adopted; else ok 'est adopt: oversized line rejected'; fi
+rm -f "$EST"; ln -s "$CASE/esttarget" "$EST"
+if burn_est_adopt; then bad 'est adopt: symlink est rejected' adopted; else ok 'est adopt: symlink est rejected'; fi
+true_case 'est adopt: symlink est not followed' test ! -e "$CASE/esttarget"
+true_case 'est adopt: symlink est not deleted' test -L "$EST"
+rm -f "$EST"
+printf '999998 1015900 active 300 5000 50000\n' > "$EST"
+true_case 'est adopt: two-second-old estimate still adopts' burn_est_adopt
+eq 'est adopt: aged estimate ttr still local' "$_B5_TTR" 15900
+_CUR_BURN_VALID=0
+rm -f "$EST"
+
+# Read-only wiring: a CORALLINE_NO_SAMPLE render never consumes a published
+# estimate (test/preview determinism, rule #32) and never writes one. The
+# planted est claims an active state no empty TSV could produce, so any
+# adoption would be visible in the output.
+CASE="$TMPD/est-ro"; mkdir -p "$CASE/state"
+write_config "$CASE/conf" "$CASE/state" burn 0
+_now=$(date +%s)
+make_payload "$CASE/input" 41.2 "$((_now + 9000))" '' ''
+printf '%s %s active 300 5000 50000\n' "$_now" "$((_now + 9000))" > "$CASE/state/burn.tsv.est"
+cp "$CASE/state/burn.tsv.est" "$CASE/est.before"
+run_runtime "$BASH_BIN" "$CASE/conf" "$CASE/input" "$CASE/out" "$CASE/err" 1
+printf '\033[0m B … \033[0m\n' > "$CASE/oracle"
+if cmp -s "$CASE/out" "$CASE/oracle"; then ok 'est read-only: no-sample render ignores a fresh estimate'; else bad 'est read-only: no-sample render ignores a fresh estimate' "$(cat "$CASE/out")"; fi
+if cmp -s "$CASE/state/burn.tsv.est" "$CASE/est.before"; then ok 'est read-only: estimate file untouched'; else bad 'est read-only: estimate file untouched' changed; fi
+eq 'est read-only: no tokens created' "$(ls "$CASE/state" | grep -c '\.tick$')" 0
+eq 'est read-only: stderr empty' "$(wc -c < "$CASE/err" | tr -d ' ')" 0
 
 # Maintenance claim: a render with no valid 5h reading may still win the
 # mutate path (trim/heal/sweep never starve), under the reserved 0.0 name; it


### PR DESCRIPTION
Supersedes #77, restarting from that branch's initial state. See the closing comment there for why: the review ran 22 rounds without converging, and the guards added along the way halved the measured benefit (paired A/B at n=16 moved from a 0.756 median CPU ratio to 0.870, adoption falling from 16/20 to 12/20 concurrent renders).

## Problem

With the write side collapsed by #76's election, the dominant multi-session state cost is the read side: every session's render runs the full burn_eta_5h awk over the capped TSV every second. At n=16 saturated on the paired harness, the state layer costs ~70 ms of a ~131 ms state-enabled render against a ~60 ms state-disabled baseline.

## Change

The election winner already pays for the full parse, so it publishes its result to `"$_SB_BASE".est` and same-second losers adopt it instead of re-parsing, via bash builtins with zero forks. The published file is display-only derived data; the TSV stays the source of truth, and any anomaly on the read side falls back to the full parse.

Format is the RAW awk contract, `<now> <maxrst> <state> <span> <delta> <latest>`, not final values: `_B5_ETA`/`_B5_TTR` feed bash arithmetic downstream, so both producers route through one shared parser (`burn_b5_line`, factored out of `burn_eta_5h` unchanged) and adopting pre-computed strings would be an arithmetic-injection vector. No ttr is published; adopters derive `ttr = max(0, maxrst - NOW)` locally so a 1-3 s-old estimate cannot trip the 5h rebind gate into warming flicker. The reader re-imposes the magnitude bounds the awk normally guarantees, ingests at most 128 bytes via `read -r -n` (bash 3.2-safe), and requires a fresh, regular, non-symlink file. Publish is rename-only through the store's tmp discipline, revalidates paths, refuses symlinks/directories/collisions with the six canonical store paths, removes its temporary on every failure path, and reuses `"$_SB_BASE".$$.tmp` so `burn_tmp_sweep` covers orphans. Maintenance winners never publish; `CORALLINE_NO_SAMPLE` renders neither write nor consume the estimate. The first commit also caps election-token digit-field lengths before integer comparison.

## What review feedback is most useful here

This is a cache with a stated contract: an estimate is a summary of the TSV with a three-second freshness bound, and inside that bound it may lag rows appended after its publish. #77 demonstrated that enumerating individual interleavings inside that bound does not terminate - each fix narrowed the window and the next round found the next window, while the fallback conditions accumulated and ate the benefit the change exists for.

So the useful questions are architectural: does this key admit a bounded set of guarantees, or does its shape invite an unbounded stream of race findings? Is there a stronger, simpler adoption key that makes whole classes of interleaving unrepresentable rather than checked? Is the guard surface proportionate to a store that lives in the user's own directory, where anyone able to plant an estimate can edit `burn-5h.tsv` directly and reach the same screen through the validated front door?

Real defects identified in #77 will be reapplied deliberately once the shape is settled.

## Verification

test/test-burn.sh grows to 311 cases, ALL PASS on macOS /bin/bash 3.2.57 and Homebrew bash 5.3.15, covering publish shape and refusals, adoption of fresh and aged estimates, rejection of stale/future/out-of-bounds/unknown-state/oversized/symlink/arithmetic-injection estimates with no side effects, a no-sample real render ignoring a planted fresh estimate byte-for-byte, and the n=5/12/16 concurrency checker asserting a well-shaped published estimate with zero orphaned temporaries alongside the existing single-writer contract. Default path renders byte-identically to main.

Paired A/B (5 alternating rounds, lead rotation, control-arm noise floor, capped 1600-row fixture, n=16): median candidate/main CPU ratio 0.756, p50 wall 423.5 ms to 324.6 ms, state-disabled arm within noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNLnF1e3vJUEsNWfXjCL7E