### PR TITLE
feat(cache): add an opt-in prompt-cache segment

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -213,9 +213,12 @@ Ask concise questions. If the user says "you decide", choose the defaults.
    else `node` on `PATH`) and `python` the active env (`$VIRTUAL_ENV` / conda /
    `.python-version`, else `python3`); each stays hidden until something is detected.
    Write the chosen segments to `VL_SEGMENTS` in this canonical order (keep only the
-   ones the user wants): `dir project git node python model effort ctx limit5h limit7d
-   burn lines cost style duration stash clock`. So opting in `effort` lands it right
-   after `model`.
+   ones the user wants): `dir project git node python model effort ctx cache limit5h
+   limit7d burn lines cost style duration stash clock`. So opting in `effort` lands it
+   right after `model`.
+   `cache` (prompt-cache hit ratio plus the countdown to the cache expiring) reads
+   `prompt_cache` from the payload, which Claude Code only sends on v2.1.263 and newer;
+   on an older build it stays hidden with no other effect.
    `burn` (projected time until a rate limit binds) writes a small sample file to
    `~/.claude/coralline/burn-5h.tsv` while it is in the list, and nothing when it is not.
 4. **Layout**: responsive default (`VL_LAYOUT="auto"`, `VL_MAX_LINES=3`), single line,

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This is the runtime default rendered from the bundled sample in a clean `main` w
 | `model` | yes | active Claude model |
 | `effort` | no | reasoning effort: `low`, `med`, `high`, `xhigh`, or `max` |
 | `ctx` | yes | context gauge and input, output, and cache token counts |
+| `cache` | no | prompt-cache hit ratio, and the countdown to the warm cache expiring |
 | `limit5h` | yes | five-hour rate-limit gauge and reset countdown |
 | `limit7d` | yes | seven-day rate-limit gauge and reset countdown |
 | `burn` | no | projected time until the binding 5h or 7d limit reaches 100% |
@@ -34,7 +35,9 @@ This is the runtime default rendered from the bundled sample in a clean `main` w
 | `stash` | no | git stash count |
 | `clock` | yes | 12- or 24-hour clock |
 
-Gauges change from green to yellow at 50% and red at 75%; both thresholds are configurable.
+Gauges change from green to yellow at 50% and red at 75%; both thresholds are configurable. `cache` reads the same thresholds inverted, because a high hit ratio is the good outcome: it turns yellow at 50% and red at 25%.
+
+`cache` needs Claude Code v2.1.263 or newer, which is where `prompt_cache` appears in the statusline payload. It hides itself before the session's first request, and drops the countdown once the cache has gone cold. Below an hour the countdown carries seconds (`10m12s`, `42s`), above it does not (`1h06m`). The countdown is the value at the last render, not a live clock: Claude Code refreshes the statusline on payload events (and once at the expiry itself), not every second, unless you set `statusLine.refreshInterval` in your settings.
 
 ## Install
 
@@ -111,7 +114,7 @@ Bash reads `~/.claude/coralline.conf`; the native renderer can read the same fil
 | `VL_CLOCK` / `VL_CLOCK_SECONDS` | `12h` / `1` | `12h`, `24h`, or `off`; seconds toggle |
 | `VL_BAR_WIDTH` | `5` | gauge width |
 | `VL_BAR_FILL` / `VL_BAR_EMPTY` | `▰` / `▱` | gauge glyphs |
-| `VL_CTX_GLYPH` / `VL_PROJECT_GLYPH` | `⬡` / `⬢` | context and project glyphs |
+| `VL_CTX_GLYPH` / `VL_PROJECT_GLYPH` / `VL_CACHE_GLYPH` | `⬡` / `⬢` / `⛁` | context, project, and cache glyphs |
 | `VL_PATH_DEPTH` / `VL_NAME_MAX` | `4` / `0` | path collapsing and optional name truncation |
 | `VL_COST_DECIMALS` | `2` | cost precision |
 | `VL_CTX_ALWAYS_SHOW` / `VL_COST_ALWAYS_SHOW` | `0` / `0` | show valid missing/empty context or cost as zero |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -24,6 +24,7 @@
 | `model` | 是 | 目前使用的 Claude model |
 | `effort` | 否 | 推理強度：`low`、`med`、`high`、`xhigh` 或 `max` |
 | `ctx` | 是 | context 用量條與輸入、輸出、快取 token 數 |
