### PR TITLE
docs: refresh pinned --ref examples from v0.16.0 to v0.16.1

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -95,7 +95,7 @@ curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.s
 
 This path is non-interactive, so it installs from `main` and skips the version prompt. To
 install a tagged release instead, ask the user which they want and pass `--ref`, e.g.
-`--ref v0.16.0` (latest release) or leave it as `main` (latest development).
+`--ref v0.16.1` (latest release) or leave it as `main` (latest development).
 
 If the user is testing a fork, keep the downloaded installer and runtime files on the same
 repo:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Run the interactive installer:
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
 ```
 
-It recommends the latest tagged release or lets you choose mutable `main`. Skip the prompt with `--ref v0.16.0` or another ref. If the one-line path cannot run, use the [manual fallback in `INSTALL.md`](./INSTALL.md#manual-fallback).
+It recommends the latest tagged release or lets you choose mutable `main`. Skip the prompt with `--ref v0.16.1` or another ref. If the one-line path cannot run, use the [manual fallback in `INSTALL.md`](./INSTALL.md#manual-fallback).
 
 ### Windows without Git Bash
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -63,7 +63,7 @@ Claude 會依環境選擇路徑、在更改偏好前詢問，並使用對應 ins
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/coralline/main/install.sh | bash
 ```
 
-它會建議最新 release tag，也能選擇可變的 `main`。使用 `--ref v0.16.0` 或其他 ref 可略過詢問。若一行安裝無法執行，使用 [`INSTALL.md` 的 manual fallback](./INSTALL.md#manual-fallback)。
+它會建議最新 release tag，也能選擇可變的 `main`。使用 `--ref v0.16.1` 或其他 ref 可略過詢問。若一行安裝無法執行，使用 [`INSTALL.md` 的 manual fallback](./INSTALL.md#manual-fallback)。
 
 ### Windows 無 Git Bash
 


### PR DESCRIPTION
Routine pre-release refresh, the same edit as #75, #80 and #82: the three pinned `--ref` install examples move from v0.16.0 to v0.16.1 so they name the tag that is about to exist.

`README.md`, `README.zh-TW.md`, and `INSTALL.md`, one line each. No runtime code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KfCwFdMHwpExkJNcxNA6Ya