### PR TITLE
docs: refresh pinned --ref examples from v0.14.0 to v0.15.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -95,7 +95,7 @@ curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.s
 
 This path is non-interactive, so it installs from `main` and skips the version prompt. To
 install a tagged release instead, ask the user which they want and pass `--ref`, e.g.
-`--ref v0.14.0` (latest release) or leave it as `main` (latest development).
+`--ref v0.15.0` (latest release) or leave it as `main` (latest development).
 
 If the user is testing a fork, keep the downloaded installer and runtime files on the same
 repo:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Run the interactive installer:
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
 ```
 
-It recommends the latest tagged release or lets you choose mutable `main`. Skip the prompt with `--ref v0.14.0` or another ref. If the one-line path cannot run, use the [manual fallback in `INSTALL.md`](./INSTALL.md#manual-fallback).
+It recommends the latest tagged release or lets you choose mutable `main`. Skip the prompt with `--ref v0.15.0` or another ref. If the one-line path cannot run, use the [manual fallback in `INSTALL.md`](./INSTALL.md#manual-fallback).
 
 ### Windows without Git Bash
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -60,7 +60,7 @@ Claude 會依環境選擇路徑、在更改偏好前詢問，並使用對應 ins
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
 ```
 
-它會建議最新 release tag，也能選擇可變的 `main`。使用 `--ref v0.14.0` 或其他 ref 可略過詢問。若一行安裝無法執行，使用 [`INSTALL.md` 的 manual fallback](./INSTALL.md#manual-fallback)。
+它會建議最新 release tag，也能選擇可變的 `main`。使用 `--ref v0.15.0` 或其他 ref 可略過詢問。若一行安裝無法執行，使用 [`INSTALL.md` 的 manual fallback](./INSTALL.md#manual-fallback)。
 
 ### Windows 無 Git Bash
 


### PR DESCRIPTION
Release prep for v0.15.0. The three pinned `--ref` examples in README.md, README.zh-TW.md and INSTALL.md still point at v0.14.0.

Ordering note: `v0.15.0` does not exist as a tag yet, so this should merge immediately after the tag is pushed, not before. Merging it earlier would leave the documented ref unresolvable for anyone installing in between.

Previous releases refreshed these one release behind (#71 shipped in v0.14.0 pointing at v0.13.0, #75 points at v0.14.0 and would ship in v0.15.0). Merging this one alongside the tag instead makes v0.15.0's documentation reference v0.15.0 itself, which is what a reader following the install instructions expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNLnF1e3vJUEsNWfXjCL7E