+| `cache` | 否 | prompt cache 命中率，以及快取失效的倒數 |
 | `limit5h` | 是 | 五小時額度量表與重置倒數 |
 | `limit7d` | 是 | 七天額度量表與重置倒數 |
 | `burn` | 否 | 綁定中的 5h 或 7d 額度到達 100% 的預估時間 |
@@ -34,7 +35,9 @@
 | `stash` | 否 | git stash 數量 |
 | `clock` | 是 | 12 或 24 小時制時鐘 |
 
-量表會從綠色變成 50% 的黃色與 75% 的紅色；兩個門檻都能自訂。
+量表會從綠色變成 50% 的黃色與 75% 的紅色；兩個門檻都能自訂。`cache` 使用同樣的門檻但方向相反，因為命中率高才是好結果：低於 50% 轉黃、低於 25% 轉紅。
+
+`cache` 需要 Claude Code v2.1.263 以上，`prompt_cache` 是從該版本開始出現在 statusline payload 裡。session 送出第一個 request 之前這一段會自我隱藏，快取變冷之後則只省略倒數。倒數在一小時以內會顯示秒數（`10m12s`、`42s`），超過一小時則不顯示（`1h06m`）。倒數顯示的是「上次 render 當下」的值，不是即時時鐘：Claude Code 只在 payload 事件（以及快取到期的那一刻）重繪 statusline，不會每秒重繪，除非你在 settings 裡設定 `statusLine.refreshInterval`。
 
 ## 安裝
 
@@ -111,7 +114,7 @@ Bash 讀取 `~/.claude/coralline.conf`，原生 renderer 也能讀同一個檔�
 | `VL_CLOCK` / `VL_CLOCK_SECONDS` | `12h` / `1` | `12h`、`24h` 或 `off`；秒數開關 |
 | `VL_BAR_WIDTH` | `5` | 量表寬度 |
 | `VL_BAR_FILL` / `VL_BAR_EMPTY` | `▰` / `▱` | 量表字符 |
-| `VL_CTX_GLYPH` / `VL_PROJECT_GLYPH` | `⬡` / `⬢` | context 與 project 字符 |
+| `VL_CTX_GLYPH` / `VL_PROJECT_GLYPH` / `VL_CACHE_GLYPH` | `⬡` / `⬢` / `⛁` | context、project 與 cache 字符 |
 | `VL_PATH_DEPTH` / `VL_NAME_MAX` | `4` / `0` | 路徑摺疊與選用的名稱截斷 |
 | `VL_COST_DECIMALS` | `2` | 費用顯示精度 |
 | `VL_CTX_ALWAYS_SHOW` / `VL_COST_ALWAYS_SHOW` | `0` / `0` | 把有效但缺失／空白的 context 或 cost 顯示為零 |

--- a/configure.sh
+++ b/configure.sh
@@ -15,7 +15,7 @@ P10K_FILE="${P10K_CONFIG:-$HOME/.p10k.zsh}"
 
 # Fallback list, used only when the runtime statusline cannot be scanned.
 # The live list is derived from statusline.sh's seg_* functions by load_segment_choices.
-SEGMENT_CHOICES="dir project git node python model effort ctx limit5h limit7d burn lines cost style duration stash clock"
+SEGMENT_CHOICES="dir project git node python model effort ctx cache limit5h limit7d burn lines cost style duration stash clock"
 DEFAULT_SEGMENTS="dir git model ctx limit5h limit7d cost clock"
 THEME_CHOICES=""
 theme_choices_loaded=0
@@ -308,7 +308,12 @@ prepare_preview_input() {
   [ -n "$sample" ] && need_file "$sample"
   input=$(mktemp "${TMPDIR:-/tmp}/coralline-input.XXXXXX") || exit 1
   if [ -n "$sample" ]; then
-    jq --arg cwd "$SCRIPT_DIR" '.cwd = $cwd | .workspace.current_dir = $cwd' "$sample" > "$input" 2>/dev/null || cp "$sample" "$input"
+    # The sample's fixed prompt_cache.expires_at would preview as a countdown
+    # years long; rebase it onto jq's own clock so `cache` previews a plausible
+    # remaining TTL. jq's `now` keeps this inside the existing call (no fork).
+    jq --arg cwd "$SCRIPT_DIR" '.cwd = $cwd | .workspace.current_dir = $cwd
+      | if has("prompt_cache") then .prompt_cache.expires_at = (now + 600 | floor) else . end' \
+      "$sample" > "$input" 2>/dev/null || cp "$sample" "$input"
   else
     jq -n --arg cwd "$SCRIPT_DIR" '{cwd: $cwd, workspace: {current_dir: $cwd}}' > "$input"
   fi

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -102,6 +102,7 @@ $Defaults = [ordered]@{
     VL_BAR_EMPTY = (Glyph 0x25B1)
     VL_CTX_GLYPH = (Glyph 0x2B21)
     VL_PROJECT_GLYPH = (Glyph 0x2B22)
+    VL_CACHE_GLYPH = (Glyph 0x26C1)
     VL_CLOCK = '12h'
     VL_CLOCK_SECONDS = '1'
     VL_PATH_DEPTH = '4'
@@ -167,6 +168,7 @@ $Defaults = [ordered]@{
     VL_BG_EFFORT = '141'
     VL_BG_NODE = ''
     VL_BG_PYTHON = ''
+    VL_BG_CACHE = ''
     VL_BG_BAR = ''
     VL_NODE_GLYPH = (Glyph 0xE718)
     VL_PY_GLYPH = (Glyph 0xE73C)
@@ -2472,6 +2474,24 @@ $fhPct = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('rate_limits
 $fhRst = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('rate_limits', 'five_hour', 'resets_at')))
 $wdPct = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('rate_limits', 'seven_day', 'used_percentage')))
 $wdRst = Remove-ControlChars (To-InvariantString (Get-JsonPath $J @('rate_limits', 'seven_day', 'resets_at')))
+# prompt_cache is absent entirely until the session's first request, and either
+# field can be null after that. Both are accepted only as JSON numbers, mirroring
+# the Bash renderer's `type == "number"` guard, so a string or an object leaves the
+# segment suppressed rather than rendering a bogus gauge. hit_ratio arrives as a
+# 0..1 ratio and is scaled here, the way the Bash side scales it inside jq.
+$cacheHit = ''
+$cacheExp = ''
+$cacheParent = Get-JsonMember $J 'prompt_cache'
+if ($cacheParent -is [pscustomobject] -or $cacheParent -is [System.Collections.IDictionary]) {
+    $hitNode = Get-JsonMember $cacheParent 'hit_ratio'
+    if ($hitNode -is [double] -or $hitNode -is [decimal] -or $hitNode -is [long] -or $hitNode -is [int]) {
+        $cacheHit = To-InvariantString ([double]$hitNode * 100)
+    }
+    $expNode = Get-JsonMember $cacheParent 'expires_at'
+    if ($expNode -is [double] -or $expNode -is [decimal] -or $expNode -is [long] -or $expNode -is [int]) {
+        $cacheExp = To-InvariantString $expNode
+    }
+}
 $costParent = Get-JsonMember $J 'cost'
 $costNode = $null
 $costKind = 'missing'
@@ -2938,6 +2958,32 @@ function Add-CtxSegment {
     Push-Segment $Cfg.VL_BG_CTX "${pfg} $($Cfg.VL_CTX_GLYPH) ${bar} ${pct}% ${dfg}$($G.Up)${ti} $($G.Down)${to} cr:${tcr} cw:${tcw} "
 }
 
+function Add-CacheSegment {
+    $pct = 0
+    if (-not (Get-PctValue $cacheHit ([ref]$pct))) { return }
+    # Inverted thresholds: cache hits are the good outcome, so 98% must read green
+    # where the same number on a usage gauge reads red.
+    $pfg = Get-Fg (Get-PctFg (100 - $pct))
+    # expires_at stays at its last value once the cache goes cold, so a non-positive
+    # remainder is the cold case and prints nothing. Under an hour the seconds are
+    # shown, because the short TTL is 5 minutes and a minute-only countdown would sit
+    # on 4m for most of it; from an hour up they are dropped. Format-Countdown is not
+    # reused here: it reports an elapsed reset as "now", which is right for a limit
+    # window and wrong for a cache that simply is not warm any more.
+    $left = ''
+    $ep = ConvertTo-Epoch $cacheExp
+    if ($null -ne $ep) {
+        $diff = [long]$ep - $Now
+        if ($diff -gt 0) {
+            $dfg = Get-Fg $Cfg.VL_FG_DIM
+            $left = "${dfg}$($G.Reset)$(Format-Duration ([double]$diff * 1000) ($diff -lt 3600))"
+        }
+    }
+    $bg = $Cfg.VL_BG_CACHE
+    if ([string]::IsNullOrEmpty($bg)) { $bg = $Cfg.VL_BG_CTX }
+    Push-Segment $bg "${pfg} $($Cfg.VL_CACHE_GLYPH) ${pct}% ${left} "
+}
+
 function Add-LimitSegment([string]$Label, [string]$RawPct, [string]$ResetsAt, [string]$Bg, [int]$PctMilli = -1) {
     $pct = 0
     if ($PctMilli -ge 0) { $pct = [int](Get-RoundEvenInt64 ([long]$PctMilli) 1000L) }
@@ -3145,6 +3191,7 @@ function Add-PythonSegment {
 
 $SegmentBuilders = [ordered]@{
     burn = { Add-BurnSegment }
+    cache = { Add-CacheSegment }
     clock = { Add-ClockSegment }
     cost = { Add-CostSegment }
     ctx = { Add-CtxSegment }

--- a/statusline.sh
+++ b/statusline.sh
@@ -52,6 +52,7 @@ VL_BAR_EMPTY="▱"
 # out of alignment (#47). Override with characters your terminal font carries.
 VL_CTX_GLYPH="⬡"                # glyph for the ctx segment (main bar and subagent rows)
 VL_PROJECT_GLYPH="⬢"            # glyph for the project segment
+VL_CACHE_GLYPH="⛁"              # glyph for the cache segment
 VL_CLOCK="12h"                  # 12h | 24h | off
 VL_CLOCK_SECONDS=1
 VL_PATH_DEPTH=4                 # collapse paths deeper than this
@@ -153,6 +154,7 @@ VL_BG_DURATION=60
 VL_BG_EFFORT=141
 VL_BG_NODE=""                   # optional; falls back to VL_BG_MODEL when empty
 VL_BG_PYTHON=""                 # optional; falls back to VL_BG_MODEL when empty
+VL_BG_CACHE=""                  # optional; falls back to VL_BG_CTX when empty
 VL_BG_BAR=""                   # classic style only — the uniform bar behind the whole
                                # row ("R,G,B" or a 256 index); empty → p10k's 238.
                                # An explicit VL_LEAN_BG overrides it.
@@ -1533,6 +1535,30 @@ seg_ctx() {  # context-window gauge with input/output/cache token counts
   push "$VL_BG_CTX" "${fgc} ${VL_CTX_GLYPH} ${_BAR} ${ci}% ${fgd}↑${ti} ↓${to} cr:${tcr} cw:${tcw} "
 }
 
+seg_cache() {  # prompt-cache hit ratio and time left before the warm cache expires
+  [ -n "$cache_pct" ] || return 0
+  local v fgc left="" diff
+  printf -v v '%.0f' "$cache_pct" 2>/dev/null || v=0
+  # Inverted thresholds: cache hits are the good outcome, so 98% must read green
+  # where the same number on a usage gauge reads red.
+  pct_fg $(( 100 - v ))
+  fg "$_PFG"; fgc="$_FG"
+  # expires_at stays at its last value once the cache goes cold, so a non-positive
+  # remainder is the cold case and prints nothing. Under an hour the seconds are
+  # shown, because the short TTL is 5 minutes and a minute-only countdown would
+  # sit on 4m for most of it; from an hour up they are dropped, since the long TTL
+  # has no use for that precision and the pill stays narrow. The row only refreshes
+  # on payload events, so read it as the value at the last render, not a live clock.
+  if to_epoch "$cache_exp"; then
+    diff=$(( _EP - NOW ))
+    if [ "$diff" -gt 0 ]; then
+      fmt_duration $(( diff * 1000 )) $(( diff < 3600 ))
+      fg "$VL_FG_DIM"; left="${_FG}↺${_DUR}"
+    fi
+  fi
+  push "${VL_BG_CACHE:-$VL_BG_CTX}" "${fgc} ${VL_CACHE_GLYPH} ${v}% ${left} "
+}
+
 seg_limit() {  # $1=label $2=pct $3=resets_at $4=bg $5=canonical pct_milli(optional)
   [ -n "$2" ] || return 0
   local v fgc rst=""
@@ -2082,14 +2108,19 @@ if _JSON_FIELDS=$(printf '%s' "$input" | jq -r '
     (member(member(.; "cost"); "total_lines_removed") // 0),
     (member(member(.; "output_style"); "name") // ""),
     (member(member(.; "cost"); "total_duration_ms") // 0),
-    (member(member(.; "effort"); "level") // "")
+    (member(member(.; "effort"); "level") // ""),
+    ((member(member(.; "prompt_cache"); "hit_ratio")) as $h |
+      if ($h|type) == "number" then ($h * 100 | tostring) else "" end),
+    ((member(member(.; "prompt_cache"); "expires_at")) as $x |
+      if ($x|type) == "number" then ($x | tostring) else "" end)
   ] | map(scrub) | join("\u001f")
   end' 2>/dev/null); then
   _JSON_OK=1
 fi
 IFS=$'\037' read -r cwd model ctx_pct _CTX_EMPTY tok_in tok_out tok_cr tok_cw \
                  fh_pct fh_rst wd_pct wd_rst cost _COST_KIND \
-                 lines_add lines_del out_style dur_ms effort <<JSON
+                 lines_add lines_del out_style dur_ms effort \
+                 cache_pct cache_exp <<JSON
 $_JSON_FIELDS
 JSON
 

--- a/test/sample-input.json
+++ b/test/sample-input.json
@@ -13,6 +13,12 @@
       "cache_creation_input_tokens": 4321
     }
   },
+  "prompt_cache": {
+    "warm": true,
+    "ttl": "5m",
+    "expires_at": 1893456000,
+    "hit_ratio": 0.9812
+  },
   "rate_limits": {
     "five_hour": { "used_percentage": 41.2, "resets_at": "2030-01-01T09:30:00Z" },
     "seven_day": { "used_percentage": 78.9, "resets_at": "2030-01-03T00:00:00Z" }

--- a/test/test-cache.sh
+++ b/test/test-cache.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Unit test for seg_cache() — the optional `cache` segment, which reads
+# prompt_cache.hit_ratio and prompt_cache.expires_at out of the statusline
+# payload. Extracts the live function from statusline.sh so this test can never
+# drift from the code it checks.
+#
+#   bash test/test-cache.sh
+#
+# Exits non-zero if any case fails. Needs only bash (no jq, no git).
+set -u
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+SCRIPT="$HERE/../statusline.sh"
+
+# Pull the segment and the helpers it calls out of the real script. Relies on
+# each function's closing brace being the only `}` at column 0.
+#
+# The sed scripts stay single-quoted and spelled out one per line rather than
+# built in a loop: on bash 3.2, `eval "$(sed -n "…{…}…" "$f")"` loses the inner
+# quotes, and the `{/,/^}` then brace-expands into two broken sed scripts.
+eval "$(sed -n '/^seg_cache() {/,/^}/p'    "$SCRIPT")"
+eval "$(sed -n '/^pct_fg() {/,/^}/p'       "$SCRIPT")"
+eval "$(sed -n '/^to_epoch() {/,/^}/p'     "$SCRIPT")"
+eval "$(sed -n '/^iso_epoch() {/,/^}/p'    "$SCRIPT")"
+eval "$(sed -n '/^fmt_duration() {/,/^}/p' "$SCRIPT")"
+
+# Stand-ins for the render machinery: record what seg_cache would paint instead
+# of emitting real escapes, so a case can assert on plain text and on the color
+# role that the inverted threshold picked.
+fg()   { _FG="<$1>"; }
+push() { _BG="$1"; _TEXT="$2"; }
+
+VL_WARN_PCT=50 ; VL_HOT_PCT=75
+VL_FG_OK=ok ; VL_FG_WARN=warn ; VL_FG_HOT=hot ; VL_FG_DIM=dim
+VL_BG_CTX=238 ; VL_BG_CACHE="" ; VL_CACHE_GLYPH="C"
+NOW=1000000
+
+fail=0
+check() {  # $1=expected  $2=label  $3=actual
+  if [ "$3" = "$1" ]; then
+    printf 'ok    %-34s -> %q\n' "$2" "$3"
+  else
+    printf 'FAIL  %-34s want=%q got=%q\n' "$2" "$1" "$3"; fail=1
+  fi
+}
+
+render() {  # $1=hit pct  $2=expires_at ; → the pushed text, colors as <role>
+  cache_pct="$1"; cache_exp="$2"
+  _BG=""; _TEXT=""
+  seg_cache
+  printf '%s' "$_TEXT"
+}
+
+# ── Suppression ──────────────────────────────────────────────────────────────
+# No prompt_cache in the payload (a session that has issued no request yet), and
+# a payload whose hit_ratio is null, both leave cache_pct empty: render nothing
+# rather than an empty pill.
+check "" "no prompt_cache"           "$(render '' '')"
+check "" "null hit_ratio, live TTL"  "$(render '' '1000300')"
+
+# ── Countdown ────────────────────────────────────────────────────────────────
+# Under an hour the seconds are shown, because the short TTL is five minutes and
+# a minute-only countdown would sit on "4m" for most of the cache's life. From an
+# hour up they are dropped. The boundary is exactly 3600s: 59m59s still carries
+# seconds, 1h00m00s does not.
+check "<ok> C 98% <dim>↺5m00s "  "warm 5m TTL"       "$(render '98.12' '1000300')"
+check "<ok> C 98% <dim>↺42s "    "under a minute"    "$(render '98.12' '1000042')"
+check "<ok> C 98% <dim>↺59m59s " "just under 1h"     "$(render '98.12' '1003599')"
+check "<ok> C 98% <dim>↺1h00m "  "1h TTL at issue"   "$(render '98.12' '1003600')"
+check "<ok> C 98% <dim>↺1h00m "  "one second past 1h" "$(render '98.12' '1003601')"
+
+# expires_at keeps its last value after the cache goes cold, so a non-positive
+# remainder is the cold case and must print no countdown at all.
+check "<ok> C 98%  "  "expired (cold)"   "$(render '98.12' '999999')"
+check "<ok> C 98%  "  "expiring exactly" "$(render '98.12' '1000000')"
+check "<ok> C 98%  "  "no expires_at"    "$(render '98.12' '')"
+
+# ── Inverted thresholds ──────────────────────────────────────────────────────
+# A high hit ratio is the good outcome, so the color roles run opposite to a
+# usage gauge: pct_fg is fed 100-v. With WARN 50 / HOT 75 that puts the warn
+# boundary at 50% hit and the hot boundary at 25% hit.
+check "<ok> C 100%  "  "100% hit is ok"    "$(render '100' '')"
+check "<ok> C 51%  "   "51% hit is ok"     "$(render '51' '')"
+check "<warn> C 50%  " "50% hit warns"     "$(render '50' '')"
+check "<warn> C 26%  " "26% hit warns"     "$(render '26' '')"
+check "<hot> C 25%  "  "25% hit is hot"    "$(render '25' '')"
+check "<hot> C 0%  "   "0% hit is hot"     "$(render '0' '')"
+
+# ── Rounding and malformed input ─────────────────────────────────────────────
+# jq hands over hit_ratio * 100, which routinely arrives with float noise.
+check "<ok> C 98%  " "98.4 rounds down"  "$(render '98.4' '')"
+check "<ok> C 99%  " "98.6 rounds up"    "$(render '98.6' '')"
+# printf %.0f is IEEE round-half-to-even, the same rule seg_ctx and seg_limit
+# already display under. Both ties land on 98, not on 98 and 99.
+check "<ok> C 98%  " "98.5 ties to even" "$(render '98.5' '')"
+check "<ok> C 98%  " "97.5 ties to even" "$(render '97.5' '')"
+check "<ok> C 98%  " "float noise"       "$(render '98.00000000000001' '')"
+check "<hot> C 0%  " "non-numeric → 0%"  "$(render 'abc' '' 2>/dev/null)"
+
+# ── Background fallback ──────────────────────────────────────────────────────
+# Themes that define no cache swatch must inherit the ctx pill, not a hardcoded
+# color; an explicit VL_BG_CACHE wins.
+render '98' '' >/dev/null
+check "238" "empty VL_BG_CACHE → ctx" "$_BG"
+VL_BG_CACHE="1,2,3"
+render '98' '' >/dev/null
+check "1,2,3" "explicit VL_BG_CACHE" "$_BG"
+VL_BG_CACHE=""
+
+exit "$fail"

--- a/test/test-glyph.sh
+++ b/test/test-glyph.sh
@@ -92,5 +92,19 @@ render 'VL_CTX_GLYPH="◔"
 '
 check "VL_CTX_GLYPH leaves ⬢ alone"         "$(has '⬢')"
 
+# (6) VL_CACHE_GLYPH / seg_cache. ⛁ U+26C1 is plain Unicode too, and is absent
+#     from every Nerd Font on the machine this was written on (JetBrainsMono and
+#     Meslo, all weights, cmap-checked), so it depends on the same fallback path
+#     #47 is about. The segment is opt-in, so the extra config adds it to the row.
+render 'VL_SEGMENTS="project ctx cache"
+'
+check "default cache glyph is ⛁"            "$(has '⛁')"
+render 'VL_SEGMENTS="project ctx cache"
+VL_CACHE_GLYPH="◍"
+'
+check "VL_CACHE_GLYPH renders the override" "$(has '◍')"
+check "VL_CACHE_GLYPH drops the default ⛁"  "$(lacks '⛁')"
+check "VL_CACHE_GLYPH leaves ⬡ alone"       "$(has '⬡')"
+
 [ "$fail" = 0 ] && printf 'ALL PASS\n' || printf 'FAILURES\n'
 exit "$fail"

--- a/test/test-statusline-ps1.ps1
+++ b/test/test-statusline-ps1.ps1
@@ -306,6 +306,12 @@ function New-Payload([string]$Cwd) {
                 cache_creation_input_tokens = 4321
             }
         }
+        prompt_cache = [ordered]@{
+            warm = $true
+            ttl = '5m'
+            expires_at = 1000300
+            hit_ratio = 0.9812
+        }
         rate_limits = [ordered]@{
             five_hour = [ordered]@{ used_percentage = 41.2; resets_at = '' }
             seven_day = [ordered]@{ used_percentage = 78.9; resets_at = '' }
@@ -549,7 +555,7 @@ esac
     Check 'reparse validation precedes config read' ($source.IndexOf('Test-SafeRegularFile $Path') -lt $source.IndexOf('Read-StrictUtf8File $Path'))
     Check 'Bash oracle main extraction contains central scrub' ($bashSource.Contains('] | map(scrub) | join('))
 
-    $expectedRegistry = @('burn','clock','cost','ctx','dir','duration','effort','git','limit5h','limit7d','lines','model','node','project','python','stash','style')
+    $expectedRegistry = @('burn','cache','clock','cost','ctx','dir','duration','effort','git','limit5h','limit7d','lines','model','node','project','python','stash','style')
     $builderBlock = [regex]::Match($source, '(?s)\$SegmentBuilders = \[ordered\]@\{(.*?)\n\}').Groups[1].Value
     $actualRegistry = @([regex]::Matches($builderBlock, '(?m)^    ([A-Za-z0-9]+) =') | ForEach-Object { $_.Groups[1].Value } | Sort-Object)
     Check 'closed PowerShell registry equals WIN-02 inventory' (($actualRegistry -join ' ') -eq (($expectedRegistry | Sort-Object) -join ' '))
@@ -1354,6 +1360,9 @@ fi
     $burnPayload.rate_limits.seven_day.resets_at = '1345600'
     $segmentCases = [ordered]@{
         burn = [pscustomobject]@{ Show=@('VL_SEGMENTS=burn','VL_CLOCK=off'); Needle=((Glyph 0x2197) + ' 7d ' + (Glyph 0x21E2)); Payload=$burnPayload; Environment=@{CORALLINE_TEST_NOW='1000000'}; Suppress={ param($p) $p.rate_limits.five_hour.used_percentage=$null; $p.rate_limits.seven_day.used_percentage=$null; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=burn' }
+        # The payload's expires_at (1000300) is 300s past the pinned CORALLINE_TEST_NOW,
+        # so the countdown lands on the seconds-carrying side of the one-hour boundary.
+        cache = [pscustomobject]@{ Show=@('VL_SEGMENTS=cache','VL_CLOCK=off'); Needle=((Glyph 0x26C1) + ' 98% ' + (Glyph 0x21BA) + '5m00s'); Environment=@{CORALLINE_TEST_NOW='1000000'}; Suppress={ param($p) $p.prompt_cache.hit_ratio=$null; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=cache' }
         clock = [pscustomobject]@{ Show=@('VL_SEGMENTS=clock','VL_CLOCK=24h','VL_CLOCK_SECONDS=0'); Needle=(Glyph 0x2299); Suppress={ param($p) $p }; SuppressConfig=@('VL_SEGMENTS=clock','VL_CLOCK=off') }
         cost = [pscustomobject]@{ Show=@('VL_SEGMENTS=cost','VL_CLOCK=off'); Needle='$1.23'; Suppress={ param($p) $p.cost.total_cost_usd=0; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=cost' }
         ctx = [pscustomobject]@{ Show=@('VL_SEGMENTS=ctx','VL_CLOCK=off'); Needle='62%'; Suppress={ param($p) $p.context_window.used_percentage=$null; $p }; SuppressConfig=$baseConfigLines + 'VL_SEGMENTS=ctx' }


### PR DESCRIPTION
Adds `cache`, an opt-in segment showing the session's prompt-cache hit ratio and the countdown to the warm cache expiring:

```
 ◆ Fable 5  ⬡ ▰▰▰▱▱ 62% ↑1.2M ↓45.6k cr:98.7k cw:4.3k  ⛁ 98% ↺10m12s  5h ▰▰▱▱▱ 41% ↺2h56m
```

Claude Code v2.1.263 puts a `prompt_cache` object in the statusline payload. The contract below was read out of that release's payload builder rather than inferred from a captured sample: the object is absent until the session's first request, `hit_ratio` is a 0..1 ratio (cache reads over cache reads + cache writes + uncached input, accumulated across the session) or null, and `expires_at` is epoch seconds (last activity plus a 5m or 1h TTL) or null. Both fields come out of the existing single `jq` call, so the segment costs no extra fork and no state file.

Below an hour the countdown carries seconds (`10m12s`, `42s`), because the short TTL is five minutes and a minute-only countdown would spend most of it sitting on `4m`. From an hour up the seconds are dropped (`1h06m`). It is the value at the last render, not a live clock: Claude Code redraws the statusline on payload events plus once at the expiry itself, not every second, unless `statusLine.refreshInterval` is set.

The color thresholds are inverted (`pct_fg` is fed `100 - v`), because a high hit ratio is the good outcome. With the defaults the pill turns yellow at 50% and red at 25%.

`cache` is off by default and a default render of both sample payloads is byte-identical to `main`. It self-suppresses on Claude Code builds older than 2.1.263, where `prompt_cache` never arrives. `VL_BG_CACHE` is empty by default and falls back to `VL_BG_CTX`, so no theme file needs a new swatch; `VL_CACHE_GLYPH` defaults to `⛁` (plain Unicode, no `VL_ASCII` fallback word needed).

`test/test-cache.sh` covers suppression, both sides of the seconds boundary, the cold and missing-expiry cases, both inverted color boundaries, `%.0f`'s round-half-to-even, non-numeric input, and the background fallback. `test-glyph.sh` gains the `VL_CACHE_GLYPH` cases. All seventeen suites pass under bash 5.3 and macOS `/bin/bash` 3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KfCwFdMHwpExkJNcxNA6Ya
